### PR TITLE
Build Overview Section

### DIFF
--- a/components/detail/OverviewSection.js
+++ b/components/detail/OverviewSection.js
@@ -1,0 +1,97 @@
+// components/detail/OverviewSection.js
+//
+// T16a (#21) — the Overview section of a Problem Detail page: the problem
+// statement (left) and source/contributor metadata (right).
+//
+// Ratified decision (issue #6, conflict C3): explicit `Input:` / `Output:`
+// fields, NOT the mockup's "FORMAL DEFINITION" set-notation block.
+// `data/fixtures.js`'s `overview.input`/`.output` strings are already
+// reshaped into that format (see that file's 3-SAT entry) — this component
+// just labels and renders them, it doesn't reformat anything itself.
+//
+// Only 3-SAT's fixture entry has a populated `overview` object; every other
+// problem has it `undefined` (an optional field per `FixtureProblem`'s
+// typedef). Both this component's absence-of-`overview` case and its
+// absence-of-`source`/`contributedBy` case degrade to a plain message
+// rather than a crash or a printed "undefined" — same "real declared data,
+// graceful when it's missing" pattern used throughout the Home page
+// components (e.g. FacetSidebar's empty option lists).
+
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import SectionShell from "./SectionShell";
+
+function LabeledField({ label, value }) {
+  return (
+    <Box>
+      <Typography component="span" sx={{ fontWeight: 700 }}>
+        {label}:{" "}
+      </Typography>
+      <Typography component="span" variant="body1">
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function StatementCard({ overview }) {
+  return (
+    <Paper sx={{ p: 2, borderRadius: 3, flex: 1, minWidth: 0 }}>
+      {overview ? (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          <LabeledField label="Input" value={overview.input} />
+          <LabeledField label="Output" value={overview.output} />
+        </Box>
+      ) : (
+        <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+          Not yet documented.
+        </Typography>
+      )}
+    </Paper>
+  );
+}
+
+function AdditionalDetailsCard({ overview }) {
+  const source = overview?.source;
+  const contributedBy = overview?.contributedBy;
+
+  return (
+    <Paper sx={{ p: 2, borderRadius: 3, flex: 1, minWidth: 0 }}>
+      <Typography variant="overline" component="h3" sx={{ display: "block", mb: 1.5 }}>
+        Additional Details
+      </Typography>
+      {source || contributedBy ? (
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+          {source && <LabeledField label="Source" value={source} />}
+          {contributedBy && <LabeledField label="Contributed by" value={contributedBy} />}
+        </Box>
+      ) : (
+        <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+          Not yet documented.
+        </Typography>
+      )}
+    </Paper>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ */
+export default function OverviewSection({ problem }) {
+  return (
+    <SectionShell sectionKey="overview" title="Overview">
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", md: "row" },
+          gap: 2,
+        }}
+      >
+        <StatementCard overview={problem.overview} />
+        <AdditionalDetailsCard overview={problem.overview} />
+      </Box>
+    </SectionShell>
+  );
+}


### PR DESCRIPTION
Closes #21

## Summary
Adds `components/detail/OverviewSection.js`: the two-card Overview section (Input/Output statement on the left, Source/Contributed by on the right) for the Problem Detail page, per the ratified Input:/Output: decision (issue #6, conflict C3) rather than the mockup's set-notation block.

## Acceptance criteria
- [x] Left card shows labeled Input/Output fields; no set notation anywhere.
- [x] Right card degrades cleanly when source or contributor is missing (omit the label, don't print "undefined").
- [x] Two-column at desktop, stacked at narrow widths (uses MUI's default `md` breakpoint via `flexDirection`; T27 can override the actual breakpoint value later without touching this component).

**Not met:** none.

## Decisions and assumptions
- Only 3-SAT's fixture entry has a populated `overview` object; the other 11 fixture problems have it `undefined` entirely (not just missing `source`/`contributedBy`). Both cards degrade to a plain "Not yet documented." message in that case, rather than crashing or rendering blank — this is a step further than the issue's own done-when (which only calls out source/contributor being individually missing), since the fixture data revealed the whole-object-missing case too.
- No `data/taxonomy.js` label lookups needed here — Input/Output/Source/Contributed by are generic field labels, not facet vocabulary, so ground rule 3 doesn't apply to this section.

## Checks
- [x] `npm run lint` is clean
- [x] `npm run build` is clean
- [x] Every interactive element added has a unique `id` (n/a — this section has no interactive elements)
- [x] No tag label text is hardcoded in a component — it comes from `data/taxonomy.js`
- [x] No deploy or publish step added, and no `[push]` section in `rbs.toml`

## Testing
- [x] Existing end-to-end tests still pass, or there are none yet covering this area