### PR TITLE
Built MUI Dark Theme

### DIFF
--- a/components/theme.js
+++ b/components/theme.js
@@ -1,0 +1,281 @@
+// components/theme.js
+//
+// T07 (#11) — the one shared MUI dark theme for the whole app. Defined once
+// here, applied in pages/_app.js via ThemeProvider + CssBaseline. Every
+// other visual task styles against this rather than ad-hoc colors.
+//
+// Built from the four mockup PDFs in mockup_images/ (gitignored, see
+// CLAUDE.md for how to extract them). Every per-facet accent color sampled
+// out of those images landed within a few RGB units of a Tailwind CSS v3
+// "-400" swatch, so FACET_ACCENT_COLORS below adopts those swatches
+// directly (and their "-600" counterparts for filled-badge backgrounds)
+// rather than approximating by eye.
+//
+// --- Ownership of the per-facet accent palette (open question in #11) ----
+// data/taxonomy.js (#10/T06) gives each facet an `accentColor` field, but
+// left the value a semantic color NAME ("blue", "salmon-red", ...) rather
+// than a real color, and explicitly left ownership of the palette for T07
+// to decide ("pick one owner and say which in a comment"). No later
+// comment on #11 settled it, so this is this task's call:
+//
+//   THIS FILE (components/theme.js) owns the actual color values.
+//   data/taxonomy.js's `accentColor` strings are lookup keys into
+//   FACET_ACCENT_COLORS below, resolved via getFacetAccentColor() —
+//   never hardcoded as hex anywhere else.
+//
+// Reasoning: taxonomy.js's own header comment declares it "Pure data ... No
+// React, no MUI, no imports from elsewhere in the app" — a real MUI-facing
+// color value doesn't belong in a file that states that constraint about
+// itself. A theme module is exactly where a color palette belongs.
+
+import { createTheme, alpha } from "@mui/material/styles";
+
+// Semantic color name (as stored in each data/taxonomy.js facet's
+// `accentColor` field) -> real color. Values are Tailwind CSS v3 "-400"
+// swatches, matched by pixel-sampling the mockups.
+export const FACET_ACCENT_COLORS = {
+  blue: "#60A5FA", // Problem Type
+  cyan: "#22D3EE", // Computational Model
+  amber: "#FB923C", // Complexity Class — reads as warm orange in the mockup, not MUI's yellow-ish "amber"
+  magenta: "#F472B6", // Quantum Complexity Class
+  "salmon-red": "#F87171", // Solver Type
+  // Solver Complexity's mockup dot sampled almost identical to Solver
+  // Type's salmon-red (within ~3 RGB units) — the mockup doesn't actually
+  // give them visually distinct hues despite the distinct semantic names.
+  // Nudged warmer/lighter here so the two facets are still tellable apart
+  // at a glance when they appear side by side (sidebar, solver cards).
+  coral: "#FF8A65", // Solver Complexity
+  violet: "#C084FC", // Reduction Type + Reduction Cost (taxonomy.js gives both the same name)
+  green: "#4ADE80", // Visualization Type
+};
+
+// Darker "-600" counterpart of each accent, used only as the background of
+// a *filled* (matched) badge — see BADGE_FAMILIES below. Keeping these next
+// to FACET_ACCENT_COLORS rather than deriving them at runtime because
+// Tailwind's 400->600 step isn't a uniform transform (hue shifts too).
+const FACET_ACCENT_COLORS_STRONG = {
+  blue: "#2563EB",
+  cyan: "#0891B2",
+  amber: "#EA580C",
+  magenta: "#DB2777",
+  "salmon-red": "#DC2626",
+  coral: "#E64A19",
+  violet: "#9333EA",
+  green: "#16A34A",
+};
+
+const FALLBACK_ACCENT = "#9CA3AF"; // neutral gray — deliberately NOT a real
+// facet color, so a typo'd/unmapped color name reads as visibly "wrong"
+// instead of silently masquerading as Problem Type's blue.
+
+/** Resolve a data/taxonomy.js `accentColor` name to a real color. */
+export function getFacetAccentColor(colorName) {
+  return FACET_ACCENT_COLORS[colorName] ?? FALLBACK_ACCENT;
+}
+
+// --- The three card badge families (T07 done-when, T12/#16) --------------
+//
+// Complexity, Solver Type and Problem Type badges each get their own MUI
+// Chip variant, in both states the mockup shows: outlined by default,
+// filled (solid background + white text) when the tag matches an active
+// filter. Consumers pick the state: `variant={matched ? "complexityFilled"
+// : "complexityOutlined"}`. The leading checkmark on a matched badge is
+// content (an icon), not styling, so T12 renders it — this file only makes
+// the filled state look right once it's there.
+const BADGE_FAMILIES = {
+  complexity: "amber",
+  solverType: "salmon-red",
+  problemType: "blue",
+};
+
+function buildChipVariants() {
+  const variants = [];
+  for (const [family, colorName] of Object.entries(BADGE_FAMILIES)) {
+    const base = FACET_ACCENT_COLORS[colorName];
+    const strong = FACET_ACCENT_COLORS_STRONG[colorName];
+    const outlinedVariant = `${family}Outlined`;
+    const filledVariant = `${family}Filled`;
+
+    variants.push({
+      props: { variant: outlinedVariant },
+      style: {
+        color: base,
+        backgroundColor: alpha(base, 0.1),
+        border: `1px solid ${alpha(base, 0.55)}`,
+        fontWeight: 600,
+      },
+    });
+    variants.push({
+      props: { variant: filledVariant },
+      style: {
+        color: "#FFFFFF",
+        backgroundColor: strong,
+        border: `1px solid ${strong}`,
+        fontWeight: 700,
+        "& .MuiChip-icon": { color: "#FFFFFF" },
+      },
+    });
+  }
+  return variants;
+}
+
+const PAGE_BACKGROUND = "#0A0908";
+const PANEL_BACKGROUND = "#17140F"; // one step lighter than the page, per the mockup's elevated surfaces
+const HAIRLINE_BORDER = "rgba(255, 237, 213, 0.09)"; // warm-tinted hairline, used for every panel/card edge
+
+const theme = createTheme({
+  palette: {
+    mode: "dark",
+    background: {
+      default: PAGE_BACKGROUND,
+      paper: PANEL_BACKGROUND,
+    },
+    divider: HAIRLINE_BORDER,
+    primary: {
+      // The single orange/amber brand accent: nav underline, "Reset to
+      // default", focus rings, the Run button. Same family as (and close
+      // in value to) the Complexity Class facet accent — the mockup reuses
+      // one hue for both roles.
+      main: "#FB923C",
+      light: "#FDBA74",
+      dark: "#EA580C",
+      contrastText: "#241505",
+    },
+    secondary: {
+      main: "#94A3B8",
+      contrastText: "#0B0A09",
+    },
+    text: {
+      primary: "#F5F1EA",
+      secondary: "rgba(245, 241, 234, 0.64)",
+    },
+  },
+  shape: {
+    borderRadius: 12,
+  },
+  typography: {
+    fontFamily:
+      '"Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    // Typography scale (T07 done-when). Conceptual name -> MUI variant:
+    //   page title            -> h1     ("Home", "3-SAT")
+    //   section title         -> h2     ("Overview", "Solvers")
+    //   facet group heading   -> overline (small caps, letter-spaced — MUI's
+    //                            overline variant already models this shape)
+    //   body                  -> body1
+    //   mono (instance/cert.) -> custom "mono" variant, see components.MuiTypography below
+    h1: {
+      fontSize: "2rem",
+      fontWeight: 700,
+      letterSpacing: "-0.01em",
+      lineHeight: 1.25,
+    },
+    h2: {
+      fontSize: "1.25rem",
+      fontWeight: 700,
+      letterSpacing: "-0.005em",
+      lineHeight: 1.3,
+    },
+    overline: {
+      fontSize: "0.6875rem",
+      fontWeight: 700,
+      letterSpacing: "0.08em",
+      lineHeight: 1.4,
+    },
+    body1: {
+      fontSize: "0.9375rem",
+      lineHeight: 1.6,
+    },
+  },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: (themeParam) => ({
+        body: {
+          backgroundColor: themeParam.palette.background.default,
+          // The mockup's subtle warm glow along the top edge, behind the
+          // nav bar. Expressed here (not styles/globals.css) because
+          // CssBaseline's styleOverrides can express it directly — see
+          // this task's done-when item about what globals.css should hold.
+          backgroundImage: `radial-gradient(1400px 480px at 18% -12%, ${alpha(
+            themeParam.palette.primary.main,
+            0.16,
+          )}, transparent 60%)`,
+          backgroundRepeat: "no-repeat",
+        },
+        a: {
+          color: "inherit",
+          textDecoration: "none",
+        },
+        // Explicit, clearly-visible focus styling against the dark
+        // background — required (T07 done-when): never remove the browser
+        // outline without replacing it with something at least as visible.
+        // Covers plain/native elements; MuiButtonBase below covers MUI's
+        // ripple-based components, whose overflow:hidden root can clip a
+        // default outline.
+        "*:focus-visible": {
+          outline: `2px solid ${themeParam.palette.primary.light}`,
+          outlineOffset: "2px",
+          borderRadius: "4px",
+        },
+      }),
+    },
+    MuiButtonBase: {
+      styleOverrides: {
+        root: ({ theme: themeParam }) => ({
+          "&.Mui-focusVisible": {
+            outline: `2px solid ${themeParam.palette.primary.light}`,
+            outlineOffset: "2px",
+          },
+        }),
+      },
+    },
+    MuiPaper: {
+      defaultProps: { elevation: 0 },
+      styleOverrides: {
+        root: ({ theme: themeParam }) => ({
+          // MUI dark-mode Paper normally lightens via a translucent white
+          // overlay gradient per elevation step, which washes out this
+          // theme's warm palette. Panels get their "one step lighter"
+          // treatment from an explicit background + hairline border
+          // instead (see PANEL_BACKGROUND / HAIRLINE_BORDER above).
+          backgroundImage: "none",
+          border: `1px solid ${themeParam.palette.divider}`,
+        }),
+      },
+    },
+    MuiButton: {
+      defaultProps: { disableElevation: true },
+      styleOverrides: {
+        root: {
+          borderRadius: 999, // pill-shaped, per the mockup's buttons ("Clear filters", "Help", "Contribute")
+          textTransform: "none",
+          fontWeight: 600,
+        },
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: {
+          borderRadius: 999, // full pill shape
+        },
+      },
+      variants: buildChipVariants(),
+    },
+    MuiTypography: {
+      variants: [
+        {
+          // The small monospace style used for instance strings and
+          // certificate text (T16c/T16d).
+          props: { variant: "mono" },
+          style: {
+            fontFamily:
+              '"JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace',
+            fontSize: "0.8125rem",
+            letterSpacing: 0,
+          },
+        },
+      ],
+    },
+  },
+});
+
+export default theme;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,13 @@
+import { ThemeProvider } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
 import "../styles/globals.css";
+import theme from "../components/theme";
 
 export default function App({ Component, pageProps }) {
-  return <Component {...pageProps} />;
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,14 +1,5 @@
-* {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  padding: 0;
-  margin: 0;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
+/* T07 (#11): box-sizing/margin reset, the anchor-tag reset, and the page's
+ * background (including its warm top-edge glow) all moved into
+ * components/theme.js's MuiCssBaseline override, which now applies
+ * CssBaseline globally (see pages/_app.js) and covers all of this. Nothing
+ * currently left for this file to hold. */


### PR DESCRIPTION
Issue:  #11 (T07 — Build the shared MUI dark theme)
Branch: task/T07-theme

Changed:
  components/theme.js   (new)
  pages/_app.js          (applies theme via ThemeProvider + CssBaseline)
  styles/globals.css     (trimmed — its box-sizing/margin reset, anchor
                           reset, and background glow all moved into the
                           theme's MuiCssBaseline override)

Done when — met:
  - Theme exported and applied in pages/_app.js via ThemeProvider + CssBaseline.
  - Typography scale covers all five: page title (h1), section title (h2),
    facet group heading (overline, small-caps/letter-spaced), body (body1),
    small monospace (custom "mono" Typography variant).
  - Badge variants exist for all three families (complexity/amber,
    solverType/salmon-red, problemType/blue), each with an Outlined and a
    Filled MuiChip variant (e.g. variant="complexityFilled").
  - Focus-visible styling is explicit: a global *:focus-visible rule plus a
    MuiButtonBase override (covers MUI's ripple root, which can clip a
    plain outline) — no browser outline removed without replacement.
  - Color palette has exactly one owner (theme.js), documented in a header
    comment and posted as a decision comment on #11.
  - styles/globals.css now holds nothing the theme can't express (see diff).

Decisions and assumptions:
  - Palette ownership (issue text: "pick one owner and say which in a
    comment," left unsettled by #10/T06 and by any comment on #11):
    theme.js owns real color values; taxonomy.js's accentColor stays a
    semantic name resolved via getFacetAccentColor(). Recorded as a
    decision comment on #11 — flagged there for project-owner confirmation
    since I made this call myself, not the owner.
  - Colors were pixel-sampled from the two Home mockup PDFs (not guessed):
    every facet accent landed within a few RGB units of a Tailwind CSS v3
    "-400" swatch, so the palette uses those swatches directly, with "-600"
    counterparts for filled-badge backgrounds.
  - Solver Type (salmon-red) and Solver Complexity (coral) sampled almost
    identical in the mockup dots despite their distinct semantic names —
    nudged coral warmer/lighter so the two stay visually distinguishable.
  - No webfont was added; typography uses a system-font stack since none
    was ported/specified and adding one felt out of scope for this task.
  - Checkbox/other per-facet-colored controls aren't themed globally here
    (each facet needs a different accent) — left for T11 (FacetSidebar) to
    apply via getFacetAccentColor() per instance; noted in a code comment.

Verification:
  - npm run lint: clean.
  - npm run build: clean, prerenders successfully.
  - Ran npm run dev and confirmed `/` (still T14's placeholder page) returns
    200 with the theme's background gradient present in the rendered HTML.

  Closes #11