### PR TITLE
Write Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+ai_documentation
+mockup_images
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Install dependencies only when needed
+FROM node:24-alpine AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Rebuild the source code only when needed
+FROM node:24-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Next.js collects completely anonymous telemetry data about general usage.
+# Learn more here: https://nextjs.org/telemetry
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# Production image, copy all the files and run next
+FROM node:24-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/package.json ./package.json
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
Issue:  #8 (T04 — Write the Dockerfile)
Branch: task/T04-dockerfile

Changed:
  Dockerfile      (new)
  .dockerignore   (new)

Done when — met:
  - `docker build` succeeds locally (verified: built as redux-frontend-t04-test:latest, ~14.9s app-image build stage).
  - Running container answers /api/health with {"status":"ok"} (verified via curl against the running container).
  - .dockerignore exists and covers node_modules, .next, ai_documentation/, mockup_images/ (also added npm-debug.log, matching Redux_GUI's existing entry).

Decisions and assumptions:
  - Dropped the `COPY --from=builder /app/public ./public` line entirely rather than adding an empty
    public/.gitkeep. This repo has no public/ directory (confirmed absent), and output:"standalone"
    doesn't require one — Next just won't serve any /public/* static assets, which matches "0 problems,
    not a crash" behavior already established in CLAUDE.md's ground rules. Cheaper than inventing an
    empty directory for a feature nobody's asked for yet; whoever adds real public assets later can
    re-add the COPY line then.
  - Used node:24-alpine on all three FROM lines per the issue.
  - Did not touch rbs.toml or add any push/deploy workflow, per the explicit ground rule (and rbs.toml's
    own comment already explains the omission).
  - Ran the full three-gate check (lint, format:check, build) per your standing instruction beyond what
    the issue itself asked for (lint + build) — all three clean.
  - Built and ran a real docker image/container to verify Done-when items rather than just eyeballing
    the Dockerfile; test container/image (redux-frontend-t04-test) fully cleaned up afterward —
    `docker ps -a` / `docker images` show no trace of it.

  Closes #8