### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
Windows checkouts were converting committed files to CRLF, which conflicts with `biome.json`'s `lineEnding: "lf"` and made `format-check` fail locally even though the committed content was already correct.

## Why
`Redux_GUI` doesn't have this problem because its documented workflow develops inside the devcontainer (Linux). This repo needs to also work correctly from a raw Windows checkout, not just inside the devcontainer.

## Test plan
- [x] `npm run format:check` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — compiles and prerenders