### PR TITLE
Add branching-strategy section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,29 @@ By submitting a contribution (pull request, patch, or code submission), you conf
 
 ---
 
+## Branching Strategy
+
+### `main`
+- **Branch name:** `main`
+- This is the default branch, and where day-to-day pull requests land.
+- Branch off `main` for your work, and open your pull request back into `main`.
+- Direct pushes are blocked by a GitHub ruleset. Everyone goes through a pull request.
+- Merging requires **1 approving review**. There is currently no required status check gating the merge — the CI workflow runs on every pull request, but it's report-only and won't block you.
+
+### `production`
+- **Branch name:** `production`
+- This is what's actually deployed. It is **never** the target of a pull request — it only moves forward when the project owner deliberately promotes finished work from `main`.
+- As of this writing, `production` has no GitHub ruleset configured, so it isn't technically protected against a direct push, force-push, or deletion. Treat it as off-limits by convention regardless: don't push to it, don't target it with a pull request, and don't rely on GitHub to stop you if you try.
+
+### Workflow
+
+1. **Branch off `main`** for your change.
+2. **Open a pull request** back into `main`.
+3. **Get 1 approving review.** A reviewer other than yourself needs to approve before you can merge.
+4. **Periodically**, the project owner promotes reviewed work from `main` into `production` to deploy it.
+
+---
+
 ## How to Contribute
 
 ### 1. Fork the repository


### PR DESCRIPTION
Issue:  #9 (T05 — Add the branching-strategy section to CONTRIBUTING.md)
Branch: task/T05-branching-strategy-docs

Changed:
  CONTRIBUTING.md   (added "## Branching Strategy" section, before "How to Contribute")

Done when — met:
  - Section added to CONTRIBUTING.md
  - Matches the rulesets actually configured (verified live via gh api, not copied from
    ARCHITECTURE.md or the issue body — see gap below)
  - A reader knows which branch to target (main) and what blocks merging (1 approval;
    production is a no-PR zone by convention)

Live ruleset state, verified just now (not the design in ai_documentation/ARCHITECTURE.md, and not what issue #9's own body assumes):

- main: exactly one ruleset, require-reviewed-pr, targeting ~DEFAULT_BRANCH. It requires a PR + 1 approving review. No required status check — rbs.yml runs on every PR but is soft: true (report-only, doesn't block). The project owner has bypass_mode: "always" — a full bypass, including pushing directly, not the pull_request-mode partial bypass ARCHITECTURE.md describes.
- production: zero rulesets. No PR requirement, no approval requirement, no deletion/force-push/history protection — nothing. Technically anyone with write access could push straight to it today.
- Neither branch has the 80%-coverage, linear-history, no-deletion, or no-force-push rules ARCHITECTURE.md describes, and there's no separate "no-bypass" ruleset alongside the PR-approval one.

I wrote CONTRIBUTING.md to match this reality exactly — it does not claim production is protected, does not claim a status check is required, and does not claim the owner's bypass is partial. Per ground rule #8, I didn't quietly reconcile this against ARCHITECTURE.md or the issue's own description — that gap (design doc + issue both describe a stricter, fully-configured state than what's live) is flagged here for you to resolve either by tightening the rulesets or updating the design docs, not something I resolved by picking one version to write.

Other note, not a blocker: biome (format:check) doesn't actually process .md files in this repo at all under the current biome.json — I confirmed even README.md comes back "ignored" with 0 files processed, unrelated to my change. npm run format:check still exits 0 (nothing to check), so the gate passes, but it isn't verifying CONTRIBUTING.md's formatting. npm run lint and npm run build are both genuinely clean.

Closes #9