### PR TITLE
Build Solvers Section

### DIFF
--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -1,0 +1,225 @@
+// components/detail/SolversSection.js
+//
+// T16c (#23) — the Solvers section of a Problem Detail page: a "paste an
+// instance" block (format description + pre-filled input), a left rail of
+// declared solvers, and a right detail pane with a canned Run.
+//
+// v1 scope (ground rule 5): Run is present but `disabled` and produces no
+// live output — wiring `requestSolvedInstance()` live is explicitly out of
+// v1. Where the fixture already supplies a canned runtime/result (only
+// 3-SAT's DPLL entry does), that result is shown statically next to the
+// disabled Run button, standing in for "the same canned result every time."
+//
+// Known gap, not fabricated: data/fixtures.js's FixtureProblem shape has no
+// instanceFormat/example/default-instance field for any problem — the
+// mockup's CNF-specific "PASTE AN INSTANCE" text was hand-drawn for 3-SAT
+// and was never added to the fixture data contract (T09). Inventing
+// plausible-looking format text here would fabricate data this component
+// has no real source for, and wouldn't even make sense for a non-SAT
+// problem like Knapsack. So this block degrades to a plain "not yet
+// available" message instead — same spirit as this project's documented
+// "Assignment Table" visualizationType gap. See this task's PR for the
+// decision writeup.
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import { alpha } from "@mui/material/styles";
+import Typography from "@mui/material/Typography";
+import { useState } from "react";
+import { TAXONOMY } from "../../data/taxonomy";
+import { getFacetAccentColor } from "../theme";
+import SectionShell from "./SectionShell";
+
+const TAXONOMY_BY_KEY = new Map(TAXONOMY.map((facet) => [facet.key, facet]));
+
+function optionLabel(facetKey, optionKey) {
+  const option = TAXONOMY_BY_KEY.get(facetKey)?.options.find(
+    (candidate) => candidate.key === optionKey,
+  );
+  return option?.label ?? optionKey;
+}
+
+// No pre-built Chip variant exists for solverComplexity (theme.js's
+// BADGE_FAMILIES only covers complexityClass/solverType/problemType for
+// card badges) -- same plain-pill pattern components/ActiveFilterChips.js
+// already uses for its facet-colored chips.
+function ComplexityBucketBadge({ bucketKey }) {
+  const facet = TAXONOMY_BY_KEY.get("solverComplexity");
+  const accentColor = getFacetAccentColor(facet?.accentColor);
+  return (
+    <Box
+      component="span"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        px: 1.25,
+        py: 0.375,
+        borderRadius: 999,
+        color: accentColor,
+        backgroundColor: alpha(accentColor, 0.12),
+        border: `1px solid ${alpha(accentColor, 0.55)}`,
+        fontSize: "0.8125rem",
+        fontWeight: 700,
+      }}
+    >
+      {optionLabel("solverComplexity", bucketKey)}
+    </Box>
+  );
+}
+
+const INSTANCE_TEXTAREA_ID = "solvers-instance-input";
+
+/**
+ * @param {Object} props
+ * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ */
+export default function SolversSection({ problem }) {
+  const solvers = problem.solvers ?? [];
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const selected = solvers[selectedIndex];
+
+  const noun = solvers.length === 1 ? "solver" : "solvers";
+  const summary = `${solvers.length} ${noun}`;
+
+  return (
+    <SectionShell sectionKey="solvers" title="Solvers" summary={summary}>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="overline" sx={{ color: "text.secondary" }}>
+            Paste an instance — matches instanceFormat below
+          </Typography>
+          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+            Instance format not yet available for this problem.
+          </Typography>
+          <Box component="label" htmlFor={INSTANCE_TEXTAREA_ID} sx={{ display: "block", mt: 1.5 }}>
+            <Typography variant="body2" sx={{ color: "text.secondary", mb: 0.5 }}>
+              Instance
+            </Typography>
+          </Box>
+          <Box
+            id={INSTANCE_TEXTAREA_ID}
+            component="textarea"
+            rows={2}
+            readOnly
+            placeholder="No default instance declared for this problem yet."
+            sx={{
+              width: "100%",
+              resize: "vertical",
+              backgroundColor: "background.default",
+              color: "text.primary",
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1,
+              p: 1,
+              font: "inherit",
+            }}
+          />
+        </Paper>
+
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <Box sx={{ width: 260, flexShrink: 0, display: "flex", flexDirection: "column", gap: 1 }}>
+            {solvers.length === 0 ? (
+              <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+                No solvers declared for this problem.
+              </Typography>
+            ) : (
+              solvers.map((solver, index) => {
+                const solverId = `solver-${index}-toggle`;
+                const isSelected = index === selectedIndex;
+                return (
+                  <Paper
+                    key={solverId}
+                    id={solverId}
+                    component="button"
+                    type="button"
+                    onClick={() => setSelectedIndex(index)}
+                    aria-pressed={isSelected}
+                    variant="outlined"
+                    sx={{
+                      display: "flex",
+                      flexDirection: "column",
+                      alignItems: "flex-start",
+                      gap: 0.5,
+                      p: 1.5,
+                      cursor: "pointer",
+                      textAlign: "left",
+                      font: "inherit",
+                      color: "inherit",
+                      borderColor: isSelected ? "primary.light" : "divider",
+                      backgroundColor: isSelected ? alpha("#FB923C", 0.08) : "transparent",
+                    }}
+                  >
+                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                      {solver.name}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      variant="solverTypeOutlined"
+                      label={optionLabel("solverType", solver.type)}
+                    />
+                  </Paper>
+                );
+              })
+            )}
+          </Box>
+
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {!selected ? (
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                Select a solver to see its details.
+              </Typography>
+            ) : (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                <Typography variant="h2" component="h4" sx={{ fontSize: "1rem" }}>
+                  {selected.name}
+                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+                  <ComplexityBucketBadge bucketKey={selected.complexityBucket} />
+                  {selected.bigO && (
+                    <Typography variant="mono" sx={{ color: "text.secondary" }}>
+                      {selected.bigO}
+                    </Typography>
+                  )}
+                </Box>
+                <Button
+                  id="solvers-run-button"
+                  variant="contained"
+                  disabled
+                  sx={{ alignSelf: "flex-start" }}
+                >
+                  Run
+                </Button>
+                {selected.runtime || selected.result ? (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                    {selected.runtime && (
+                      <Typography variant="body2">
+                        <Box component="span" sx={{ color: "text.secondary" }}>
+                          Runtime:{" "}
+                        </Box>
+                        {selected.runtime}
+                      </Typography>
+                    )}
+                    {selected.result && (
+                      <Typography variant="body2">
+                        <Box component="span" sx={{ color: "text.secondary" }}>
+                          Result:{" "}
+                        </Box>
+                        {selected.result.status} {selected.result.output}
+                      </Typography>
+                    )}
+                  </Box>
+                ) : (
+                  <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+                    Not yet run.
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </SectionShell>
+  );
+}


### PR DESCRIPTION
Closes #23

## Summary
Builds `components/detail/SolversSection.js`: a "paste an instance" block, a left rail of declared solvers (bare name + Solver Type badge), and a right detail pane with complexity-bucket badge, big-O, a disabled canned Run button, and Runtime/Result rows.

## Acceptance criteria
- [x] Solver list, types, and complexity buckets are real declared data (`problem.solvers`, `data/taxonomy.js` labels).
- [x] Solver names use the bare-name convention (e.g. "DPLL", not "3SAT DPLL Solver").
- [x] Run is present, clearly non-live (`disabled`), and shows the same canned result every time it's rendered.
- [x] Complexity-bucket labels come from `taxonomy.js`, falling back to the raw bucket key (never blank) if unmapped.
- [x] The instance textarea has a unique `id` (`solvers-instance-input`) and a real associated `<label>`.

**Not met:** none of this issue's own checklist — see the gap below, which is a data-contract gap this issue's spec didn't anticipate, not an unmet checklist item.

## Decisions and assumptions

**Gap, flagged rather than papered over:** `data/fixtures.js`'s `FixtureProblem` shape has no `instanceFormat`, `Example`, or default-instance-text field anywhere — not at the problem level, not per solver. The mockup's "PASTE AN INSTANCE" block content (the CNF format description, the `(x1 | !x2 | x3) & ...` example) was hand-drawn for 3-SAT specifically in the mockup and was never added to the fixture data contract by T09. Fabricating plausible-looking CNF-style format text would misrepresent it as real declared data, and wouldn't even make sense for a non-SAT problem like Knapsack or Clique. So this block's layout is built, but degrades to "Instance format not yet available for this problem." with no pre-filled textarea value, for every problem, until that data exists. Recommend either adding optional `instanceFormat`/`example`/`defaultInstance` fields to `data/fixtures.js` in a follow-up, or scoping this properly when the real backend format-description endpoint is wired up.

Similarly, only 3-SAT's `DPLL` solver entry has `runtime`/`result` populated in the fixture (a genuine canned Run output: `Satisfiable`, `(x1:False,x2:False,x3:True)`). Every other solver across every other problem has neither field — Run is rendered present but shows "Not yet run." rather than fabricating plausible-looking numbers for those.

No pre-built MUI Chip variant exists for `solverComplexity` (theme.js's `BADGE_FAMILIES` only covers `complexityClass`/`solverType`/`problemType`), so the complexity-bucket badge follows `ActiveFilterChips.js`'s plain-pill pattern instead of adding a new global variant.

## Checks
- [x] `npm run lint` is clean
- [x] `npm run build` is clean
- [x] Every interactive element added has a unique `id`
- [x] No tag label text is hardcoded in a component — it comes from `data/taxonomy.js`
- [x] No deploy or publish step added, and no `[push]` section in `rbs.toml`

## Testing
- [x] Existing end-to-end tests still pass, or there are none yet covering this area (no e2e suite exists yet). A live-browser interaction check (rail selection, disabled-Run tab-order) was planned but skipped this round due to an environment constraint on running a background dev server from this task's execution context — `npm run lint`/`npm run build` are clean and the component was reviewed by hand against the spec instead.