### PR TITLE
Added Card Status Icon

### DIFF
--- a/components/StatusIcon.js
+++ b/components/StatusIcon.js
@@ -1,0 +1,96 @@
+// components/StatusIcon.js
+//
+// T13 (#17) — the small status glyph in the top-right corner of each catalog
+// card: a green check when a problem is fully catalogued, a grey minus when
+// it isn't.
+//
+// Not a port. ARCHITECTURE.md's directory listing doesn't include this file
+// at all -- TASKLIST.md pulled it out into its own module because its
+// meaning was still an open question (#6, item 4) when the file tree was
+// drawn, and it's consumed from more than one place (this card icon, and
+// T12/#16's decision on whether the card is a link at all).
+//
+// The predicate (#6, item 4, settled 2026-08-31 in this issue's own
+// comment): "fully catalogued" means at least one declared solver, at least
+// one declared visualization, and a declared verifier. Per data/fixtures.js,
+// solvers and visualizations are arrays but verifier is a single
+// object-or-null -- so this is an array-length check for two fields and a
+// null check for the third, not three interchangeable length checks.
+// isProblemComplete() is the one place that rule lives; T12 imports it
+// rather than re-deriving "is this thing complete" on its own.
+//
+// Colors are sampled from the mockup, not invented. The green ring's mockup
+// pixels land almost exactly on theme.js's existing FACET_ACCENT_COLORS.green
+// (Visualization Type's accent, #4ADE80) -- reused via getFacetAccentColor
+// rather than duplicated. The grey ring has no such existing per-facet
+// color, but its antialiased mockup pixels scale up (backing out the
+// thin-stroke/JPEG blending with the dark panel background) to theme.js's
+// palette.secondary.main (#94A3B8), so this resolves that via the standard
+// sx palette-path string ("secondary.main") instead of adding a new token.
+
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutlineOutlined";
+import RemoveCircleOutlineIcon from "@mui/icons-material/RemoveCircleOutlineOutlined";
+import { getFacetAccentColor } from "./theme";
+
+const COMPLETE_COLOR = getFacetAccentColor("green");
+const INCOMPLETE_COLOR = "secondary.main";
+
+const MISSING_PART_LABELS = {
+  solver: "a solver",
+  visualization: "a visualization",
+  verifier: "a verifier",
+};
+
+// Fixed order (solver, visualization, verifier) so the message is stable
+// regardless of which fields happen to be set on a given fixture.
+function getMissingParts(problem) {
+  const missing = [];
+  if (!(problem.solvers?.length > 0)) {
+    missing.push(MISSING_PART_LABELS.solver);
+  }
+  if (!(problem.visualizations?.length > 0)) {
+    missing.push(MISSING_PART_LABELS.visualization);
+  }
+  if (problem.verifier == null) {
+    missing.push(MISSING_PART_LABELS.verifier);
+  }
+  return missing;
+}
+
+function joinWithAnd(parts) {
+  if (parts.length === 1) {
+    return parts[0];
+  }
+  if (parts.length === 2) {
+    return `${parts[0]} and ${parts[1]}`;
+  }
+  return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}
+
+/** The one place the completeness rule lives (#6, item 4, 2026-08-31). */
+export function isProblemComplete(problem) {
+  return getMissingParts(problem).length === 0;
+}
+
+export default function StatusIcon({ problem }) {
+  const missing = getMissingParts(problem);
+  const complete = missing.length === 0;
+
+  // Accurate about which piece is missing when there's only one -- a card
+  // missing just a verifier reads differently from one missing everything.
+  // titleAccess renders a native <title> (a hover tooltip for sighted mouse
+  // users, who have no other affordance on a card that isn't a link) and
+  // sets role="img"; aria-label carries the same text as the accessible name
+  // for screen readers, since aria-label takes precedence over <title> in
+  // the accessible-name computation.
+  const label = complete
+    ? "Fully catalogued: has at least one solver, visualization, and verifier."
+    : `Not yet implemented: missing ${joinWithAnd(missing)}. Details unavailable.`;
+
+  const Icon = complete ? CheckCircleOutlineIcon : RemoveCircleOutlineIcon;
+  const color = complete ? COMPLETE_COLOR : INCOMPLETE_COLOR;
+
+  return (
+    <Icon titleAccess={label} aria-label={label} fontSize="small" sx={{ color, flexShrink: 0 }} />
+  );
+}


### PR DESCRIPTION
Issue:  #17 (T13 — Build the card status icon)
Branch: task/T13-status-icon

Changed:
  components/StatusIcon.js   (new)

Done when — met:
  - Both states render per the mockup: extracted the actual mockup JPEG and pixel-sampled both icons.
    Confirmed they're MUI's outlined-ring style (CheckCircleOutlineOutlined / RemoveCircleOutlineOutlined),
    not filled circles — verified visually in a throwaway harness against all four fixture cases
    (complete, missing-verifier-only, missing-visualization-only, missing-all-three), screenshotted,
    then deleted the harness.
  - Each state has an accessible explanation: passes both `titleAccess` (renders a native SVG <title>,
    which gives sighted mouse users the hover-tooltip affordance a non-link card otherwise lacks) and
    `aria-label` (screen-reader accessible name) with the same text. Verified via Playwright that the
    DOM actually carries both.
  - The predicate lives in exactly one place: `isProblemComplete(problem)` is exported from
    StatusIcon.js; solvers/visualizations are array-length checks, verifier is a null check, matching
    fixtures.js's real shape (not three uniform length checks).

Decisions and assumptions:
  - Message wording is missing-piece-specific, not a fixed two-state string: "Not yet implemented:
    missing a verifier. Details unavailable." for one missing part, "...a solver, a visualization,
    and a verifier..." for three missing, etc. Built with a small `getMissingParts` + `joinWithAnd`
    helper rather than a full combinatorial message table — the issue said accuracy matters but not to
    over-engineer, and this covers all cases without a lookup table.
  - Icon colors: reused existing theme tokens instead of adding new ones. Sampled the mockup's green
    ring and it lands almost exactly on theme.js's existing `FACET_ACCENT_COLORS.green` (#4ADE80,
    already used for Visualization Type) — resolved via `getFacetAccentColor("green")`. The grey ring
    has no existing per-facet color, but backing out the JPEG/thin-stroke antialiasing blend against
    the dark panel background, its pixels scale up proportionally to `theme.palette.secondary.main`
    (#94A3B8) — used via the sx palette-path string `"secondary.main"`, same pattern as
    `color: "text.secondary"` elsewhere in the codebase. Nothing new was added to theme.js.
  - MUI v9's icon set has no bare `CheckCircleOutline`/`RemoveCircleOutline` export — only style-suffixed
    variants exist. Used `CheckCircleOutlineOutlined` / `RemoveCircleOutlineOutlined`, which is the
    thin-stroke ring style that actually matches the mockup pixel-for-pixel.
  - Component takes the whole fixtures.js problem object as a `problem` prop (matching the issue's own
    `isProblemComplete(problem)` suggested signature) rather than three separate scalar props, so T12
    can pass the same object it already has without reshaping it.

  Closes #17