### PR TITLE
Fixed Home Page Scrollbar

### DIFF
--- a/components/FacetSidebar.js
+++ b/components/FacetSidebar.js
@@ -32,16 +32,6 @@ import { useState } from "react";
 import { TAXONOMY } from "../data/taxonomy";
 import { getFacetAccentColor } from "./theme";
 
-// Long lists scroll inside the group instead of pushing the rest of the
-// panel down. The mockup shows this for Problem Type (13 values, capped at
-// ~8 visible rows) — applied generically here rather than special-cased to
-// that one facet, so it also naturally covers Complexity Class (10 values
-// after absorbing Quantum Complexity Class, #6 2026-09-01) and
-// Visualization Type (12), neither of which existed in this shape when the
-// mockup was drawn. ~34px/row is an approximation (MUI doesn't expose a
-// fixed FormControlLabel row height); short lists just never reach it.
-const OPTION_LIST_MAX_HEIGHT = 8 * 34;
-
 function FacetFilterGroup({ facet, options, selected, onChange }) {
   const [expanded, setExpanded] = useState(true);
   const toggleId = `facet-${facet.key}-toggle`;
@@ -146,8 +136,17 @@ function FacetFilterGroup({ facet, options, selected, onChange }) {
         id={listId}
         sx={{
           display: expanded ? "flex" : "none",
-          maxHeight: OPTION_LIST_MAX_HEIGHT,
-          overflowY: "auto",
+          // MUI's FormGroup defaults to `flexWrap: "wrap"` (Root style, see
+          // node_modules/@mui/material/FormGroup/FormGroup.js). Combined
+          // with `flexDirection: "column"` (also the default), a long list
+          // wrapped into a second flex *column* rather than growing
+          // downward — reported in #68 as options "starting on the next
+          // column after going out of view." Forced to `nowrap` so a group
+          // always grows straight down the page instead of sideways; per
+          // #68's revised direction there's no per-group height cap or
+          // internal scroll any more; the whole panel scrolls as one
+          // (see the sidebar's own overflowY in pages/index.js).
+          flexWrap: "nowrap",
           pl: 3,
         }}
       >

--- a/components/ProblemGrid.js
+++ b/components/ProblemGrid.js
@@ -38,6 +38,7 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import ProblemCatalogCard from "./ProblemCatalogCard";
+import { thinScrollbarSx } from "./theme";
 
 const DESKTOP_COLUMN_COUNT = 3;
 
@@ -76,6 +77,8 @@ export default function ProblemGrid({
         alignItems: "start",
         gap: 2,
         pb: 1,
+        pr: 1,
+        ...thinScrollbarSx,
       }}
     >
       {problems.map((problem) => (

--- a/components/theme.js
+++ b/components/theme.js
@@ -123,6 +123,30 @@ const PAGE_BACKGROUND = "#0A0908";
 const PANEL_BACKGROUND = "#17140F"; // one step lighter than the page, per the mockup's elevated surfaces
 const HAIRLINE_BORDER = "rgba(255, 237, 213, 0.09)"; // warm-tinted hairline, used for every panel/card edge
 
+// Shared scrollbar treatment for every internally-scrolling region on the
+// Home page (#68): the sidebar's own scroll, each facet group's capped
+// option list, and the card grid. Track is transparent (matches the page
+// background it sits over, per #68's explicit requirement) and the thumb is
+// a slim, low-contrast bar rather than the browser default. Firefox
+// properties (`scrollbarWidth`/`scrollbarColor`) and the WebKit
+// pseudo-elements are both set so Chrome/Edge/Safari and Firefox match.
+const SCROLLBAR_THUMB_COLOR = "rgba(245, 241, 234, 0.22)";
+export const thinScrollbarSx = {
+  scrollbarWidth: "thin",
+  scrollbarColor: `${SCROLLBAR_THUMB_COLOR} transparent`,
+  "&::-webkit-scrollbar": {
+    width: 6,
+    height: 6,
+  },
+  "&::-webkit-scrollbar-track": {
+    background: "transparent",
+  },
+  "&::-webkit-scrollbar-thumb": {
+    backgroundColor: SCROLLBAR_THUMB_COLOR,
+    borderRadius: 999,
+  },
+};
+
 const theme = createTheme({
   palette: {
     mode: "dark",

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,6 +34,7 @@ import ProblemGrid from "../components/ProblemGrid";
 import SearchBar from "../components/SearchBar";
 import { FIXTURE_PROBLEMS } from "../data/fixtures";
 import { TAXONOMY } from "../data/taxonomy";
+import { thinScrollbarSx } from "../components/theme";
 
 // The three facets ProblemCatalogCard actually renders badges for -- the
 // only keys its own `matchedTags` prop needs (components/ProblemCatalogCard.js
@@ -43,7 +44,10 @@ import { TAXONOMY } from "../data/taxonomy";
 // doesn't render anyway.
 const CARD_BADGE_FACETS = ["complexityClass", "solverType", "problemType"];
 
-const SIDEBAR_WIDTH = 280;
+// #68: 280 was too narrow -- the longest option labels ("Algebra and Number
+// Theory", "Logical/Functional Models") wrapped to a second line against
+// their checkbox + count. Widened so every option renders on one line.
+const SIDEBAR_WIDTH = 340;
 
 function buildEmptySelection() {
   const selection = {};
@@ -179,7 +183,19 @@ export default function Home() {
         />
 
         <Box sx={{ flex: 1, minHeight: 0, display: "flex", gap: 4 }}>
-          <Box sx={{ width: SIDEBAR_WIDTH, flexShrink: 0, overflowY: "auto" }}>
+          {/* #68: the one scrollbar for the whole filter panel -- expanded
+              facet groups render every option in full (FacetSidebar no
+              longer caps/scrolls internally), so this is the only way the
+              sidebar scrolls. */}
+          <Box
+            sx={{
+              width: SIDEBAR_WIDTH,
+              flexShrink: 0,
+              overflowY: "auto",
+              pr: 1,
+              ...thinScrollbarSx,
+            }}
+          >
             <FacetSidebar
               facetOptions={facetOptions}
               selected={selected}

--- a/pages/index.js
+++ b/pages/index.js
@@ -32,9 +32,9 @@ import FacetSidebar from "../components/FacetSidebar";
 import NavBar from "../components/NavBar";
 import ProblemGrid from "../components/ProblemGrid";
 import SearchBar from "../components/SearchBar";
+import { thinScrollbarSx } from "../components/theme";
 import { FIXTURE_PROBLEMS } from "../data/fixtures";
 import { TAXONOMY } from "../data/taxonomy";
-import { thinScrollbarSx } from "../components/theme";
 
 // The three facets ProblemCatalogCard actually renders badges for -- the
 // only keys its own `matchedTags` prop needs (components/ProblemCatalogCard.js


### PR DESCRIPTION
Issue: #68 (Fix Horizontal and Vertical Scrollbars On Home Page)
Branch: task/T68-fix-home-scrollbars

Changed:
components/FacetSidebar.js   (fixed the column-wrap bug, dropped per-group scroll cap)
components/ProblemGrid.js    (thin/transparent scrollbar)
components/theme.js          (new shared thinScrollbarSx)
pages/index.js               (wider sidebar, thin/transparent scrollbar)

Root cause: MUI's FormGroup defaults to flexWrap: "wrap". Combined with flexDirection: "column" and the old capped height, an overflowing facet's options started a new flex column instead of scrolling — exactly the "starting on the next column" bug described in the issue.

Done when — met:
- Facet options now grow straight down in one column, never wrap sideways.
- Sidebar widened 280→340px so the longest labels ("Algebra and Number Theory", "Logical/Functional Models") render on one line.
- All scrollbars (sidebar, and the grid, for consistency across the Home page) now use a shared thin, transparent-track style (thinScrollbarSx in theme.js).

Decisions and assumptions (discussed live with you mid-task, not silently decided):
- The issue's text originally called for two scrollbars — a small one per facet group plus one large sidebar scrollbar. You reconsidered and asked for a single scrollbar design instead: facet groups now expand to show every option in full, with only the sidebar's own outer scrollbar handling scrolling. Implemented that way — nested scrollbars are also just a bad pattern (mouse-wheel target ambiguity, easy to miss, awkward keyboard scrolling), so this is the better call anyway. This is a scope change from issue #68's literal "Done when" text, worth noting when it's closed.
- Also applied the same thin/transparent scrollbar treatment to ProblemGrid's scrollbar, since the issue title says "Home Page" broadly and the mockup shows a thin grid scrollbar too — not explicitly requested in the issue body, flagging as an assumption.

Closes #68