### PR TITLE
Fix Problem Card Spacing

### DIFF
--- a/components/ProblemGrid.js
+++ b/components/ProblemGrid.js
@@ -74,7 +74,10 @@ export default function ProblemGrid({
         display: "grid",
         gridTemplateColumns: `repeat(${DESKTOP_COLUMN_COUNT}, minmax(0, 1fr))`,
         alignItems: "start",
-        gap: 2,
+        // #69: row gap trimmed independently of column gap -- the issue is
+        // specifically about vertical space between cards, not horizontal.
+        rowGap: 1.25,
+        columnGap: 2,
         pb: 1,
       }}
     >

--- a/pages/index.js
+++ b/pages/index.js
@@ -170,13 +170,21 @@ export default function Home() {
           </Typography>
         </Box>
 
-        <SearchBar value={searchValue} onChange={setSearchValue} />
+        {/* #69: search bar and the "Filtering by" row share one tight
+            inner gap, separate from the outer section gap above/below this
+            block. ActiveFilterChips renders null when nothing is selected
+            (#19), so this Box collapses to just the search bar and no gap
+            is spent on it -- the only vertical space filtering adds is the
+            chips row's own height, not a second full section gap. */}
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.25 }}>
+          <SearchBar value={searchValue} onChange={setSearchValue} />
 
-        <ActiveFilterChips
-          selected={selected}
-          onRemove={handleRemoveChip}
-          onClearAll={handleClearAll}
-        />
+          <ActiveFilterChips
+            selected={selected}
+            onRemove={handleRemoveChip}
+            onClearAll={handleClearAll}
+          />
+        </Box>
 
         <Box sx={{ flex: 1, minHeight: 0, display: "flex", gap: 4 }}>
           <Box sx={{ width: SIDEBAR_WIDTH, flexShrink: 0, overflowY: "auto" }}>


### PR DESCRIPTION
Issue:  #69 (Fix Vertical Padding Spacing Between Cards)
Branch: task/T69-reduce-card-padding

Changed:
  components/ProblemGrid.js   (grid rowGap 16px → 10px, columnGap unchanged at 16px)
  pages/index.js               (SearchBar + ActiveFilterChips now share a tight
                                 gap:1.25 (10px) wrapper, separate from the outer
                                 section gap:3)

Done when — met:
  - Default vertical space between cards reduced (row gap only, left column
    gap alone since the issue is specifically about vertical spacing).
  - Selecting a filter no longer compounds two full outer-section gaps
    (24px + 24px) around the "Filtering by" chip row — it now only costs
    its own compact height plus one 10px inner gap. Measured with
    Playwright: growth in space above the grid on selecting a filter went
    from ~53px to ~39px.

Done when — not met / partial:
  - Could not reproduce any vertical-space growth from typing in the
    search bar alone in the current code — SearchBar's own height never
    changes, and it doesn't insert ActiveFilterChips (that only reacts to
    facet checkbox selections). So "search bar" growth isn't something I
    could find or fix in this codebase as it stands; it may be describing
    a different environment, or was observed together with a filter
    selection. Flagging rather than guessing further.
  - Did not touch card grid column gap, card internal padding (Paper p:2),
    or the outer page-level gap:3 between major sections (header block /
    search block / results row) — those weren't implicated by measurement
    and touching them risked changing things the issue didn't ask about.

Decisions and assumptions:
  - Root-caused via Playwright DOM measurement (getBoundingClientRect)
    rather than guessing from CSS alone: confirmed the grid's own rowGap
    and card heights are constant regardless of filter/search state (ruled
    out CSS Grid row-stretch as a cause), and that the real growth came
    from ActiveFilterChips inserting between two `gap: 3` flex siblings in
    pages/index.js, effectively spending 48px of section gap plus its own
    height just to show one chip row.
  - Chose rowGap: 1.25 (10px) and inner wrapper gap: 1.25 (10px) as
    moderate reductions — tight enough to visibly fit a 4th row in the
    default 900px-tall viewport screenshot without cards feeling cramped
    against each other.
  - Did not make ActiveFilterChips reserve a persistent empty slot to get
    literal zero-growth, since #19's own done-when explicitly requires it
    be "absent entirely -- not an empty container -- when nothing is
    selected." Reducing the outer double-gap was the fix available within
    that existing constraint.

  Closes #69