### PR TITLE
Build Shared Detail Page

### DIFF
--- a/components/detail/SectionShell.js
+++ b/components/detail/SectionShell.js
@@ -1,0 +1,138 @@
+// components/detail/SectionShell.js
+//
+// T15 (#20) — the shared frame around all five Problem Detail sections
+// (Overview, Visualizations, Solvers, Verifier, Reductions). Built before
+// the sections themselves so all five can be worked on in parallel once it
+// exists (TASKLIST.md's T15 entry).
+//
+// Rounded panel, hairline border, slightly lifted surface — the same
+// Paper treatment as components/ProblemCatalogCard.js's cards. Header row:
+// a six-dot drag grip, a chevron toggle, the section title, and an
+// optional right-aligned summary (`3 visualizations`, `4 solvers`, …).
+// Overview and Verifier pass no summary — the header row still has to look
+// right without one (issue done-when), which is why the title element
+// grows to fill the row rather than the summary being pinned with a fixed
+// offset.
+//
+// The drag grip is a separate DOM element from the chevron button and
+// carries no click handler of its own (issue body: "the single most common
+// bug in this kind of component" is a grip that also toggles collapse).
+// It's a static affordance for now — actual drag-to-reorder is wired up by
+// whichever task assembles the Detail page (T21) across multiple
+// SectionShell instances; this component only has to guarantee the grip
+// and the toggle never share a click target.
+//
+// Accessibility: unlike FacetSidebar's facet groups (a sidebar nav list,
+// nothing on that page needs them in the heading outline), a Problem Detail
+// page's five sections ARE meant to be real headings — theme.js's own
+// typography-scale comment declares "section title -> h2 ('Overview',
+// 'Solvers')". So the title is a genuine, non-hidden <h2> per the WAI-ARIA
+// accordion pattern (heading wraps the toggle button; the button's visible
+// text is its accessible name), not aria-hidden text folded into a manual
+// aria-label the way FacetFilterGroup's group label is. That keeps
+// "Overview", "Solvers", etc. discoverable via screen-reader heading
+// navigation, which a hidden label would have silently dropped.
+//
+// The body stays mounted and is hidden via `display: none` rather than
+// unmounted while collapsed (same choice as FacetSidebar's option list) —
+// a section's own internal state (e.g. Solvers' pasted instance, T16c)
+// shouldn't reset just because its panel was collapsed.
+
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import { useState } from "react";
+
+/**
+ * @param {Object} props
+ * @param {string} props.sectionKey Derives every id on this instance
+ *   (`section-${sectionKey}-toggle`, `section-${sectionKey}-body`) so five
+ *   sections on one Detail page never collide (issue done-when).
+ * @param {string} props.title Section heading text ("Overview", "Solvers",
+ *   …) — not looked up here; each section component owns its own title.
+ * @param {string} [props.summary] Optional right-aligned count summary
+ *   ("3 visualizations"). Omitted entirely for Overview and Verifier.
+ * @param {React.ReactNode} props.children The section body, shown when
+ *   expanded.
+ */
+export default function SectionShell({ sectionKey, title, summary, children }) {
+  const [expanded, setExpanded] = useState(true);
+  const toggleId = `section-${sectionKey}-toggle`;
+  const bodyId = `section-${sectionKey}-body`;
+  const gripId = `section-${sectionKey}-grip`;
+
+  return (
+    <Paper sx={{ borderRadius: 3, overflow: "hidden" }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, px: 2, py: 1.75 }}>
+        <Box
+          id={gripId}
+          aria-hidden="true"
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            color: "text.secondary",
+            cursor: "grab",
+            flexShrink: 0,
+          }}
+        >
+          <DragIndicatorIcon fontSize="small" />
+        </Box>
+
+        <Typography component="h2" variant="h2" sx={{ m: 0, flex: 1, minWidth: 0 }}>
+          <Box
+            id={toggleId}
+            component="button"
+            type="button"
+            aria-expanded={expanded}
+            aria-controls={bodyId}
+            onClick={() => setExpanded((prev) => !prev)}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1.5,
+              width: "100%",
+              border: "none",
+              background: "none",
+              p: 0,
+              cursor: "pointer",
+              color: "inherit",
+              font: "inherit",
+              textAlign: "left",
+            }}
+          >
+            <ChevronRightIcon
+              aria-hidden="true"
+              fontSize="small"
+              sx={{
+                color: "text.secondary",
+                flexShrink: 0,
+                transform: expanded ? "rotate(90deg)" : "none",
+                transition: "transform 0.15s ease",
+              }}
+            />
+            <Box component="span">{title}</Box>
+          </Box>
+        </Typography>
+
+        {summary && (
+          <Typography variant="body2" sx={{ color: "text.secondary", flexShrink: 0 }}>
+            {summary}
+          </Typography>
+        )}
+      </Box>
+
+      <Box
+        id={bodyId}
+        sx={{
+          display: expanded ? "block" : "none",
+          px: 2,
+          pb: 2,
+        }}
+      >
+        {children}
+      </Box>
+    </Paper>
+  );
+}


### PR DESCRIPTION
Issue:  #20 (T15 — Build the shared detail section frame)
Branch: task/T15-section-shell

Changed:
  components/detail/SectionShell.js   (new)

Done when — met:
  - Looks correct both with and without the right-hand summary (verified via Playwright
    screenshot of all 5 sections, 2 without summary / 3 with)
  - The chevron is a real button with aria-expanded/aria-controls pointing at the body
    (verified: aria-expanded toggles true/false, aria-controls="section-<key>-body")
  - Dragging by the grip never toggles collapse — the grip carries no click handler at all,
    it's a separate DOM element from the toggle button
  - Each instance's ids derive from the section key (section-overview-toggle,
    section-solvers-toggle, etc.) — verified no collisions across 5 instances on one page
  - The "all collapsed" mockup is reproducible by collapsing all five (verified screenshot
    matches mockup_images/Problem Detail — all collapsed.pdf closely)

Decisions and assumptions:
  - Diverged from FacetSidebar's accessibility pattern on purpose: FacetFilterGroup hides its
    label text (aria-hidden) and puts everything in one manual aria-label on the button, which
    is fine for a sidebar filter list. But theme.js's own typography-scale comment declares
    "section title -> h2 ('Overview', 'Solvers')" — these are meant to be real page headings.
    So SectionShell wraps the toggle button in a genuine, non-hidden <h2> (WAI-ARIA accordion
    pattern) instead, so "Overview"/"Solvers"/etc. stay discoverable via screen-reader heading
    navigation. Flagging this since it's a different pattern than the nearest precedent in the
    codebase, in case the project owner wants the two to match instead.
  - Defaulted `expanded` state to `true` (matching FacetFilterGroup's own default), not `false`
    — the issue's own done-when phrases the all-collapsed check as "reproducible by collapsing
    all five" (an action), which reads as confirming the mechanism works rather than mandating
    collapsed-by-default. One-line change if the project owner wants Detail sections to start
    collapsed instead.
  - The drag grip (MUI's DragIndicatorIcon, a real six-dot glyph) is purely a visual affordance
    for now — no drag-and-drop library is wired up here. TASKLIST.md scopes actual reordering
    to whichever task assembles the full Detail page (T21) across multiple SectionShell
    instances; T15's own done-when only requires the grip and toggle be separate, non-
    interfering elements, which this satisfies.
  - Body content stays mounted and is hidden via `display: none` (not unmounted) while
    collapsed, same choice already made in FacetSidebar's option list — so a section's own
    internal state (e.g. Solvers' pasted instance) doesn't get wiped by collapsing it.

  Closes #20