### PR TITLE
Build Verifier Section

### DIFF
--- a/components/detail/VerifierSection.js
+++ b/components/detail/VerifierSection.js
@@ -1,0 +1,189 @@
+// components/detail/VerifierSection.js
+//
+// T16d (#24) — the Verifier section of a Problem Detail page: the
+// certificate format a solution takes, plus a "check a certificate" demo.
+//
+// v1 scope (ground rule 5): certificate format is real declared data, but
+// Verify is inert — no live verification. The Verify button is `disabled`
+// (out of tab order automatically) rather than wired to a fake handler, so
+// it never looks functional when it isn't. The result banner below it is
+// simply the fixture's own canned outcome for its pre-filled example, shown
+// unconditionally rather than gated behind a click that wouldn't do
+// anything real anyway.
+//
+// Per the ratified naming convention this section's title is always the
+// generic "Verifier" — never problem-prefixed — so it's hardcoded by this
+// component's caller-facing contract, not derived from `problem.name`.
+
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Paper from "@mui/material/Paper";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { useState } from "react";
+import SectionShell from "./SectionShell";
+
+const CERTIFICATE_INPUT_ID_PREFIX = "verifier-certificate-input";
+
+/**
+ * @param {Object} props
+ * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ *   `problem.verifier` is `{ certificateDescription, certificateFormat,
+ *   exampleCertificate?, resultBanner?: { valid, headline, detail },
+ *   properties?: string[] } | null` -- only 3-SAT's fixture has every
+ *   optional field populated; most problems have just the two required
+ *   fields, and Closest Pair of Points has `verifier: null` entirely and
+ *   deliberately (the fixture's own "incomplete problem" example).
+ */
+export default function VerifierSection({ problem }) {
+  const verifier = problem.verifier;
+  const [certificateValue, setCertificateValue] = useState(verifier?.exampleCertificate ?? "");
+  const inputId = `${CERTIFICATE_INPUT_ID_PREFIX}-${problem.slug}`;
+
+  if (!verifier) {
+    return (
+      <SectionShell sectionKey="verifier" title="Verifier">
+        <Typography variant="body1" sx={{ color: "text.secondary" }}>
+          No verifier declared for this problem.
+        </Typography>
+      </SectionShell>
+    );
+  }
+
+  return (
+    <SectionShell sectionKey="verifier" title="Verifier">
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="overline" sx={{ color: "text.secondary" }}>
+            Certificate Format
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            {verifier.certificateDescription}
+          </Typography>
+          <Box
+            component="pre"
+            sx={{
+              mt: 1.5,
+              mb: 0,
+              p: 1.5,
+              borderRadius: 1,
+              backgroundColor: "background.default",
+              overflowX: "auto",
+            }}
+          >
+            <Typography variant="mono" component="code" sx={{ whiteSpace: "pre-wrap" }}>
+              {verifier.certificateFormat}
+            </Typography>
+          </Box>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: 2 }}>
+          <Typography variant="overline" sx={{ color: "text.secondary" }}>
+            Check a Certificate — matches the format above
+          </Typography>
+
+          <Box sx={{ mt: 1.5, display: "flex", gap: 1.5, alignItems: "flex-start" }}>
+            <Box component="label" htmlFor={inputId} sx={visuallyHiddenSx}>
+              Certificate to check
+            </Box>
+            <TextField
+              id={inputId}
+              fullWidth
+              size="small"
+              value={certificateValue}
+              onChange={(event) => setCertificateValue(event.target.value)}
+              slotProps={{ htmlInput: { sx: { fontFamily: monoFontFamily } } }}
+            />
+            <Box
+              id={`verifier-verify-button-${problem.slug}`}
+              component="button"
+              type="button"
+              disabled
+              sx={disabledActionButtonSx}
+            >
+              Verify
+            </Box>
+          </Box>
+
+          {verifier.exampleCertificate && (
+            <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
+              Pre-filled with the default solver&apos;s result above — replace it to check your own
+              certificate.
+            </Typography>
+          )}
+
+          {verifier.resultBanner && (
+            <Box
+              sx={{
+                mt: 2,
+                display: "flex",
+                alignItems: "flex-start",
+                gap: 1,
+                p: 1.5,
+                borderRadius: 1,
+                color: verifier.resultBanner.valid ? "success.light" : "error.light",
+                backgroundColor: verifier.resultBanner.valid
+                  ? "rgba(74, 222, 128, 0.12)"
+                  : "rgba(248, 113, 113, 0.12)",
+                border: "1px solid",
+                borderColor: verifier.resultBanner.valid
+                  ? "rgba(74, 222, 128, 0.4)"
+                  : "rgba(248, 113, 113, 0.4)",
+              }}
+            >
+              {verifier.resultBanner.valid ? (
+                <CheckCircleIcon fontSize="small" sx={{ mt: "2px" }} />
+              ) : (
+                <CancelIcon fontSize="small" sx={{ mt: "2px" }} />
+              )}
+              <Typography variant="body2" sx={{ color: "inherit" }}>
+                <strong>{verifier.resultBanner.headline}</strong> — {verifier.resultBanner.detail}
+              </Typography>
+            </Box>
+          )}
+
+          {verifier.properties && verifier.properties.length > 0 && (
+            <Box sx={{ mt: 2, display: "flex", flexWrap: "wrap", gap: 1 }}>
+              {verifier.properties.map((property) => (
+                <Chip key={property} size="small" variant="outlined" label={property} />
+              ))}
+            </Box>
+          )}
+        </Paper>
+      </Box>
+    </SectionShell>
+  );
+}
+
+const monoFontFamily = '"JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace';
+
+const disabledActionButtonSx = {
+  flexShrink: 0,
+  border: "1px solid",
+  borderColor: "divider",
+  borderRadius: 999,
+  px: 2,
+  py: 1,
+  color: "text.disabled",
+  backgroundColor: "transparent",
+  font: "inherit",
+  fontWeight: 600,
+  cursor: "not-allowed",
+};
+
+// Standard visually-hidden clip pattern (same as components/SearchBar.js) --
+// the label needs to exist for screen readers without displacing the
+// visible input.
+const visuallyHiddenSx = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+};


### PR DESCRIPTION
Closes #24

## Summary
Adds `components/detail/VerifierSection.js`: a CERTIFICATE FORMAT card (real declared data) plus a CHECK A CERTIFICATE demo block with an inert `Verify` button and a canned result banner.

## Acceptance criteria
- [x] Certificate format text is real declared data (`problem.verifier.certificateDescription`/`certificateFormat`, never fabricated).
- [x] Verify is present, clearly non-live (`disabled`, out of tab order), canned output (the fixture's own `resultBanner`, shown unconditionally rather than gated behind a click that wouldn't do anything).
- [x] Section heading is generic ("Verifier", hardcoded — never interpolates `problem.name`).
- [x] The result banner has a non-color-only success/failure indication: a `CheckCircleIcon`/`CancelIcon` plus headline/detail text, not just a green/red background.

**Not met:** none.

## Decisions and assumptions
- Only 3-SAT's fixture has the full `verifier` shape (`exampleCertificate`, `resultBanner`, `properties` all populated). Every other problem with a verifier has just `{ certificateDescription, certificateFormat }` — the component omits the pre-filled input helper line, result banner, and property chips entirely when those fields are absent, rather than fabricating a fake "Verify" outcome.
- Closest Pair of Points has `verifier: null` entirely and deliberately (the fixture's own "incomplete problem" example) — renders a plain "No verifier declared for this problem." placeholder instead of crashing.
- The certificate-check `TextField` stays editable (not `disabled`) even though `Verify` itself is inert — ground rule 5's "no live Verify" reads as the verification action being canned, not that typing in the box should be blocked; the helper text's own "replace it to check your own certificate" implies an editable field.
- `verifier.properties` is freeform declared text (not `data/taxonomy.js` facet vocabulary), so it's rendered directly as plain outlined chips rather than going through a taxonomy label lookup — ground rule 3 doesn't apply to this field.

## Checks
- [x] `npm run lint` is clean
- [x] `npm run build` is clean
- [x] Every interactive element added has a unique `id` (certificate input and Verify button both derive theirs from `problem.slug`)
- [x] No tag label text is hardcoded in a component — it comes from `data/taxonomy.js` (n/a here: this section has no taxonomy-facet badges, only freeform declared `properties` text)
- [x] No deploy or publish step added, and no `[push]` section in `rbs.toml`

## Testing
- [x] Existing end-to-end tests still pass, or there are none yet covering this area