### PR TITLE
Setup NavBar and Breadcrumbs

### DIFF
--- a/components/Breadcrumb.js
+++ b/components/Breadcrumb.js
@@ -1,0 +1,38 @@
+// components/Breadcrumb.js
+//
+// T08 (#12) — the "Home / {Problem}" line that sits above the problem
+// title on a detail page. "Home" links back to the catalog; the problem
+// name is plain text, not a link, because it's the page already showing.
+//
+// Detail-page-only placement is a consuming-page concern (T19's
+// pages/[problem].js), not something this component enforces itself.
+
+import Box from "@mui/material/Box";
+import Link from "next/link";
+
+export default function Breadcrumb({ problemName }) {
+  return (
+    <Box
+      component="nav"
+      aria-label="Breadcrumb"
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.75,
+        fontSize: "0.9375rem",
+        color: "text.secondary",
+        mb: 1,
+      }}
+    >
+      <Box id="breadcrumb-home-link" component={Link} href="/" sx={{ color: "inherit" }}>
+        Home
+      </Box>
+      <Box component="span" aria-hidden="true">
+        /
+      </Box>
+      <Box component="span" sx={{ color: "text.primary" }}>
+        {problemName}
+      </Box>
+    </Box>
+  );
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -1,0 +1,88 @@
+// components/NavBar.js
+//
+// T08 (#12) — page chrome shown at the top of every page: the "REDUX"
+// wordmark, the "Home" nav item (with an orange underline on the current
+// route), and the Help/Contribute pill buttons.
+//
+// Active-route detection reads the router directly (useRouter().pathname)
+// rather than taking a prop, per the issue's explicit warning: a
+// per-page prop silently goes stale the moment a route is added.
+//
+// Help and Contribute are chrome only for v1 (#12 scope note). Redux_GUI
+// already has live /help and /contribute pages, but nothing in this repo
+// (.env.example, ARCHITECTURE.md) names a confirmed URL for a deployed
+// Redux_GUI instance to link to, so guessing a domain felt worse than
+// leaving them inert — swap in a real href once the project owner
+// confirms one.
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+const CHROME_LINKS = [
+  { id: "navbar-help-button", label: "Help" },
+  { id: "navbar-contribute-button", label: "Contribute" },
+];
+
+export default function NavBar() {
+  const router = useRouter();
+  const isHomeActive = router.pathname === "/";
+
+  return (
+    <Box
+      component="header"
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 3,
+        px: { xs: 3, sm: 5 },
+        py: 2.5,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 5 }}>
+        <Box
+          id="navbar-wordmark-link"
+          component={Link}
+          href="/"
+          sx={{
+            fontSize: "1.05rem",
+            fontWeight: 700,
+            letterSpacing: "0.28em",
+            color: "text.primary",
+          }}
+        >
+          REDUX
+        </Box>
+
+        <Box
+          id="navbar-home-link"
+          component={Link}
+          href="/"
+          aria-current={isHomeActive ? "page" : undefined}
+          sx={{
+            fontSize: "0.9375rem",
+            fontWeight: 600,
+            color: isHomeActive ? "text.primary" : "text.secondary",
+            borderBottom: "2px solid",
+            borderColor: isHomeActive ? "primary.main" : "transparent",
+            pb: 0.75,
+          }}
+        >
+          Home
+        </Box>
+      </Box>
+
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+        {CHROME_LINKS.map(({ id, label }) => (
+          <Button key={id} id={id} variant="outlined" disabled>
+            {label}
+          </Button>
+        ))}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
Issue:  #12 (T08 Build the nav bar and breadcrumb)
Branch: task/T08-navbar-breadcrumb

Changed:
  components/NavBar.js      (new)
  components/Breadcrumb.js  (new)

Done when met:
  - NavBar matches the mockups on both the Home and detail-page chrome (verified visually via
    Playwright screenshots against a temporary wiring into pages/index.js. See decisions below).
  - Active-route underline is derived from `useRouter().pathname === "/"`, not a prop. Verified it's
    on for "/" and off on a non-"/" route.
  - Breadcrumb renders "Home / {problemName}", Home as a next/link, the name as plain text.
  - Every link/button has a unique id: navbar-wordmark-link, navbar-home-link, navbar-help-button,
    navbar-contribute-button, breadcrumb-home-link.

Done when not met:
  - "Breadcrumb appears only on the detail page" can't be fully proven yet. Pages/[problem].js
    doesn't exist (that's T19, blocked on T08+T09+T18). The component itself doesn't self-restrict by
    route (it just renders wherever it's imported), so this is satisfied by construction but only
    provable once a page wires it in.

Decisions and assumptions:
  - Help/Contribute rendered as disabled (inert) pill buttons rather than linked out. The issue offers
    both options, but no confirmed live URL for a deployed Redux_GUI instance exists anywhere in this
    repo (.env.example, ARCHITECTURE.md) Redux_GUI's /help and /contribute routes exist in that repo
    but I found no deployment URL to point at. Left a comment in NavBar.js marking exactly where to
    add a real href once the project owner confirms one. Not significant enough to warrant a decision
    comment on #12 (it's reversible, single-file), but flagging here since it's the one judgment call.
  - Verified visually: temporarily wired NavBar into pages/index.js and a scratch pages/_test-detail.js
    (with Breadcrumb), ran the dev server, screenshotted both with Playwright, and compared side-by-side
    against the Home and Problem Detail mockup PDFs wordmark, underline on/off, pill buttons, and
    breadcrumb all matched. Reverted pages/index.js to its original placeholder and deleted the scratch
    page afterward; working tree now only shows the two new component files.
  - Noted but did not touch: `npx biome check` on main's components/theme.js and pages/_app.js
    (pre-existing from the merged T07 PR) shows 3 format/import-order failures this is what that
    stray CI report mid-task was about. Out of scope for T08 (different files, not something this
    issue asks me to fix), but flagging since it'll fail the repo's format-check CI step until someone
    cleans it up. My two new files pass `npx biome check` cleanly.

  Closes #12