### PR TITLE
T14b + T17 — Active filter chips row and card grid

### DIFF
--- a/components/ActiveFilterChips.js
+++ b/components/ActiveFilterChips.js
@@ -1,0 +1,148 @@
+// components/ActiveFilterChips.js
+//
+// T14b (#19) — the "FILTERING BY" row that sits between the search bar and
+// the results grid on the Home page, once at least one filter is selected.
+// Split out of T14 (#18) because it's a self-contained component named in
+// ARCHITECTURE.md, and can be built in parallel with the rest of the Home
+// page rather than after it.
+//
+// Absent entirely -- not an empty container -- when nothing is selected
+// (issue done-when; the default Home mockup has no gap there), so this
+// returns null rather than rendering a row with nothing in it.
+//
+// Not built on MUI Chip's own `onDelete`/`deleteIcon` plumbing: passing
+// `onDelete` turns the *whole* Chip into a ButtonBase (Chip.js), which would
+// make each chip two overlapping tab stops -- the chip root (reachable via
+// Tab, deletes on Backspace/Delete) and any custom deleteIcon element placed
+// inside it. The issue's own done-when wants one real, separately
+// identifiable remove control per chip ("its own unique id and an
+// accessible name that says what it removes"), not a keyboard shortcut on
+// the chip as a whole, so this builds a plain pill (label + a real `<button>`
+// remove control) instead of reaching for Chip here.
+//
+// Every chip's label text comes from data/taxonomy.js; colors come from
+// components/theme.js's getFacetAccentColor(), the same helper
+// FacetSidebar's group dot and selection badge already use.
+
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import { alpha } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { TAXONOMY } from "../data/taxonomy";
+import { getFacetAccentColor } from "./theme";
+
+const TAXONOMY_BY_KEY = new Map(TAXONOMY.map((facet) => [facet.key, facet]));
+
+function optionLabel(facetKey, optionKey) {
+  const option = TAXONOMY_BY_KEY.get(facetKey)?.options.find((candidate) => {
+    return candidate.key === optionKey;
+  });
+  return option?.label ?? optionKey;
+}
+
+function FilterChip({ facet, optionKey, onRemove }) {
+  const accentColor = getFacetAccentColor(facet.accentColor);
+  const label = optionLabel(facet.key, optionKey);
+  const removeId = `active-filter-chip-${facet.key}-${optionKey}-remove`;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+        pl: 1.25,
+        pr: 0.5,
+        py: 0.375,
+        borderRadius: 999,
+        color: accentColor,
+        backgroundColor: alpha(accentColor, 0.12),
+        border: `1px solid ${alpha(accentColor, 0.55)}`,
+        fontSize: "0.8125rem",
+        fontWeight: 600,
+      }}
+    >
+      <Box component="span">{label}</Box>
+      <Box
+        id={removeId}
+        component="button"
+        type="button"
+        aria-label={`Remove ${label} filter`}
+        onClick={() => onRemove(facet.key, optionKey)}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          border: "none",
+          background: "none",
+          p: 0.25,
+          borderRadius: "50%",
+          color: "inherit",
+          cursor: "pointer",
+          lineHeight: 0,
+        }}
+      >
+        <CloseIcon aria-hidden="true" sx={{ fontSize: "0.9375rem" }} />
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {Object} [props.selected] `{ [facetKey]: Set<optionKey> }` -- the
+ *   same shape FacetSidebar's `selected` prop already uses, so the Home page
+ *   can pass one filter-state object to both.
+ * @param {(facetKey: string, optionKey: string) => void} props.onRemove
+ *   Called when a single chip's remove button is pressed.
+ * @param {() => void} props.onClearAll Called by the row's "Clear all"
+ *   action. This component only ever touches filter selections -- clearing
+ *   the search box too (issue body) is the page's responsibility.
+ */
+export default function ActiveFilterChips({ selected = {}, onRemove, onClearAll }) {
+  const entries = [];
+  for (const facet of TAXONOMY) {
+    for (const optionKey of selected[facet.key] ?? []) {
+      entries.push({ facet, optionKey });
+    }
+  }
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1 }}>
+      <Typography variant="overline" component="span" sx={{ color: "text.secondary" }}>
+        Filtering by
+      </Typography>
+      {entries.map(({ facet, optionKey }) => (
+        <FilterChip
+          key={`${facet.key}-${optionKey}`}
+          facet={facet}
+          optionKey={optionKey}
+          onRemove={onRemove}
+        />
+      ))}
+      <Box
+        id="active-filter-chips-clear-all"
+        component="button"
+        type="button"
+        onClick={onClearAll}
+        sx={{
+          border: "none",
+          background: "none",
+          p: 0,
+          ml: 0.5,
+          color: "text.secondary",
+          font: "inherit",
+          fontWeight: 600,
+          cursor: "pointer",
+          textDecoration: "underline",
+        }}
+      >
+        Clear all
+      </Box>
+    </Box>
+  );
+}

--- a/components/ProblemGrid.js
+++ b/components/ProblemGrid.js
@@ -1,0 +1,86 @@
+// components/ProblemGrid.js
+//
+// T17 (#26) — the grid ProblemCatalogCard sits in on the Home page.
+//
+// Real CSS Grid (not flex-wrap): a shared row/column track keeps every
+// card's top edge aligned to the same row regardless of how many tag rows a
+// given card happens to render (#26 done-when: "rows line up even when
+// cards have different numbers of tag rows"). `alignItems: "start"` keeps
+// each card at its own intrinsic height rather than CSS Grid's default
+// stretch behavior, which would pad a shorter card's background down to
+// match its tallest row-mate -- the Home mockup shows cards of visibly
+// different heights sitting in the same row, not stretched to match.
+//
+// Column count is a named constant, not a literal repeated across
+// properties, so T28 (#37) -- which owns the narrow-width breakpoints and
+// whether/how this becomes responsive -- has one place to change rather
+// than a hunt through this file. Phase 1 is desktop-only; going to 2 and
+// then 1 column at narrower widths is explicitly T28's call, not this
+// task's, so no breakpoint object is added here.
+//
+// Owns its own vertical scroll (`overflowY: "auto"`) rather than leaving it
+// to an ancestor, because the mockup's results column scrolls independently
+// while the sidebar stays put (visible scrollbar sits at the grid's own
+// right edge, not the page's). This only takes effect once the Home page
+// (T14/#18) gives this component a bounded height to scroll within (e.g.
+// `flex: 1` inside a fixed-height row below the nav/search chrome) -- that
+// outer layout is #18's job, not this component's.
+//
+// "Doesn't trap keyboard focus" (#26 done-when) needs no extra code: plain
+// `overflow: auto` never removes an element from tab order, and browsers
+// already auto-scroll a newly focused element into view.
+//
+// Empty-state wording is a placeholder -- the issue says to "coordinate the
+// exact wording with T29 (#38)", which hasn't been built yet -- so it's
+// exposed as an overridable `emptyMessage` prop rather than hardcoded, so
+// T29 can supply the final copy without editing this file.
+
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import ProblemCatalogCard from "./ProblemCatalogCard";
+
+const DESKTOP_COLUMN_COUNT = 3;
+
+/**
+ * @param {Object} props
+ * @param {Array} props.problems Data/fixtures.js-shaped FixtureProblem
+ *   objects to render, already filtered and searched by the caller -- this
+ *   component only lays them out, it never filters.
+ * @param {Object} [props.matchedTags] `{ [facetKey]: Set<optionKey> }`,
+ *   forwarded to every card unchanged (ProblemCatalogCard's own prop).
+ * @param {string} [props.emptyMessage] Shown in place of the grid when
+ *   `problems` is empty (ground rule 6: an empty grid, not a crash).
+ */
+export default function ProblemGrid({
+  problems,
+  matchedTags = {},
+  emptyMessage = "No problems match your filters.",
+}) {
+  if (problems.length === 0) {
+    return (
+      <Box sx={{ py: 6, textAlign: "center" }}>
+        <Typography variant="body1" sx={{ color: "text.secondary" }}>
+          {emptyMessage}
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        height: "100%",
+        overflowY: "auto",
+        display: "grid",
+        gridTemplateColumns: `repeat(${DESKTOP_COLUMN_COUNT}, minmax(0, 1fr))`,
+        alignItems: "start",
+        gap: 2,
+        pb: 1,
+      }}
+    >
+      {problems.map((problem) => (
+        <ProblemCatalogCard key={problem.slug} problem={problem} matchedTags={matchedTags} />
+      ))}
+    </Box>
+  );
+}


### PR DESCRIPTION
Issues: #19 (T14b — Build the active filter chips row) and #26 (T17 — Build the card grid)
Branch: task/T14b-active-filter-chips

Both landed on this one branch because the two components were built back to
back and their untracked files ended up staged together before either was
committed — noted here rather than split after the fact, since neither
component depends on the other.

Changed:
  components/ActiveFilterChips.js   (new — #19)
  components/ProblemGrid.js         (new — #26)

## #19 — ActiveFilterChips.js

Done when — met:
  - Chip colours match the tag category, via theme.js's getFacetAccentColor()
    (same helper FacetSidebar already uses), not hardcoded per tag.
  - Removing one chip leaves other selections untouched — verified with
    Playwright: removed NP-complete, Exact/Heuristic stayed.
  - Row disappears entirely (returns null, not an empty container) when no
    filters are selected.
  - Each chip's remove control is a real <button> with its own id
    (active-filter-chip-<facetKey>-<optionKey>-remove) and an aria-label
    naming exactly what it removes (e.g. "Remove NP-complete filter") —
    verified it's the first Tab stop on the page.
  - Chip text comes from data/taxonomy.js via a lookup; no label strings
    written here.

Decisions and assumptions:
  - Built as a plain custom pill (Box + nested <button>), not MUI Chip's
    onDelete/deleteIcon. Passing onDelete turns the whole Chip into a
    ButtonBase (confirmed by reading Chip.js), which would make each chip
    two overlapping tab stops instead of the one clean, individually-labeled
    remove control the issue's done-when asks for.
  - `selected` prop shape is `{ [facetKey]: Set<optionKey> }`, matching
    FacetSidebar's existing `selected` prop exactly, so the Home page (#18)
    can hand the same filter-state object to both components.
  - `onClearAll` only empties filter selections; the issue says "Clear all"
    must also empty the search box, but that state lives on the Home page
    (#18), not here — this component just fires the callback.

## #26 — ProblemGrid.js

Done when — met:
  - Cards equal-width with even gutters via CSS Grid (repeat(3, minmax(0,1fr))
    + gap); rows stay aligned regardless of each card's tag-row count —
    verified visually with the 12 mixed-content fixtures.
  - Empty state shows a centered message instead of blank space (ground
    rule 6) when `problems` is empty — verified visually.
  - Scrolling area doesn't trap keyboard focus: verified with Playwright —
    tabbed from the first card to the last (Job-Shop Scheduling) with no
    dead stops, and the browser auto-scrolled it into view. Confirmed via
    scrollHeight/clientHeight that the grid's own box scrolls independently
    of the page body, matching the mockup's own grid-local scrollbar.

Decisions and assumptions:
  - Column count is a named constant (DESKTOP_COLUMN_COUNT = 3), not
    hardcoded inline, but no responsive breakpoints are added — the issue
    explicitly reserves narrower-width column counts for T28 (#37).
  - Used alignItems: "start" so cards keep their own intrinsic height rather
    than CSS Grid's default stretch, which would pad shorter cards down to
    match a taller row-mate. Checked this against the actual "Home — default,
    no filters" mockup (extracted the embedded JPEG) — cards there are
    visibly different heights within the same row, not stretched, so this
    matches.
  - Empty-state copy ("No problems match your filters.") is a placeholder —
    the issue says to coordinate exact wording with T29 (#38), which hasn't
    been built yet — so it's exposed as an overridable `emptyMessage` prop
    rather than hardcoded internally.
  - This component assumes its parent gives it a bounded height (e.g. flex:
    1 in a fixed-height row) so its own overflowY: auto can take effect.
    That outer layout is #18's job; noted here so whoever builds #18 doesn't
    have to rediscover it.

Closes #19
Closes #26
