### PR TITLE
Added Drag Reorder Mechanic

### DIFF
--- a/components/ProblemDetailLayout.js
+++ b/components/ProblemDetailLayout.js
@@ -1,0 +1,252 @@
+// components/ProblemDetailLayout.js
+//
+// T18 (#27) — holds the five Problem Detail sections (Overview,
+// Visualizations, Solvers, Verifier, Reductions), lets them be dragged into
+// a different order by their SectionShell grip, and tracks which are
+// collapsed. Pattern ported from Redux_GUI's pages/index.js (SortableRow,
+// handleDragEnd, the @dnd-kit sensors/DndContext/SortableContext wiring) —
+// same @dnd-kit packages, this is a fresh implementation against this
+// repo's own component shape, not a copy of that file (issue body: "write
+// our own version of the pattern rather than copying the file wholesale").
+//
+// --- Decision: does "Reset to default" also reset collapse state? --------
+// NO — it restores order only. Collapse state is left untouched.
+//
+// Recorded as a decision comment on issue #27 per CLAUDE.md's "Recording
+// decisions" section. Reasoning, in short: both the issue body and
+// TASKLIST.md's T18 entry describe order and collapse state as two
+// independent axes ("Each section collapses independently, and collapse
+// state is separate from order"), and the "Done when" list only ever asks
+// Reset to restore "the canonical order" — never mentions collapse. Keeping
+// them independent also means SectionShell doesn't need to become a
+// controlled component for this task (it stays exactly as T15 left it,
+// beyond the new dragHandleProps passthrough), which is the smaller, more
+// obviously-correct change. Rejected alternative: making Reset also
+// re-collapse/re-expand every section, which would require lifting
+// SectionShell's `expanded` state up into this component (an
+// expanded/onToggle prop pair, falling back to the existing internal
+// useState when absent) — defensible, but a larger change for a behavior
+// neither doc actually asks for.
+//
+// --- Grip scoping (issue done-when: "dragging elsewhere on the header does
+// not [reorder]") ---------------------------------------------------------
+// SortableSection below calls useSortable({id}) and clones its child with
+// `dragHandleProps: { attributes, listeners }` rather than attaching those
+// to the whole row — exactly Redux_GUI's SortableRow pattern. Each section
+// component forwards that prop straight through to its own SectionShell
+// call, which spreads it only onto the grip Box (see that file's T18
+// comment). So the drag activator is scoped to the grip alone; nothing else
+// in the header — including the chevron/title button — carries a listener.
+//
+// --- Keyboard support ------------------------------------------------------
+// Sensors are PointerSensor + TouchSensor (ported from Redux_GUI) plus a
+// KeyboardSensor with `sortableKeyboardCoordinates` — an explicit,
+// non-optional v1 accessibility requirement per the issue body, and not
+// something Redux_GUI's own version has. Space picks a section up, arrow
+// keys move it, Space drops it, Escape cancels — standard @dnd-kit
+// sortable-preset keyboard behavior once the sensor is registered.
+//
+// --- Screen-reader announcements -------------------------------------------
+// DndContext's default announcements say generic things like "Draggable
+// item overview was moved...". SECTION_ANNOUNCEMENTS below overrides them
+// with text naming the real section title instead.
+//
+// --- No persistence ---------------------------------------------------------
+// `order` is plain component-local useState. No localStorage, no URL
+// params — per the issue body and TASKLIST.md's T18 entry ("do not add
+// persistence ... unless the project owner asks").
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { cloneElement, useState } from "react";
+import OverviewSection from "./detail/OverviewSection";
+import ReductionsSection from "./detail/ReductionsSection";
+import SolversSection from "./detail/SolversSection";
+import VerifierSection from "./detail/VerifierSection";
+import VisualizationsSection from "./detail/VisualizationsSection";
+
+// Default order per the ratified "move Reduce pane below Verify" decision
+// (TASKLIST.md T18 entry) — Reductions goes last deliberately, not by
+// omission.
+const SECTIONS = [
+  { key: "overview", title: "Overview", Component: OverviewSection },
+  { key: "visualizations", title: "Visualizations", Component: VisualizationsSection },
+  { key: "solvers", title: "Solvers", Component: SolversSection },
+  { key: "verifier", title: "Verifier", Component: VerifierSection },
+  { key: "reductions", title: "Reductions", Component: ReductionsSection },
+];
+
+const SECTIONS_BY_KEY = new Map(SECTIONS.map((section) => [section.key, section]));
+const DEFAULT_ORDER = SECTIONS.map((section) => section.key);
+
+function sectionTitle(key) {
+  return SECTIONS_BY_KEY.get(key)?.title ?? key;
+}
+
+// Overridden @dnd-kit live-region announcements (issue done-when: name the
+// real section, not the library's generic "sortable item" defaults). Pure
+// function of section keys, so this can live at module scope rather than
+// being rebuilt every render.
+const SECTION_ANNOUNCEMENTS = {
+  onDragStart({ active }) {
+    return `Picked up the ${sectionTitle(active.id)} section. Use the arrow keys to move it, space bar to drop, escape to cancel.`;
+  },
+  onDragOver({ active, over }) {
+    if (over && active.id !== over.id) {
+      return `The ${sectionTitle(active.id)} section was moved next to the ${sectionTitle(over.id)} section.`;
+    }
+    return `The ${sectionTitle(active.id)} section is back in its original position.`;
+  },
+  onDragEnd({ active, over }) {
+    if (over) {
+      return `The ${sectionTitle(active.id)} section was dropped next to the ${sectionTitle(over.id)} section.`;
+    }
+    return `The ${sectionTitle(active.id)} section was dropped.`;
+  },
+  onDragCancel({ active }) {
+    return `Reordering the ${sectionTitle(active.id)} section was cancelled.`;
+  },
+};
+
+// Ported from Redux_GUI's pages/index.js `SortableRow` — clones its single
+// child with `dragHandleProps` rather than spreading drag attributes/
+// listeners on the row itself, so the child (a section component) can hand
+// them to just its grip.
+function SortableSection({ id, children }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    position: "relative",
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  const childWithDragHandle = cloneElement(children, {
+    dragHandleProps: { attributes, listeners },
+  });
+
+  return (
+    <Box ref={setNodeRef} style={style}>
+      {childWithDragHandle}
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem,
+ *   passed straight through to every section.
+ */
+export default function ProblemDetailLayout({ problem }) {
+  const [order, setOrder] = useState(DEFAULT_ORDER);
+
+  // PointerSensor covers mouse; TouchSensor adds mobile/tablet support
+  // (both ported from Redux_GUI). KeyboardSensor is new here — see file
+  // header.
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(event) {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setOrder((items) => {
+        const oldIndex = items.indexOf(active.id);
+        const newIndex = items.indexOf(over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  }
+
+  function handleReset() {
+    setOrder(DEFAULT_ORDER);
+  }
+
+  const currentLayoutText = order.map(sectionTitle).join(", ");
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+          columnGap: 1.5,
+          rowGap: 0.5,
+        }}
+      >
+        <DragIndicatorIcon aria-hidden="true" fontSize="small" sx={{ color: "text.secondary" }} />
+        <Typography
+          variant="body2"
+          component="span"
+          sx={{ color: "text.secondary", flex: 1, minWidth: 0 }}
+        >
+          Drag any section by its grip to reorder. Click a chevron to expand. Current layout:{" "}
+          {currentLayoutText}.
+        </Typography>
+        <Box
+          id="detail-layout-reset"
+          component="button"
+          type="button"
+          onClick={handleReset}
+          sx={{
+            border: "none",
+            background: "none",
+            p: 0,
+            color: "primary.main",
+            font: "inherit",
+            fontWeight: 600,
+            cursor: "pointer",
+            textDecoration: "underline",
+            flexShrink: 0,
+          }}
+        >
+          Reset to default
+        </Box>
+      </Box>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        accessibility={{ announcements: SECTION_ANNOUNCEMENTS }}
+      >
+        <SortableContext items={order} strategy={verticalListSortingStrategy}>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {order.map((key) => {
+              const { Component } = SECTIONS_BY_KEY.get(key);
+              return (
+                <SortableSection key={key} id={key}>
+                  <Component problem={problem} />
+                </SortableSection>
+              );
+            })}
+          </Box>
+        </SortableContext>
+      </DndContext>
+    </Box>
+  );
+}

--- a/components/detail/OverviewSection.js
+++ b/components/detail/OverviewSection.js
@@ -78,10 +78,12 @@ function AdditionalDetailsCard({ overview }) {
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
+ *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function OverviewSection({ problem }) {
+export default function OverviewSection({ problem, dragHandleProps }) {
   return (
-    <SectionShell sectionKey="overview" title="Overview">
+    <SectionShell sectionKey="overview" title="Overview" dragHandleProps={dragHandleProps}>
       <Box
         sx={{
           display: "flex",

--- a/components/detail/ReductionsSection.js
+++ b/components/detail/ReductionsSection.js
@@ -103,8 +103,10 @@ function CanvasCard({ title }) {
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
+ *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function ReductionsSection({ problem }) {
+export default function ReductionsSection({ problem, dragHandleProps }) {
   const { to, from } = problem.reductions;
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [fromExpanded, setFromExpanded] = useState(true);
@@ -121,7 +123,12 @@ export default function ReductionsSection({ problem }) {
   const fromBodyId = "reductions-from-body";
 
   return (
-    <SectionShell sectionKey="reductions" title="Reductions" summary={summary}>
+    <SectionShell
+      sectionKey="reductions"
+      title="Reductions"
+      summary={summary}
+      dragHandleProps={dragHandleProps}
+    >
       {!hasAny && (
         <Typography variant="body2" sx={{ color: "text.secondary" }}>
           No reductions declared for this problem.

--- a/components/detail/SectionShell.js
+++ b/components/detail/SectionShell.js
@@ -17,10 +17,13 @@
 // The drag grip is a separate DOM element from the chevron button and
 // carries no click handler of its own (issue body: "the single most common
 // bug in this kind of component" is a grip that also toggles collapse).
-// It's a static affordance for now — actual drag-to-reorder is wired up by
-// whichever task assembles the Detail page (T21) across multiple
-// SectionShell instances; this component only has to guarantee the grip
-// and the toggle never share a click target.
+// Wired up as a real @dnd-kit drag activator by T18 (#27,
+// components/ProblemDetailLayout.js): that component passes an optional
+// `dragHandleProps` (`{ attributes, listeners }`, straight from
+// `useSortable()`), spread onto this same grip Box rather than adding a
+// second grip element. With no `dragHandleProps` (e.g. any standalone
+// rendering of a section outside the drag context) the grip stays the
+// static, `aria-hidden` affordance it always was.
 //
 // Accessibility: unlike FacetSidebar's facet groups (a sidebar nav list,
 // nothing on that page needs them in the heading outline), a Problem Detail
@@ -56,8 +59,11 @@ import { useState } from "react";
  *   ("3 visualizations"). Omitted entirely for Overview and Verifier.
  * @param {React.ReactNode} props.children The section body, shown when
  *   expanded.
+ * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
+ *   From T18's `useSortable()`, spread onto the grip so it becomes the real
+ *   drag activator. Omitted, the grip stays decorative (`aria-hidden`).
  */
-export default function SectionShell({ sectionKey, title, summary, children }) {
+export default function SectionShell({ sectionKey, title, summary, children, dragHandleProps }) {
   const [expanded, setExpanded] = useState(true);
   const toggleId = `section-${sectionKey}-toggle`;
   const bodyId = `section-${sectionKey}-body`;
@@ -68,7 +74,13 @@ export default function SectionShell({ sectionKey, title, summary, children }) {
       <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, px: 2, py: 1.75 }}>
         <Box
           id={gripId}
-          aria-hidden="true"
+          {...(dragHandleProps
+            ? {
+                ...dragHandleProps.attributes,
+                ...dragHandleProps.listeners,
+                "aria-label": `Drag to reorder the ${title} section`,
+              }
+            : { "aria-hidden": "true" })}
           sx={{
             display: "flex",
             alignItems: "center",

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -74,8 +74,10 @@ const INSTANCE_TEXTAREA_ID = "solvers-instance-input";
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
+ *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function SolversSection({ problem }) {
+export default function SolversSection({ problem, dragHandleProps }) {
   const solvers = problem.solvers ?? [];
   const [selectedIndex, setSelectedIndex] = useState(0);
   const selected = solvers[selectedIndex];
@@ -84,7 +86,12 @@ export default function SolversSection({ problem }) {
   const summary = `${solvers.length} ${noun}`;
 
   return (
-    <SectionShell sectionKey="solvers" title="Solvers" summary={summary}>
+    <SectionShell
+      sectionKey="solvers"
+      title="Solvers"
+      summary={summary}
+      dragHandleProps={dragHandleProps}
+    >
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Typography variant="overline" sx={{ color: "text.secondary" }}>

--- a/components/detail/VerifierSection.js
+++ b/components/detail/VerifierSection.js
@@ -36,15 +36,17 @@ const CERTIFICATE_INPUT_ID_PREFIX = "verifier-certificate-input";
  *   optional field populated; most problems have just the two required
  *   fields, and Closest Pair of Points has `verifier: null` entirely and
  *   deliberately (the fixture's own "incomplete problem" example).
+ * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
+ *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function VerifierSection({ problem }) {
+export default function VerifierSection({ problem, dragHandleProps }) {
   const verifier = problem.verifier;
   const [certificateValue, setCertificateValue] = useState(verifier?.exampleCertificate ?? "");
   const inputId = `${CERTIFICATE_INPUT_ID_PREFIX}-${problem.slug}`;
 
   if (!verifier) {
     return (
-      <SectionShell sectionKey="verifier" title="Verifier">
+      <SectionShell sectionKey="verifier" title="Verifier" dragHandleProps={dragHandleProps}>
         <Typography variant="body1" sx={{ color: "text.secondary" }}>
           No verifier declared for this problem.
         </Typography>
@@ -53,7 +55,7 @@ export default function VerifierSection({ problem }) {
   }
 
   return (
-    <SectionShell sectionKey="verifier" title="Verifier">
+    <SectionShell sectionKey="verifier" title="Verifier" dragHandleProps={dragHandleProps}>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Typography variant="overline" sx={{ color: "text.secondary" }}>

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -66,8 +66,10 @@ function TypeBadge({ typeKey }) {
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
+ *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function VisualizationsSection({ problem }) {
+export default function VisualizationsSection({ problem, dragHandleProps }) {
   const visualizations = problem.visualizations ?? [];
   const [selectedIndex, setSelectedIndex] = useState(0);
   const selected = visualizations[selectedIndex];
@@ -78,6 +80,7 @@ export default function VisualizationsSection({ problem }) {
       sectionKey="visualizations"
       title="Visualizations"
       summary={`${visualizations.length} ${noun}`}
+      dragHandleProps={dragHandleProps}
     >
       {visualizations.length === 0 ? (
         <Typography variant="body2" sx={{ color: "text.secondary" }}>


### PR DESCRIPTION
Issue:  #27 (T18 — Build the drag-to-reorder detail layout)
Branch: task/T18-drag-reorder-detail-layout

Changed:
- components/ProblemDetailLayout.js (new) — the layout component itself
- components/detail/SectionShell.js — added optional dragHandleProps, spread onto the existing grip Box (real drag activator when provided, decorative aria-hidden grip otherwise)
- components/detail/OverviewSection.js, VisualizationsSection.js, SolversSection.js, VerifierSection.js, ReductionsSection.js — each accepts an optional dragHandleProps prop and forwards it straight through to its own SectionShell call (mechanical, no content/behavior changes)

Done when — all met:
- Dragging by the grip reorders; dragging elsewhere on the header does not (verified: title-click drag attempt leaves order unchanged, and still toggles collapse normally)
- "Current layout:" text updates live as order changes
- Reset to default restores the canonical order
- KeyboardSensor (with sortableKeyboardCoordinates) registered; full keyboard cycle — pick up (Space), move (Arrow keys), drop (Space), cancel (Escape) — verified working
- @dnd-kit announcements configured via DndContext's accessibility={{ announcements }}, naming real section titles (e.g. "The Solvers section was dropped next to the Visualizations section.") — verified in the live region, not the library's generic defaults
- Order state is plain component-local useState, no persistence added

Decision — recorded as a comment on issue #27: Reset to default restores order only; collapse state is left untouched, since both docs treat order and collapse as independent, and the Done-when list only ever mentions restoring order. Full reasoning and rejected alternative are in the issue comment.

Other assumptions: none beyond what's documented in code comments (grip scoping, announcement text choices).

Verification: npm run lint, npm run format:check, npm run build all clean. Drove a throwaway pages/__detail-layout-preview.js (3-SAT fixture) with Playwright to prove every interactive/accessibility done-when item — note Playwright's page.mouse.* doesn't synthesize real PointerEvents in this headless Chromium setup, so pointer-drag was proven via native PointerEvent dispatch instead (confirmed dnd-kit's PointerSensor activates correctly given a genuine event). Preview file and all scratch scripts deleted; dev server stopped; nothing extra in the diff.

Housekeeping done first (per CLAUDE.md workflow): synced main, and cleaned up 5 merged local branches (T16a–T16e) along with their orphaned worktrees in Redux_Frontend_worktrees/ (two of which had corrupted .git links and needed manual force-removal — all five confirmed merged via gh pr list --state merged before deleting).

Closes #27