### PR TITLE
Adding Filter Indicators To Problem Cards

### DIFF
--- a/components/ProblemCatalogCard.js
+++ b/components/ProblemCatalogCard.js
@@ -26,6 +26,15 @@
 // deriveComplexityClasses() (data/taxonomy.js) already produced into that
 // array -- 2 or 3 badges on one row is expected, not special-cased (#6 item
 // 7, 2026-09-01 follow-up, supersedes the original quantum-slot rule).
+//
+// #70: BASE_BADGE_FACET_KEYS (complexityClass/solverType/problemType) always
+// render, same as before. Any OTHER taxonomy facet gets its own row added
+// on top, but only once `matchedTags` says a filter for it is active --
+// pages/index.js only ever shows problems matching every active facet
+// selection (matchesSelectedFacets), so a card that's on screen at all
+// already has a tag for that facet worth showing. Rows use the same
+// TagRow/Chip-variant treatment either way, so an added row looks exactly
+// like a default one whose filter is selected (issue body).
 
 import CheckIcon from "@mui/icons-material/Check";
 import Box from "@mui/material/Box";
@@ -38,17 +47,11 @@ import StatusIcon, { isProblemComplete } from "./StatusIcon";
 
 const EMPTY_SET = new Set();
 
-// Row order per the issue body. `chipFamily` is the theme.js Chip-variant
-// family name (components/theme.js's "three card badge families (T07
-// done-when, T12/#16)") -- deliberately not the same string as `facetKey`
-// (data/taxonomy.js's facet is "complexityClass", the chip family is
-// "complexity"), so each row is mapped to its family explicitly rather than
-// built by concatenating the taxonomy facet key.
-const BADGE_ROWS = [
-  { facetKey: "complexityClass", chipFamily: "complexity" },
-  { facetKey: "solverType", chipFamily: "solverType" },
-  { facetKey: "problemType", chipFamily: "problemType" },
-];
+// Row order per the issue body. Each row's Chip-variant family is now just
+// its own facetKey (theme.js's per-facet chip variants, #70) -- so a facet
+// outside this base list can reuse the exact same TagRow with no extra
+// mapping.
+const BASE_BADGE_FACET_KEYS = ["complexityClass", "solverType", "problemType"];
 
 const TAXONOMY_BY_KEY = new Map(TAXONOMY.map((facet) => [facet.key, facet]));
 
@@ -59,7 +62,19 @@ function optionLabel(facetKey, optionKey) {
   return option?.label ?? optionKey;
 }
 
-function TagRow({ facetKey, chipFamily, tagKeys, matchedKeys }) {
+// data/taxonomy.js's own shape-contract note (see pages/index.js's header
+// comment): every facet except computationalModel stores its problem-level
+// tag as an array even when `multiValued: false`. Normalizing here rather
+// than special-casing computationalModel lets every facet, base or added,
+// go through one TagRow.
+function tagValueAsArray(tagValue) {
+  if (Array.isArray(tagValue)) {
+    return tagValue;
+  }
+  return tagValue == null ? [] : [tagValue];
+}
+
+function TagRow({ facetKey, tagKeys, matchedKeys }) {
   if (!tagKeys || tagKeys.length === 0) {
     return null;
   }
@@ -71,7 +86,7 @@ function TagRow({ facetKey, chipFamily, tagKeys, matchedKeys }) {
           <Chip
             key={optionKey}
             size="small"
-            variant={matched ? `${chipFamily}Filled` : `${chipFamily}Outlined`}
+            variant={matched ? `${facetKey}Filled` : `${facetKey}Outlined`}
             icon={matched ? <CheckIcon /> : undefined}
             label={optionLabel(facetKey, optionKey)}
           />
@@ -87,13 +102,24 @@ function TagRow({ facetKey, chipFamily, tagKeys, matchedKeys }) {
  *   (name, slug, tags.<facetKey>[]).
  * @param {Object} [props.matchedTags] `{ [facetKey]: Set<optionKey> }` --
  *   which of this card's own tags match the currently active filters, in the
- *   same `Set`-valued shape FacetSidebar's `selected` prop already uses. The
- *   card only ever reads this prop; it never looks at filter state itself
- *   (issue body, "The matched-tag treatment"), which keeps it reusable and
- *   easy to test.
+ *   same `Set`-valued shape FacetSidebar's `selected` prop already uses --
+ *   now for every taxonomy facet, not just the three rendered by default
+ *   (#70), since a non-empty set for any other facet is also what triggers
+ *   this card to add that facet's own row. The card only ever reads this
+ *   prop; it never looks at filter state itself (issue body, "The
+ *   matched-tag treatment"), which keeps it reusable and easy to test.
  */
 export default function ProblemCatalogCard({ problem, matchedTags = {} }) {
   const complete = isProblemComplete(problem);
+
+  // #70: a facet outside the base three gets a row added only once a filter
+  // for it is active (a non-empty matched set) -- every card on screen
+  // already matches every active facet selection (pages/index.js's
+  // matchesSelectedFacets), so there's always a real tag to show.
+  const extraFacetKeys = TAXONOMY.map((facet) => facet.key).filter(
+    (facetKey) =>
+      !BASE_BADGE_FACET_KEYS.includes(facetKey) && (matchedTags[facetKey]?.size ?? 0) > 0,
+  );
 
   return (
     <Paper
@@ -135,12 +161,19 @@ export default function ProblemCatalogCard({ problem, matchedTags = {} }) {
       </Box>
 
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-        {BADGE_ROWS.map(({ facetKey, chipFamily }) => (
+        {BASE_BADGE_FACET_KEYS.map((facetKey) => (
           <TagRow
             key={facetKey}
             facetKey={facetKey}
-            chipFamily={chipFamily}
-            tagKeys={problem.tags?.[facetKey]}
+            tagKeys={tagValueAsArray(problem.tags?.[facetKey])}
+            matchedKeys={matchedTags[facetKey] ?? EMPTY_SET}
+          />
+        ))}
+        {extraFacetKeys.map((facetKey) => (
+          <TagRow
+            key={facetKey}
+            facetKey={facetKey}
+            tagKeys={tagValueAsArray(problem.tags?.[facetKey])}
             matchedKeys={matchedTags[facetKey] ?? EMPTY_SET}
           />
         ))}

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -41,10 +41,11 @@ function optionLabel(facetKey, optionKey) {
   return option?.label ?? optionKey;
 }
 
-// No pre-built Chip variant exists for solverComplexity (theme.js's
-// BADGE_FAMILIES only covers complexityClass/solverType/problemType for
-// card badges) -- same plain-pill pattern components/ActiveFilterChips.js
-// already uses for its facet-colored chips.
+// Deliberately not the theme.js `solverComplexityOutlined`/`Filled` Chip
+// variant (#70) -- this badge is a static declared-complexity label on the
+// Problem Detail page, not a filterable card tag, so it stays the same
+// plain-pill pattern components/ActiveFilterChips.js already uses for its
+// facet-colored chips.
 function ComplexityBucketBadge({ bucketKey }) {
   const facet = TAXONOMY_BY_KEY.get("solverComplexity");
   const accentColor = getFacetAccentColor(facet?.accentColor);

--- a/components/theme.js
+++ b/components/theme.js
@@ -29,6 +29,7 @@
 // itself. A theme module is exactly where a color palette belongs.
 
 import { alpha, createTheme } from "@mui/material/styles";
+import { TAXONOMY } from "../data/taxonomy";
 
 // Semantic color name (as stored in each data/taxonomy.js facet's
 // `accentColor` field) -> real color. Values are Tailwind CSS v3 "-400"
@@ -73,28 +74,29 @@ export function getFacetAccentColor(colorName) {
   return FACET_ACCENT_COLORS[colorName] ?? FALLBACK_ACCENT;
 }
 
-// --- The three card badge families (T07 done-when, T12/#16) --------------
+// --- Per-facet card badge / tag-row chip families (T07 done-when, T12/#16,
+// #70) -----------------------------------------------------------------
 //
-// Complexity, Solver Type and Problem Type badges each get their own MUI
-// Chip variant, in both states the mockup shows: outlined by default,
-// filled (solid background + white text) when the tag matches an active
-// filter. Consumers pick the state: `variant={matched ? "complexityFilled"
-// : "complexityOutlined"}`. The leading checkmark on a matched badge is
-// content (an icon), not styling, so T12 renders it — this file only makes
-// the filled state look right once it's there.
-const BADGE_FAMILIES = {
-  complexity: "amber",
-  solverType: "salmon-red",
-  problemType: "blue",
-};
-
+// Every data/taxonomy.js facet gets its own MUI Chip variant pair, keyed by
+// the facet's own `key`: outlined by default, filled (solid background +
+// white text) when the tag matches an active filter. Consumers pick the
+// state: `variant={matched ? "complexityClassFilled" :
+// "complexityClassOutlined"}`. The leading checkmark on a matched badge is
+// content (an icon), not styling, so ProblemCatalogCard renders it — this
+// file only makes the filled state look right once it's there.
+//
+// #70: originally only complexityClass/solverType/problemType (the three
+// facets ProblemCatalogCard renders by default) had variants here. Widened
+// to every facet so a card can add a tag row for ANY facet once a filter for
+// it is active, with the exact same filled/checkmark/bold treatment as the
+// three default rows.
 function buildChipVariants() {
   const variants = [];
-  for (const [family, colorName] of Object.entries(BADGE_FAMILIES)) {
-    const base = FACET_ACCENT_COLORS[colorName];
-    const strong = FACET_ACCENT_COLORS_STRONG[colorName];
-    const outlinedVariant = `${family}Outlined`;
-    const filledVariant = `${family}Filled`;
+  for (const facet of TAXONOMY) {
+    const base = FACET_ACCENT_COLORS[facet.accentColor];
+    const strong = FACET_ACCENT_COLORS_STRONG[facet.accentColor];
+    const outlinedVariant = `${facet.key}Outlined`;
+    const filledVariant = `${facet.key}Filled`;
 
     variants.push({
       props: { variant: outlinedVariant },

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,14 +36,6 @@ import { thinScrollbarSx } from "../components/theme";
 import { FIXTURE_PROBLEMS } from "../data/fixtures";
 import { TAXONOMY } from "../data/taxonomy";
 
-// The three facets ProblemCatalogCard actually renders badges for -- the
-// only keys its own `matchedTags` prop needs (components/ProblemCatalogCard.js
-// BADGE_ROWS). Slicing these out of `selected` keeps the prop's meaning
-// ("what should highlight on a card") distinct from the sidebar's full
-// 8-facet selection state, even though a card ignores any extra key it
-// doesn't render anyway.
-const CARD_BADGE_FACETS = ["complexityClass", "solverType", "problemType"];
-
 // #68: 280 was too narrow -- the longest option labels ("Algebra and Number
 // Theory", "Logical/Functional Models") wrapped to a second line against
 // their checkbox + count. Widened so every option renders on one line.
@@ -124,13 +116,12 @@ export default function Home() {
     });
   }, [selected, searchValue]);
 
-  const matchedTags = useMemo(() => {
-    const tags = {};
-    for (const facetKey of CARD_BADGE_FACETS) {
-      tags[facetKey] = selected[facetKey] ?? new Set();
-    }
-    return tags;
-  }, [selected]);
+  // #70: passed straight through, not sliced to a fixed subset of facets --
+  // `selected` is already `{ [facetKey]: Set<optionKey> }`, exactly the
+  // shape ProblemCatalogCard's `matchedTags` prop wants, and a card now adds
+  // a row for ANY facet with an active selection, not only the three it
+  // renders by default.
+  const matchedTags = selected;
 
   const handleFacetChange = (facetKey, nextSet) => {
     setSelected((prev) => ({ ...prev, [facetKey]: nextSet }));


### PR DESCRIPTION
Issue:  #70 (Add Filter Selections to Problem Cards as Checked Tags)
Branch: task/T70-filter-checked-tags

Changed:
  components/theme.js                  (Chip variants generalized from 3 hardcoded facets to all 8 taxonomy facets)
  components/ProblemCatalogCard.js     (cards now add a tag row for any facet with an active filter selection, not just Complexity Class/Solver Type/Problem Type)
  pages/index.js                       (matchedTags now passes the full `selected` state instead of a 3-facet slice; removed the now-unneeded CARD_BADGE_FACETS constant)
  components/detail/SolversSection.js  (comment-only: corrected a stale reference to the old 3-facet BADGE_FAMILIES)

Done when — met:
  - Selecting a filter for a facet outside the three default badge rows (e.g. Reduction Type) adds a new row to matching cards, rendered filled + checkmark + bold — verified live via Playwright screenshot (Karp (Many-One) row appeared on 0/1 Knapsack, 1-in-3 SAT, 3-SAT, etc.)
  - Selecting a filter for one of the three default facets (e.g. Complexity Class -> NP) still just highlights within the existing row — no duplicate row added — verified live.
  - No console errors during either interaction.
  - `npm run lint` and `npm run build` both clean.

Decisions and assumptions:
  - Extended theme.js's chip-variant builder to derive a Filled/Outlined pair per taxonomy facet.key (deriving the variant name directly from facetKey rather than the old ad hoc "complexity" alias for complexityClass), rather than one-off styling just for the newly-needed facets, since the issue's wording ("just like the default displayed tags") calls for the exact same visual treatment everywhere, and the code already had all 8 facets' accent colors defined in FACET_ACCENT_COLORS/_STRONG.
  - Added rows appear in data/taxonomy.js's declared facet order (computationalModel, solverComplexity, reductionType, reductionCost, visualizationType), after the three base rows.
  - Since ProblemGrid only ever displays problems that already match every active facet selection (existing AND-across-facets filtering in pages/index.js), an added row's tag list is simply the problem's own tags for that facet — no extra "does this match" check was needed beyond "is the facet's selected-set non-empty."
  - components/detail/SolversSection.js's solverComplexity badge was deliberately left on its own plain-pill styling rather than switched to the new solverComplexityFilled/Outlined chip variant — it's a static detail-page label, not a filterable card tag, so switching it was out of scope; only fixed its now-stale comment.
  
  Closes #70 