### PR TITLE
Added Taxonomy Data

### DIFF
--- a/data/taxonomy.js
+++ b/data/taxonomy.js
@@ -1,0 +1,274 @@
+// data/taxonomy.js
+//
+// Single source of truth for every tag category shown in the catalog: the
+// ordered facet registry (allowed values, display labels, ordering, accent
+// colors), plus the backend -> frontend translation maps and derivation
+// rules. No component anywhere may hardcode a label this file owns — a
+// future casing change is a one-line edit here, not a hunt through the app.
+//
+// Pure data and derivation logic only. No React, no MUI, no imports from
+// elsewhere in the app.
+//
+// Facet decisions are ratified in GitHub issue #6 ("T02 — Resolve the open
+// taxonomy decisions"); value lists are reconciled against the real backend
+// in ai_documentation/TAXONOMY_REFERENCE.md. Citations below point at the
+// specific #6 answer that drove each choice.
+
+// Used wherever a tag field has no real or overlay value. Defined once here
+// so mergeSupplementalTags.js (#22) and everything downstream import it
+// rather than repeating the string literal.
+export const UNCLASSIFIED = "Unclassified";
+
+// The eight sidebar facets (#6, 2026-09-01: the mockup's ninth group, a
+// separate "Quantum Complexity Class" facet, was merged into Complexity
+// Class — see that facet's entry below). Every facet here is a Home sidebar
+// filter; there are no detail-page-only facets in the ratified design
+// (ARCHITECTURE.md "The taxonomy gap").
+export const TAXONOMY = [
+  {
+    key: "problemType",
+    // #6 q2 (2026-08-31): label is "Problem Type", not the mockup's
+    // "Problem Domain" — keeps docs, code and UI on one name.
+    label: "Problem Type",
+    accentColor: "blue",
+    sidebar: true,
+    multiValued: true,
+    options: [
+      { key: "graphTheory", label: "Graph Theory" },
+      { key: "networkDesign", label: "Network Design" },
+      { key: "setsAndPartitions", label: "Sets and Partitions" },
+      { key: "storageAndRetrieval", label: "Storage and Retrieval" },
+      { key: "sequencingAndScheduling", label: "Sequencing and Scheduling" },
+      { key: "mathematicalProgramming", label: "Mathematical Programming" },
+      { key: "algebraAndNumberTheory", label: "Algebra and Number Theory" },
+      { key: "computationalGeometry", label: "Computational Geometry" },
+      { key: "gamesAndPuzzles", label: "Games and Puzzles" },
+      { key: "logic", label: "Logic" },
+      { key: "automataAndLanguages", label: "Automata and Languages" },
+      { key: "programOptimization", label: "Program Optimization" },
+      { key: "miscellaneous", label: "Miscellaneous" },
+    ],
+  },
+  {
+    key: "computationalModel",
+    label: "Computational Model",
+    accentColor: "cyan",
+    sidebar: true,
+    // Single-valued, mutually exclusive (TAXONOMY_REFERENCE.md §2).
+    multiValued: false,
+    options: [
+      { key: "turingMachines", label: "Turing Machines" },
+      { key: "automata", label: "Automata" },
+      { key: "logicalFunctionalModels", label: "Logical/Functional Models" },
+      { key: "parallelDistributed", label: "Parallel/Distributed" },
+      { key: "quantumModels", label: "Quantum Models" },
+    ],
+  },
+  {
+    key: "complexityClass",
+    label: "Complexity Class",
+    accentColor: "amber",
+    sidebar: true,
+    // #6 (2026-09-01, supersedes the 2026-08-31 record): multi-valued, and
+    // absorbs the former separate "Quantum Complexity Class" facet. A
+    // problem shows every class it truly belongs to at once (0/1 Knapsack is
+    // both NP-complete and NP) — see deriveComplexityClasses() below.
+    multiValued: true,
+    options: [
+      // Classical ladder, ordered by increasing difficulty (ratified
+      // 2026-08-31). Wikipedia casing: lowercase "complete"/"hard".
+      { key: "p", label: "P" },
+      { key: "np", label: "NP" },
+      { key: "npComplete", label: "NP-complete" },
+      { key: "npHard", label: "NP-hard" },
+      // Quantum classes, merged in from the deleted facet (#6, 2026-09-01).
+      // No backend field exists; these are sourced entirely from the
+      // supplementalTags.js overlay (#7).
+      { key: "bqp", label: "BQP" },
+      { key: "eqp", label: "EQP" },
+      { key: "qma", label: "QMA" },
+      { key: "qcma", label: "QCMA" },
+      { key: "qip", label: "QIP" },
+      { key: "mipStar", label: "MIP*" },
+    ],
+  },
+  {
+    key: "solverType",
+    label: "Solver Type",
+    accentColor: "salmon-red",
+    sidebar: true,
+    multiValued: true,
+    options: [
+      { key: "exact", label: "Exact" },
+      { key: "heuristic", label: "Heuristic" },
+      { key: "approximation", label: "Approximation" },
+      // No backend source for these three — they legitimately show (0)
+      // until the backend adds matching SolverType values or per-solver
+      // overlay tagging exists. That's correct behavior, not a bug.
+      { key: "randomized", label: "Randomized" },
+      { key: "numerical", label: "Numerical" },
+      { key: "automatedReasoning", label: "Automated Reasoning" },
+      { key: "quantum", label: "Quantum" },
+    ],
+  },
+  {
+    key: "solverComplexity",
+    label: "Solver Complexity",
+    accentColor: "coral",
+    // #6 q1 (2026-08-31): IS a sidebar filter, showing all 8 ratified
+    // buckets even though the backend enum only has 3 today — the other 5
+    // legitimately show (0) rather than being hidden. An earlier draft of
+    // ARCHITECTURE.md said this was detail-page-only metadata; that was
+    // wrong and has been corrected there and here.
+    sidebar: true,
+    multiValued: false,
+    options: [
+      { key: "constant", label: "Constant" },
+      { key: "logarithmic", label: "Logarithmic" },
+      { key: "linear", label: "Linear" },
+      { key: "logLinear", label: "Log-linear" },
+      { key: "quadratic", label: "Quadratic" },
+      { key: "polynomial", label: "Polynomial" },
+      { key: "exponential", label: "Exponential" },
+      { key: "factorial", label: "Factorial" },
+    ],
+  },
+  {
+    key: "reductionType",
+    label: "Reduction Type",
+    accentColor: "violet",
+    sidebar: true,
+    // Tier 1, mutually exclusive (TAXONOMY_REFERENCE.md §7).
+    multiValued: false,
+    options: [
+      { key: "karp", label: "Karp (Many-One)" },
+      { key: "cook", label: "Cook (Turing)" },
+      { key: "lApReductions", label: "L/AP-Reductions" },
+      { key: "parsimonious", label: "Parsimonious" },
+      { key: "randomized", label: "Randomized" },
+      { key: "parameterized", label: "Parameterized" },
+      { key: "fineGrained", label: "Fine-Grained" },
+    ],
+  },
+  {
+    key: "reductionCost",
+    label: "Reduction Cost",
+    accentColor: "violet",
+    sidebar: true,
+    multiValued: false,
+    options: [
+      { key: "linear", label: "Linear" },
+      { key: "quadratic", label: "Quadratic" },
+      { key: "cubic", label: "Cubic" },
+      // C5 / TAXONOMY_REFERENCE.md §8: missing from the original planning
+      // doc, but already backend-backed (ReductionCost.HigherPolynomial)
+      // and shown in the mockup ("Higher Poly."). No backend work needed.
+      { key: "higherPolynomial", label: "Higher Polynomial" },
+      // Deliberately left out of v1 (TAXONOMY_REFERENCE.md §8): Logarithmic
+      // Space, Approximation Degradation, Kernelization Bounds,
+      // Spatial/Qubit Overhead. The backend has no concept of them, so
+      // they'd sit permanently at (0).
+    ],
+  },
+  {
+    key: "visualizationType",
+    label: "Visualization Type",
+    accentColor: "green",
+    sidebar: true,
+    // Each visualization declares exactly one conceptual style.
+    multiValued: false,
+    // #6 q3 (2026-08-31): conceptual labels supplied by the `visualStyle`
+    // overlay field, NOT the backend's renderer-implementation enum
+    // (TAXONOMY_REFERENCE.md §9 conflict C4).
+    options: [
+      { key: "nodeLinkDiagram", label: "Node-Link Diagram" },
+      { key: "dag", label: "DAG" },
+      { key: "bipartiteFactorGraph", label: "Bipartite Factor Graph" },
+      { key: "logicGateSchematic", label: "Logic Gate Schematic" },
+      { key: "bdd", label: "BDD" },
+      { key: "searchTree", label: "Search Tree" },
+      { key: "ganttChart", label: "Gantt Chart" },
+      { key: "spaceTimeDiagram", label: "Space-Time Diagram" },
+      { key: "voronoiMap", label: "Voronoi Map" },
+      { key: "threeDSurfacePlot", label: "3D Surface Plot" },
+      { key: "lossLandscape", label: "Loss Landscape" },
+      { key: "quantumCircuit", label: "Quantum Circuit" },
+    ],
+  },
+];
+
+// --- Translation maps: backend vocabulary -> frontend option key(s) -------
+//
+// The backend's enums and the frontend's display vocabulary don't match.
+// Those translations live here, beside the values they translate into, so
+// all tag-naming decisions live in exactly one file.
+
+// SolverType (backend, describes algorithm family) -> Solver Type option key
+// (frontend, describes solving approach). TAXONOMY_REFERENCE.md §5/§5a.
+//
+// Three map straight across. Eight exhaustive/deterministic families collapse
+// into "Exact". `Greedy` isn't named in this issue's Part 2 body text, but
+// TAXONOMY_REFERENCE.md §5a resolves "Greedy Algorithms" to Heuristic, and is
+// included here so every backend SolverType member has a mapping (see this
+// task's handback summary for that assumption).
+export const SOLVER_TYPE_MAP = {
+  BruteForce: "exact",
+  Greedy: "heuristic",
+  DynamicProgramming: "exact",
+  Approximation: "approximation",
+  Heuristic: "heuristic",
+  DivideAndConquer: "exact",
+  Quantum: "quantum",
+  StateTransition: "exact",
+  BreadthFirstSearch: "exact",
+  DepthFirstSearch: "exact",
+  Backtracking: "exact",
+  Constructive: "exact",
+  // Not yet hand-tagged by the backend curator — no Solver Type tag.
+  Unclassified: undefined,
+};
+
+// ComplexityClass (backend, single-valued) -> the full set of Complexity
+// Class option keys a problem belongs to, by true containment. Reworked
+// 2026-09-01 (#6): this is a derivation, not a 1:1 rename, because a single
+// backend value can (and P/NPComplete do) imply more than one displayed
+// class. `QuantumOracle` yields no classical value — those problems carry a
+// real quantum class from the overlay instead (see deriveComplexityClasses).
+export const COMPLEXITY_CLASS_MAP = {
+  P: ["p", "np"],
+  NPComplete: ["npComplete", "np", "npHard"],
+  NPIntermediate: ["np"],
+  NPHard: ["npHard"],
+  QuantumOracle: [],
+  Unclassified: [],
+};
+
+/**
+ * The full set of Complexity Class option keys a problem belongs to.
+ *
+ * `backendComplexityClass` is the single stored `ComplexityClass` enum
+ * value. `overlayQuantumClasses` is the problem's quantum classes from the
+ * supplementalTags.js overlay (e.g. ["bqp"]) — unioned onto the classical
+ * set derived from the backend value, since a problem can carry both.
+ *
+ * Invariant (TAXONOMY_REFERENCE.md §3/#6 2026-09-01): "np" appears ALONE in
+ * the classical portion of the result only when `backendComplexityClass` is
+ * "NPIntermediate" — every other classical value either omits "np" or pairs
+ * it with "p" or "npComplete"/"npHard". A caller that ever sees a bare "np"
+ * from any other backend value has a bug in this map, not in the caller.
+ */
+export function deriveComplexityClasses(backendComplexityClass, overlayQuantumClasses = []) {
+  const classical = COMPLEXITY_CLASS_MAP[backendComplexityClass] ?? [];
+  return Array.from(new Set([...classical, ...overlayQuantumClasses]));
+}
+
+// ReductionCost (backend) -> Reduction Cost option key (frontend). Linear,
+// Quadratic, Cubic and HigherPolynomial map straight across — this facet is
+// the best-aligned of the backend-gap facets (TAXONOMY_REFERENCE.md §8).
+export const REDUCTION_COST_MAP = {
+  Linear: "linear",
+  Quadratic: "quadratic",
+  Cubic: "cubic",
+  HigherPolynomial: "higherPolynomial",
+  Unclassified: undefined,
+};


### PR DESCRIPTION
Issue:  #10 (T06 — Build data/taxonomy.js, the single source of truth for tag labels)
Branch: task/T06-taxonomy

Changed:
  data/taxonomy.js   (new)

Done when — met:
  - All facets present with full ratified option lists in ratified order — 8 facets,
    not 9: the 2026-09-01 follow-up on #6 merged Quantum Complexity Class into
    Complexity Class, so I built 8, not the issue body's original "nine categories."
  - Complexity Class runs P → NP → NP-complete → NP-hard, plus the 6 merged-in
    quantum values (BQP, EQP, QMA, QCMA, QIP, MIP*).
  - Every #6 decision reflected, with a comment citing which decision drove it
    (Problem Type label, Solver Complexity as sidebar filter, Visualization Type
    overlay, Complexity Class multi-valued rework, QuantumOracle handling).
  - SOLVER_TYPE_MAP, COMPLEXITY_CLASS_MAP, REDUCTION_COST_MAP, and
    deriveComplexityClasses are all exported and reviewable by reading the file alone.
  - Zero React/MUI imports — pure data.
  - No component in the repo hardcodes a taxonomy label (only pages/index.js
    exists today, and it's unrelated placeholder text) — npm run lint and
    npm run build are both clean.

Done when — not met:
  - None. All checkboxes are satisfied given the 2026-09-01 supersession.

Decisions and assumptions (this issue didn't fully settle these):
  1. derivesNpBadge() is gone, replaced by deriveComplexityClasses(backendValue,
     overlayQuantumClasses) per the 2026-09-01 follow-up — it returns the full
     derived set (e.g. NPComplete → ["npComplete","np","npHard"]) and unions in
     any quantum classes from the overlay. The "assert in code" suggestion for the
     bare-NP invariant is documented as a comment, not a runtime throw — throwing
     on live backend data would crash the page for a labeling-file bug, which
     conflicts with ground rule 6 (never crash on data issues).
  2. Added `Greedy: "heuristic"` to SOLVER_TYPE_MAP. The issue's Part 2 text lists
     only 8 backend values collapsing into "Exact" and 3 mapping direct — it never
     mentions `Greedy`, even though it's a real SolverType enum member. TAXONOMY_
     REFERENCE.md §5a resolves "Greedy Algorithms" → Heuristic, so I used that
     rather than leaving Greedy solvers with no tag at all.
  3. Visualization Type option labels are singular ("DAG", "Bipartite Factor
     Graph") to match every other facet's convention and the issue's own inline
     examples. TAXONOMY_REFERENCE.md §9 phrases the same 12 values as plural
     category names ("DAGs", "Bipartite Factor Graphs") — I treated that as
     descriptive phrasing, not the literal display string.
  4. Found but did NOT resolve: the mockup's VisualizationsSection badge example
     ("Assignment Table / Table") implies a "Table" visualization-type value, but
     TAXONOMY_REFERENCE.md §9's ratified 12-value list has no "Table" entry. I
     followed the ratified list (per this issue's own instruction to use it) and
     left "Table" out rather than silently adding a 13th value — flagging this
     gap for the project owner rather than deciding it.
  5. The card-status-icon predicate (green ⇔ ≥1 solver + ≥1 visualization + ≥1
     verifier), mentioned in #6 as *possibly* belonging in taxonomy.js, was left
     out — TASKLIST.md explicitly assigns that predicate to T13/#17
     (components/StatusIcon.js), and it isn't in this issue's Done-when list.
  6. accentColor values are semantic tokens ("blue", "salmon-red", "coral", …)
     taken from TASKLIST's T07 description, not CSS/hex values — T07
     (components/theme.js) still needs to decide whether it owns the real
     palette values or consumes these tokens directly; I didn't pick that
     ownership since T07 isn't built yet.
  7. multiValued flags: Problem Type, Complexity Class, and Solver Type are
     `true`; Computational Model, Solver Complexity, Reduction Type, Reduction
     Cost, and Visualization Type are `false`. This isn't fully spelled out
     anywhere for the latter five — I inferred it from each backend enum being
     single-valued per entity (TAXONOMY_REFERENCE.md's "single-valued, mutually
     exclusive" language for Computational Model and Reduction Type extended by
     analogy to the other per-solver/per-reduction/per-visualization facets).

Suggested PR:
  T06 — Build data/taxonomy.js, the single source of truth for tag labels

  Closes #10