### PR TITLE
Added package permissions so actions run

### DIFF
--- a/.github/workflows/rbs.yml
+++ b/.github/workflows/rbs.yml
@@ -5,13 +5,15 @@ on:
   push:
     branches: [main, production]
 
-# No `packages: write` here, deliberately. This workflow only builds and tests (report-only,
-# `soft: true`) — it never publishes an image. Redux_GUI's copy of this file carries that permission
-# because the same repo also has a publish.yml that needs it; this repo has no publish workflow, and
-# won't until the frontend is confirmed production-ready.
+# `packages: write` is required here even though this repo has no publish step of its own: the
+# reusable ci.yml job in Redux_Build_System requests it (for the future `rbs push`), and a reusable
+# workflow can only narrow the permissions its caller grants, never widen them. Omitting it here
+# doesn't skip publishing — it makes the whole job fail to start (startup_failure) because the
+# called job can't get a permission the caller withheld. See ci.yml's own header comment.
 permissions:
   contents: read
   pull-requests: write
+  packages: write
 
 concurrency:
   group: rbs-${{ github.ref }}


### PR DESCRIPTION
Branch: fix/rbs-packages-permission (based on main)

Changed:
  .github/workflows/rbs.yml

What changed:
  Restored `packages: write` to the top-level `permissions:` block, and rewrote the
  comment above it to explain why it's required (previously explained why it was
  removed — that reasoning was the bug). No other lines touched.

Why this fixes it:
  ReduxISU/Redux_Build_System's reusable ci.yml job requests contents:read +
  pull-requests:write + packages:write. A reusable workflow's job can only be granted
  a subset of what the caller's top-level `permissions:` block allows — it can never
  request more. With packages:write missing from rbs.yml, GitHub refused to start the
  job at all (startup_failure, 0s), regardless of branch or PR content.

Verified:
  - YAML parses cleanly (python yaml.safe_load).
  - This doesn't touch ground rule 2 (no deploy/publish workflow, no [push] in
    rbs.toml) — nothing here adds a publish step; it only satisfies a permission
    the existing reusable CI job already declares it needs.