### PR TITLE
Added menus with scrollbars to solvers, visualization, and reduction sections on problem detail pages

### DIFF
--- a/components/detail/ReductionsSection.js
+++ b/components/detail/ReductionsSection.js
@@ -33,8 +33,12 @@ import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 import { TAXONOMY } from "../../data/taxonomy";
-import { getFacetAccentColor } from "../theme";
+import { getFacetAccentColor, thinScrollbarSx } from "../theme";
 import SectionShell from "./SectionShell";
+
+// #71: fixed list height so a problem with many declared reduction targets
+// scrolls inside the list instead of stretching the section indefinitely.
+const REDUCES_TO_MAX_HEIGHT = 220;
 
 const REDUCTION_COST_FACET = TAXONOMY.find((facet) => facet.key === "reductionCost");
 const REDUCTION_COST_LABELS = new Map(
@@ -178,12 +182,15 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
             Reduces to
           </Typography>
           <Box
+            role="listbox"
+            aria-label="Reduces to"
             sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 0.75,
-              maxHeight: 220,
+              maxHeight: REDUCES_TO_MAX_HEIGHT,
               overflowY: "auto",
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 1.5,
+              ...thinScrollbarSx,
             }}
           >
             {to.map((reduction, index) => {
@@ -194,7 +201,8 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
                   id={`reduction-to-${slugify(reduction.target)}`}
                   component="button"
                   type="button"
-                  aria-pressed={isSelected}
+                  role="option"
+                  aria-selected={isSelected}
                   onClick={() => setSelectedIndex(index)}
                   sx={(theme) => ({
                     display: "flex",
@@ -208,12 +216,17 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
                     color: "inherit",
                     px: 1.5,
                     py: 1,
-                    borderRadius: 1.5,
-                    border: "1px solid",
-                    borderColor: isSelected ? "primary.main" : "divider",
+                    border: "none",
+                    borderLeft: "3px solid",
+                    borderLeftColor: isSelected ? "primary.main" : "transparent",
                     backgroundColor: isSelected
                       ? alpha(theme.palette.primary.main, 0.12)
                       : "transparent",
+                    "&:hover": {
+                      backgroundColor: isSelected
+                        ? alpha(theme.palette.primary.main, 0.12)
+                        : alpha(theme.palette.common.white, 0.04),
+                    },
                   })}
                 >
                   <Typography variant="body2">

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -29,8 +29,12 @@ import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 import { TAXONOMY } from "../../data/taxonomy";
-import { getFacetAccentColor } from "../theme";
+import { getFacetAccentColor, thinScrollbarSx } from "../theme";
 import SectionShell from "./SectionShell";
+
+// #71: fixed rail height so a problem with many declared solvers scrolls
+// inside the rail instead of stretching the section indefinitely.
+const RAIL_MAX_HEIGHT = 320;
 
 const TAXONOMY_BY_KEY = new Map(TAXONOMY.map((facet) => [facet.key, facet]));
 
@@ -127,51 +131,85 @@ export default function SolversSection({ problem, dragHandleProps }) {
         </Paper>
 
         <Box sx={{ display: "flex", gap: 2 }}>
-          <Box sx={{ width: 260, flexShrink: 0, display: "flex", flexDirection: "column", gap: 1 }}>
-            {solvers.length === 0 ? (
-              <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
-                No solvers declared for this problem.
-              </Typography>
-            ) : (
-              solvers.map((solver, index) => {
+          {solvers.length === 0 ? (
+            <Typography
+              variant="body2"
+              sx={{ width: 260, flexShrink: 0, color: "text.secondary", fontStyle: "italic" }}
+            >
+              No solvers declared for this problem.
+            </Typography>
+          ) : (
+            <Box
+              component="ul"
+              role="listbox"
+              aria-label="Solvers"
+              sx={{
+                listStyle: "none",
+                m: 0,
+                p: 0,
+                width: 260,
+                flexShrink: 0,
+                maxHeight: RAIL_MAX_HEIGHT,
+                overflowY: "auto",
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 2,
+                ...thinScrollbarSx,
+              }}
+            >
+              {solvers.map((solver, index) => {
                 const solverId = `solver-${index}-toggle`;
                 const isSelected = index === selectedIndex;
                 return (
-                  <Paper
-                    key={solverId}
-                    id={solverId}
-                    component="button"
-                    type="button"
-                    onClick={() => setSelectedIndex(index)}
-                    aria-pressed={isSelected}
-                    variant="outlined"
-                    sx={{
-                      display: "flex",
-                      flexDirection: "column",
-                      alignItems: "flex-start",
-                      gap: 0.5,
-                      p: 1.5,
-                      cursor: "pointer",
-                      textAlign: "left",
-                      font: "inherit",
-                      color: "inherit",
-                      borderColor: isSelected ? "primary.light" : "divider",
-                      backgroundColor: isSelected ? alpha("#FB923C", 0.08) : "transparent",
-                    }}
-                  >
-                    <Typography variant="body2" sx={{ fontWeight: 700 }}>
-                      {solver.name}
-                    </Typography>
-                    <Chip
-                      size="small"
-                      variant="solverTypeOutlined"
-                      label={optionLabel("solverType", solver.type)}
-                    />
-                  </Paper>
+                  <Box component="li" key={solverId} sx={{ listStyle: "none" }}>
+                    <Box
+                      id={solverId}
+                      component="button"
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => setSelectedIndex(index)}
+                      sx={(theme) => ({
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "flex-start",
+                        gap: 0.5,
+                        width: "100%",
+                        p: 1.5,
+                        cursor: "pointer",
+                        textAlign: "left",
+                        font: "inherit",
+                        color: "inherit",
+                        border: "none",
+                        borderLeft: "3px solid",
+                        borderLeftColor: isSelected ? "primary.main" : "transparent",
+                        backgroundColor: isSelected
+                          ? alpha(theme.palette.primary.main, 0.14)
+                          : "transparent",
+                        "&:hover": {
+                          backgroundColor: isSelected
+                            ? alpha(theme.palette.primary.main, 0.14)
+                            : alpha(theme.palette.common.white, 0.04),
+                        },
+                      })}
+                    >
+                      <Typography
+                        variant="body2"
+                        sx={{ fontWeight: 700, color: isSelected ? "text.primary" : "text.secondary" }}
+                      >
+                        {solver.name}
+                      </Typography>
+                      <Chip
+                        size="small"
+                        variant="solverTypeOutlined"
+                        label={optionLabel("solverType", solver.type)}
+                      />
+                    </Box>
+                  </Box>
                 );
-              })
-            )}
-          </Box>
+              })}
+            </Box>
+          )}
 
           <Box sx={{ flex: 1, minWidth: 0 }}>
             {!selected ? (

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -195,7 +195,10 @@ export default function SolversSection({ problem, dragHandleProps }) {
                     >
                       <Typography
                         variant="body2"
-                        sx={{ fontWeight: 700, color: isSelected ? "text.primary" : "text.secondary" }}
+                        sx={{
+                          fontWeight: 700,
+                          color: isSelected ? "text.primary" : "text.secondary",
+                        }}
                       >
                         {solver.name}
                       </Typography>

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -25,10 +25,14 @@ import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 import { TAXONOMY, UNCLASSIFIED } from "../../data/taxonomy";
-import { getFacetAccentColor } from "../theme";
+import { getFacetAccentColor, thinScrollbarSx } from "../theme";
 import SectionShell from "./SectionShell";
 
 const VISUALIZATION_TYPE_FACET = TAXONOMY.find((facet) => facet.key === "visualizationType");
+
+// #71: fixed rail height so a problem with many declared visualizations
+// scrolls inside the rail instead of stretching the section indefinitely.
+const RAIL_MAX_HEIGHT = 320;
 
 // Falls back to the raw key (or the UNCLASSIFIED sentinel itself, e.g.
 // 3-SAT's "Assignment Table" -- a real, documented taxonomy gap, see
@@ -90,49 +94,62 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
         <Box sx={{ display: "flex", gap: 2 }}>
           <Box
             component="ul"
+            role="listbox"
+            aria-label="Visualizations"
             sx={{
               listStyle: "none",
               m: 0,
               p: 0,
               width: 220,
               flexShrink: 0,
-              maxHeight: 360,
+              maxHeight: RAIL_MAX_HEIGHT,
               overflowY: "auto",
-              display: "flex",
-              flexDirection: "column",
-              gap: 1,
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 2,
+              ...thinScrollbarSx,
             }}
           >
             {visualizations.map((visualization, index) => {
               const isSelected = index === selectedIndex;
               const entryId = `visualizations-rail-entry-${index}`;
               return (
-                <Box component="li" key={entryId}>
+                <Box component="li" key={entryId} sx={{ listStyle: "none" }}>
                   <Box
                     id={entryId}
                     component="button"
                     type="button"
-                    aria-pressed={isSelected}
+                    role="option"
+                    aria-selected={isSelected}
                     onClick={() => setSelectedIndex(index)}
-                    sx={{
+                    sx={(theme) => ({
                       display: "flex",
                       flexDirection: "column",
                       alignItems: "flex-start",
                       gap: 0.5,
                       width: "100%",
                       p: 1,
-                      borderRadius: 2,
-                      border: "1px solid",
-                      borderColor: isSelected ? "primary.main" : "divider",
-                      backgroundColor: (t) =>
-                        isSelected ? alpha(t.palette.primary.main, 0.1) : "transparent",
+                      border: "none",
+                      borderLeft: "3px solid",
+                      borderLeftColor: isSelected ? "primary.main" : "transparent",
+                      backgroundColor: isSelected
+                        ? alpha(theme.palette.primary.main, 0.1)
+                        : "transparent",
+                      "&:hover": {
+                        backgroundColor: isSelected
+                          ? alpha(theme.palette.primary.main, 0.1)
+                          : alpha(theme.palette.common.white, 0.04),
+                      },
                       color: "inherit",
                       font: "inherit",
                       textAlign: "left",
                       cursor: "pointer",
-                    }}
+                    })}
                   >
-                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{ fontWeight: 600, color: isSelected ? "text.primary" : "text.secondary" }}
+                    >
                       {visualization.name}
                     </Typography>
                     <TypeBadge typeKey={visualization.type} />

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -148,7 +148,10 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
                   >
                     <Typography
                       variant="body2"
-                      sx={{ fontWeight: 600, color: isSelected ? "text.primary" : "text.secondary" }}
+                      sx={{
+                        fontWeight: 600,
+                        color: isSelected ? "text.primary" : "text.secondary",
+                      }}
                     >
                       {visualization.name}
                     </Typography>


### PR DESCRIPTION
Issue:  #71 (Make Selection Menus in Problem Details Vertical Scrolling Lists)
Branch: task/T71-vertical-scroll-menus

Changed:
  components/detail/SolversSection.js         (solver rail: was individually-bordered button cards, now one bordered scrollable menu)
  components/detail/VisualizationsSection.js  (visualization rail: same treatment)
  components/detail/ReductionsSection.js      ("Reduces to" list only — "Reduces from" is informational/non-selectable, left as-is)

Done when — met:
  - Solvers, Visualizations, and "Reduces to" selections are now flat menu rows (role="listbox"/role="option") inside one bordered, height-capped, vertically-scrollable panel — verified the Solvers rail actually clips and scrolls (scrollHeight 288px vs clientHeight 108px when forced to overflow) and that clicking an item still updates selection/aria-selected.
  - Scrollbar reuses the app's existing thinScrollbarSx token (components/theme.js) — transparent track, 6px slim thumb, already used for the Home page grid — rather than inventing a new one, since it's already an exact match for the issue's "transparent background, slim width" ask.
  - Selected row now matches the mockup ("Problem Detail — draggable panels.pdf"): full-row background wash + orange left accent bar, instead of a bordered box per item.
  - Verified visually against the mockup with a Playwright screenshot at /3-sat, and confirmed lint + build are clean.

Decisions and assumptions:
  - None of the current fixture data (data/fixtures.js) actually has enough solvers/visualizations/reduction targets to overflow the new fixed max-heights (320px / 320px / 220px) in practice today — I verified the scroll mechanism works by temporarily forcing a smaller height in a throwaway browser session (not committed), rather than relying on real data that doesn't yet exist. The fixed heights guard against future fixture growth, matching the mockup's own capped-list treatment.
  - "Reduces from" (informational, not selectable) was intentionally left untouched — the issue's "selections with multiple choices" wording matches "Reduces to" (interactive), not the read-only "from" list.
  - Switched aria-pressed (toggle-button semantics) to role="listbox"/role="option" + aria-selected on all three rails, since the issue explicitly asks for "items in a menu" rather than buttons — this is the standard accessible pattern for a single-select scrollable list.

  Closes #71