### PR TITLE
Seed Frontend with Redux Backend Values

### DIFF
--- a/data/fixtures.js
+++ b/data/fixtures.js
@@ -24,12 +24,12 @@
 // Only the `tags` object nested in each entry is the part T23's
 // `useCatalogIndex()` must reproduce exactly -- that hook returns
 // `{ index, loading, error }`, where `index` is a `Map<problemName, tags>`
-// built from the 5 real-backend-derived facets (complexityClass, solverType,
-// reductionCost, visualizationType, solverComplexity) plus the 4 fully-gap
-// facets merged in via `mergeSupplementalTags` (problemType,
-// computationalModel, reductionType) and the quantum half of complexityClass
-// -- see the overlay-field-count note below for why that list has 5 members,
-// not 4. T25 depends on swapping `FIXTURE_CATALOG_INDEX` for the real
+// built from the 6 real-backend-derived facets (complexityClass, solverType,
+// reductionCost, reductionType, visualizationType, solverComplexity) plus
+// the 3 fully-gap facets merged in via `mergeSupplementalTags` (problemType,
+// computationalModel) and the quantum half of complexityClass -- see the
+// overlay-field-count note below for why that list has 4 members now, not
+// 5 or 4-as-originally-written. T25 depends on swapping `FIXTURE_CATALOG_INDEX` for the real
 // `useCatalogIndex()` return value being a one-line change in pages/index.js,
 // so `tags` must stay exactly this shape: every facet key from
 // `data/taxonomy.js`'s `TAXONOMY` array, valued as either a single option
@@ -53,31 +53,35 @@
 // T23 does not need to reproduce this part of the shape.
 //
 // -----------------------------------------------------------------------
-// DECISION: five overlay fields, not four
+// DECISION: four overlay fields, not five (not four the original way either)
 // -----------------------------------------------------------------------
 // Issue #13's own "Done when" list says "one of the four supplemental
 // overlay fields," and TASKLIST.md's T22 write-up and ARCHITECTURE.md's
 // directory-tree comment for supplementalTags.js/mergeSupplementalTags.js
-// both also say "4 gap fields." That count is stale: it predates the
-// 2026-08-31 addition of the conceptual `visualStyle` field (issue #6,
-// conflict C4). ARCHITECTURE.md's "The taxonomy gap" section (last touched
-// 2026-09-01, the most recently corrected version of this count) and
-// TAXONOMY_REFERENCE.md §9 both explicitly call visualStyle "a fifth
-// overlay field" / "the fifth overlay field alongside the four backend-gap
-// fields." The real, merged `data/taxonomy.js` (T06, PR #45) confirms this
-// reading: its `visualizationType` facet's options are already the
-// conceptual vocabulary (Node-Link Diagram, Bipartite Factor Graph, BDD,
-// ...), not the backend's renderer enum, sourced -- per that file's own
-// comment -- from the visualStyle overlay.
+// both also say "4 gap fields." That count was stale once already: it
+// predated the 2026-08-31 addition of the conceptual `visualStyle` field
+// (issue #6, conflict C4), which made it five (problemType,
+// computationalModel, reductionType, the quantum half of complexityClass,
+// visualStyle). It is stale again, differently, as of 2026-09-02: Reduction
+// Type was retargeted to ReduxISU/Redux#396's real `ReductionType` field
+// (Restriction/LocalReplacement/ComponentDesign, TAXONOMY_REFERENCE.md §7)
+// rather than requesting a new backend field for the vocabulary originally
+// ratified -- see issue #31. That makes reductionType a real-backend-derived
+// facet, not an overlay one, dropping the count back to four: problemType,
+// computationalModel, the quantum half of complexityClass, and visualStyle.
 //
-// So the count is: 3 fully-gap fields with zero backend counterpart
-// (problemType, computationalModel, reductionType), + the quantum half of
-// complexityClass (partial overlay onto an otherwise-real backend field),
-// + visualStyle (partial overlay onto visualizationType) = 5 overlay
-// concepts in all. This fixture is built against that reading. Whoever
-// picks up T22/T23 should treat "four" in the issue body and in
-// mergeSupplementalTags.js's own doc-comment as the stale figure and update
-// it to five, rather than reproducing it forward.
+// So the count is: 2 fully-gap fields with zero backend counterpart
+// (problemType, computationalModel), + the quantum half of complexityClass
+// (partial overlay onto an otherwise-real backend field), + visualStyle
+// (partial overlay onto visualizationType) = 4 overlay concepts in all.
+// reductionType joins reductionCost, solverType, solverComplexity and
+// visualizationType as a facet with a translation map
+// (data/taxonomy.js's REDUCTION_TYPE_MAP) but no overlay entry. This
+// fixture is built against that reading. Whoever picks up T22/T23 should
+// treat "four" or "five" in the issue body and in mergeSupplementalTags.js's
+// own doc-comment as the stale figure (depending on when it was written)
+// and update it to four-as-defined-here, rather than reproducing an earlier
+// count forward.
 //
 // (None of the 12 sample problems below are QuantumOracle-classified, so
 // none of them exercise the quantum half of complexityClass -- that part of
@@ -152,7 +156,9 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact"],
       solverComplexity: ["polynomial", "exponential"],
-      reductionType: ["karp"],
+      // Matches the real backend's Subset Sum -> Knapsack reduction
+      // (FengReduction.cs), which is ReductionType.Restriction.
+      reductionType: ["restriction"],
       reductionCost: ["linear"],
       visualizationType: ["searchTree"],
     },
@@ -177,7 +183,7 @@ export const FIXTURE_PROBLEMS = [
       certificateFormat: "certificate = [i1, i2, …, ik]",
     },
     reductions: {
-      to: [{ target: "Subset Sum", cost: "linear", type: "karp" }],
+      to: [{ target: "Subset Sum", cost: "linear", type: "restriction" }],
       from: [],
     },
   },
@@ -192,7 +198,10 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact"],
       solverComplexity: ["exponential"],
-      reductionType: ["karp"],
+      // Gadget-per-clause construction (each 3-literal clause becomes a
+      // small fixed circuit enforcing "exactly one true"), which is
+      // ReductionType.ComponentDesign, not a plain relabeling.
+      reductionType: ["componentDesign"],
       reductionCost: ["linear"],
       visualizationType: ["bipartiteFactorGraph"],
     },
@@ -210,7 +219,7 @@ export const FIXTURE_PROBLEMS = [
     },
     reductions: {
       to: [],
-      from: [{ source: "3-SAT", cost: "linear", type: "karp" }],
+      from: [{ source: "3-SAT", cost: "linear", type: "componentDesign" }],
     },
   },
   {
@@ -230,7 +239,14 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact", "heuristic", "automatedReasoning"],
       solverComplexity: ["exponential"],
-      reductionType: ["karp"],
+      // Union of this problem's 5 reduces-to + 2 reduces-from edges' proof
+      // techniques below (TAXONOMY_REFERENCE.md §7, issue #31) -- localReplacement
+      // from the SAT->3SAT/Circuit-SAT->3SAT direction (per-clause/per-gate
+      // substitution), componentDesign from the gadget-heavy 3SAT->Clique/
+      // VertexCover/SubsetSum/HamiltonianCycle direction, except
+      // 3SAT->IntegerProgramming which matches the real backend's
+      // KarpIntProgStandard.cs (LocalReplacement).
+      reductionType: ["componentDesign", "localReplacement"],
       // Union of this problem's own reduces-to (linear, quadratic, quadratic,
       // cubic, higherPolynomial) and reduces-from (linear, linear) costs.
       reductionCost: ["linear", "quadratic", "cubic", "higherPolynomial"],
@@ -320,15 +336,15 @@ export const FIXTURE_PROBLEMS = [
       // Order matches the mockup; VERTEX COVER is the one shown as
       // "(shown above)" in the mockup's default selection.
       to: [
-        { target: "Vertex Cover", cost: "linear", type: "karp" },
-        { target: "Clique", cost: "quadratic", type: "karp" },
-        { target: "Subset Sum", cost: "quadratic", type: "karp" },
-        { target: "Integer Programming", cost: "cubic", type: "karp" },
-        { target: "Hamiltonian Cycle", cost: "higherPolynomial", type: "karp" },
+        { target: "Vertex Cover", cost: "linear", type: "componentDesign" },
+        { target: "Clique", cost: "quadratic", type: "componentDesign" },
+        { target: "Subset Sum", cost: "quadratic", type: "componentDesign" },
+        { target: "Integer Programming", cost: "cubic", type: "localReplacement" },
+        { target: "Hamiltonian Cycle", cost: "higherPolynomial", type: "componentDesign" },
       ],
       from: [
-        { source: "General CNF-SAT", cost: "linear", type: "karp" },
-        { source: "Circuit-SAT", cost: "linear", type: "karp" },
+        { source: "General CNF-SAT", cost: "linear", type: "localReplacement" },
+        { source: "Circuit-SAT", cost: "linear", type: "localReplacement" },
       ],
     },
   },
@@ -343,7 +359,10 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact"],
       solverComplexity: ["exponential"],
-      reductionType: ["karp"],
+      // Cook-Levin: each gate becomes a local clause gadget --
+      // ReductionType.LocalReplacement, matching 3-SAT's own reduces-from
+      // entry for this same edge below.
+      reductionType: ["localReplacement"],
       reductionCost: ["linear"],
       visualizationType: ["logicGateSchematic"],
     },
@@ -360,9 +379,9 @@ export const FIXTURE_PROBLEMS = [
       certificateFormat: "certificate = [in1, in2, …, ink]",
     },
     // Cook-Levin: Circuit-SAT reduces to 3-SAT -- matches 3-SAT's own
-    // reduces-from entry above (both say Linear).
+    // reduces-from entry above (both say Linear, both say LocalReplacement).
     reductions: {
-      to: [{ target: "3-SAT", cost: "linear", type: "karp" }],
+      to: [{ target: "3-SAT", cost: "linear", type: "localReplacement" }],
       from: [],
     },
   },
@@ -377,7 +396,9 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact"],
       solverComplexity: ["exponential"],
-      reductionType: ["karp"],
+      // Matches 3-SAT's own reduces-to entry for this edge --
+      // ReductionType.ComponentDesign (clause-to-triangle gadgets).
+      reductionType: ["componentDesign"],
       reductionCost: ["quadratic"],
       visualizationType: ["nodeLinkDiagram"],
     },
@@ -400,7 +421,7 @@ export const FIXTURE_PROBLEMS = [
     // Textbook 3-SAT -> Clique reduction; matches 3-SAT's reduces-to entry.
     reductions: {
       to: [],
-      from: [{ source: "3-SAT", cost: "quadratic", type: "karp" }],
+      from: [{ source: "3-SAT", cost: "quadratic", type: "componentDesign" }],
     },
   },
   {
@@ -522,7 +543,9 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact", "heuristic"],
       solverComplexity: ["exponential", "polynomial"],
-      reductionType: ["karp"],
+      // Same relabeling family as the real backend's GraphColoringToCliqueCover.cs
+      // (ReductionType.Restriction).
+      reductionType: ["restriction"],
       reductionCost: ["linear"],
       visualizationType: ["nodeLinkDiagram"],
     },
@@ -543,7 +566,7 @@ export const FIXTURE_PROBLEMS = [
       certificateFormat: "certificate = [c(v1), c(v2), …, c(vn)]",
     },
     reductions: {
-      to: [{ target: "Clique", cost: "linear", type: "karp" }],
+      to: [{ target: "Clique", cost: "linear", type: "restriction" }],
       from: [],
     },
   },
@@ -557,7 +580,9 @@ export const FIXTURE_PROBLEMS = [
       complexityClass: ["npComplete", "np", "npHard"],
       solverType: ["exact"],
       solverComplexity: ["exponential"],
-      reductionType: ["karp"],
+      // Matches 3-SAT's own reduces-to entry for this edge --
+      // ReductionType.ComponentDesign (per-clause/per-variable edge gadgets).
+      reductionType: ["componentDesign"],
       reductionCost: ["higherPolynomial"],
       // No declared visualization -- see the status-icon note below.
       visualizationType: [],
@@ -570,10 +595,10 @@ export const FIXTURE_PROBLEMS = [
       certificateDescription: "An ordered list of vertices forming the cycle.",
       certificateFormat: "certificate = [v1, v2, …, vn]",
     },
-    // Matches 3-SAT's own reduces-to entry (Higher Poly.).
+    // Matches 3-SAT's own reduces-to entry (Higher Poly., ComponentDesign).
     reductions: {
       to: [],
-      from: [{ source: "3-SAT", cost: "higherPolynomial", type: "karp" }],
+      from: [{ source: "3-SAT", cost: "higherPolynomial", type: "componentDesign" }],
     },
   },
   {

--- a/data/supplementalTags.js
+++ b/data/supplementalTags.js
@@ -1,0 +1,365 @@
+// data/supplementalTags.js
+//
+// T03 (issue #7). THE hand-authored overlay: values for the tag categories the
+// real Redux backend has no field for yet. mergeSupplementalTags.js (T18/#22,
+// not yet built) will read this file and prefer a real backend value over
+// what's here whenever one exists -- this file only fills the gap.
+//
+// -----------------------------------------------------------------------
+// Source and freshness
+// -----------------------------------------------------------------------
+// Keys below are the exact `problemName` strings returned by the live
+// production backend (https://redux.isu.edu/api/redux/), queried 2026-09-02
+// via Navigation/Batch/allProblems (49 problem codes) cross-referenced
+// against Navigation/Batch/allInfo (each code's `problemName` field -- the
+// human-readable display name, NOT the short code allProblems itself
+// returns, e.g. code "SAT3" -> problemName "3SAT"). If this file starts
+// showing zero coverage everywhere, re-run that query -- the catalog may
+// have grown past 49 problems since this date, or a name may have changed.
+//
+// Full 49-name list captured this run (paste into the PR description):
+//   Feedback Arc Set, Bernstein Vazirani, Bin Packing, Clique, Clique Cover,
+//   Convex Hull, Cut, Deutsch, Deutsch Jozsa, DFA Acceptance,
+//   Directed Hamiltonian Path, 3-Dimensional Matching, Dominating Set,
+//   Edit Distance, Exact Cover, Graph Coloring, Hamiltonian Path,
+//   Hitting Set, Independent Set, 0-1 Integer Programming, Job Sequencing,
+//   Knapsack (Binary), Lossless Data Compression, Max Cut, Minimum Cut,
+//   Minimum Spanning Tree, Minimum S-T Cut, NFA Acceptance,
+//   Feedback Node Set, N-Queens, Partition, Prime Factorization,
+//   Pump Scheduling Cost Minimization, Pump Scheduling Emergency Resilience,
+//   SAT, 3SAT, Set Cover, Simon's Problem,
+//   Single Pair Shortest Path Problem, Single Source Shortest Path Problem,
+//   Steiner Tree, Strongly Connected Components, Subset Sum, Sudoku,
+//   Topological Sort, Traveling Salesperson, Unstructured Search,
+//   Vertex Cover, Weighted Cut
+//
+// Note this is 49, not the ~59 issue #7 and TASKLIST.md's T03 write-up
+// expect from the mockup -- see this task's handback summary. Also note
+// several of these real names differ from data/fixtures.js's Phase-1 sample
+// keys ("3SAT" not "3-SAT", "Knapsack (Binary)" not "0/1 Knapsack",
+// "Hamiltonian Path" not "Hamiltonian Cycle", no "Circuit-SAT" or
+// "General CNF-SAT" in the real catalog at all) -- exactly the silent-zero-
+// coverage trap this issue warns about. fixtures.js is Shell-phase-only and
+// isn't wired to this file, so nothing is broken today, but whoever wires
+// T23/useCatalogIndex should key off THIS file's names, not fixtures.js's.
+//
+// -----------------------------------------------------------------------
+// Field precedence and shape
+// -----------------------------------------------------------------------
+// Only three fields live in this file (down from the four/five referenced in
+// older comments -- Reduction Type was retargeted to real backend data on
+// 2026-09-02, issue #31, and needs no overlay entry at all; see
+// data/taxonomy.js's reductionType facet comment and REDUCTION_TYPE_MAP):
+//
+//   problemType        string[]  -- always a ONE-ELEMENT array. The real
+//                                   backend field (ReduxISU/Redux#396,
+//                                   `ProblemType problemType { get; }`) is
+//                                   single-valued, not the ProblemType[] this
+//                                   project's taxonomy originally assumed.
+//                                   Wrapped in an array here so the shape
+//                                   matches taxonomy.js's multiValued:true
+//                                   problemType facet. None of the 49
+//                                   problems in #396's branch declare more
+//                                   than one value, so this mismatch stayed
+//                                   theoretical for this pass -- see the
+//                                   handback summary if that ever changes.
+//   computationalModel string    -- single value (taxonomy.js: multiValued
+//                                   false), omitted where not confidently
+//                                   knowable.
+//   complexityClass    string[]  -- ONLY present on genuinely quantum-
+//                                   complexity problems (the former
+//                                   `QuantumOracle` bucket). This is the
+//                                   "overlayQuantumClasses" argument
+//                                   data/taxonomy.js's deriveComplexityClasses()
+//                                   unions onto the classical set it derives
+//                                   from the real backend's ComplexityClass
+//                                   value -- see that function's doc comment.
+//                                   Every other problem simply has no
+//                                   `complexityClass` key here; its badge
+//                                   comes entirely from the real backend
+//                                   field via COMPLEXITY_CLASS_MAP.
+//
+// All values are data/taxonomy.js option keys (camelCase), never the
+// backend's PascalCase enum names -- e.g. `GraphTheory` -> "graphTheory",
+// `EQP` -> "eqp" -- same translation convention as SOLVER_TYPE_MAP /
+// REDUCTION_COST_MAP.
+//
+// -----------------------------------------------------------------------
+// Sourcing
+// -----------------------------------------------------------------------
+// problemType and complexityClass (quantum half) are copied from
+// ReduxISU/Redux#396 (open, unmerged, branch
+// feature/tag-system-expansion-375-379), per the 2026-09-01 decision on
+// issue #31 not to re-derive hand-researched work already sitting in that
+// branch. Verified directly against that branch's source (not the PR diff
+// summary): grepped `Problems/**/*_Class.cs` for
+// `problemType { get; } = ProblemType\.` (49 matches, one per problem) and
+// `complexityClass { get; } = ComplexityClass\.(EQP|BQP)` (5 matches:
+// Deutsch, Deutsch Jozsa, Bernstein Vazirani -> EQP; Simon's Problem,
+// Unstructured Search -> BQP). Both match this issue's and #31's written
+// expectations exactly.
+//
+// computationalModel is fully hand-researched here (#396 doesn't touch this
+// facet at all). Default is "turingMachines" for ordinary classical
+// decision/optimization problems. Three exceptions, reasoned from each
+// problem's actual formal definition (queried from allInfo, not guessed):
+//   - DFA Acceptance, NFA Acceptance -> "automata" (the problem IS a finite-
+//     automaton acceptance question).
+//   - SAT, 3SAT -> "logicalFunctionalModels" (the problem IS a Boolean-
+//     formula satisfiability question).
+//   - Pump Scheduling Cost Minimization, Pump Scheduling Emergency
+//     Resilience -> "parallelDistributed" (deciding which of several pumps
+//     to run concurrently each hour -- a genuinely concurrent-resource
+//     problem, not just a sequential ordering one).
+//   - Deutsch, Deutsch Jozsa, Bernstein Vazirani, Simon's Problem,
+//     Unstructured Search -> "quantumModels" (the same 5 problems whose
+//     complexity class is quantum -- their formal definitions are stated
+//     directly in terms of oracle/black-box quantum functions).
+// Deliberately NOT quantum: Prime Factorization, despite Shor's Algorithm
+// being one of its solvers. Its formal definition (`{<i> | i is int}`) is a
+// plain classical decomposition problem; having a quantum solver available
+// doesn't change the problem's own computational model, any more than SAT
+// having a Grover-based solver (SATGroverSolver) makes SAT's model quantum.
+// See the handback summary -- this is a judgment call, not backend data.
+//
+// visualStyle is also fully hand-researched (no backend field on any
+// branch). Keyed per VISUALIZATION INSTANCE, not per problem (a problem can
+// have several visualizations of different conceptual styles) -- the real
+// instance names returned by Navigation/Batch/allVisualizations (e.g.
+// "ArcSetDefaultVisualization"), the same names Navigation/Batch/
+// allVisualizationTypes keys its renderer values by. 48 visualization
+// instances exist across the 49 problems today (queried 2026-09-02).
+// GraphD3/GraphLaTeX instances are mapped to "nodeLinkDiagram" by default
+// (TAXONOMY_REFERENCE.md §9's direct mapping for GraphLaTeX; for GraphD3,
+// checked each problem's actual graph structure rather than guessing) with
+// one exception: Topological Sort's graph is a DAG by definition (topological
+// sort is undefined on a graph with cycles), so its visualization is tagged
+// "dag" instead of the generic node-link label. QuantumCircuitD3/
+// QuantumCircuitQjs -> "quantumCircuit" (direct). PumpSchedule ->
+// "ganttChart" (direct-ish, per §9). BooleanSatisfiability, SetD3,
+// DynamicTable, and Unimplemented instances are left UNCLASSIFIED --
+// checked the actual renderer source (ReduxISU/Redux_GUI's
+// StandardSATSvgReact.js and StandardSetSvgReact.js) rather than guessing
+// from the enum name alone:
+//   - BooleanSatisfiability draws literal clause boxes joined by "∧" with
+//     true/false literal highlighting -- not a gate-and-wire circuit
+//     (Logic Gate Schematic) and not a branching decision structure (BDD),
+//     so it fits neither of the two candidates TAXONOMY_REFERENCE.md §9
+//     floated. No option in the ratified 12-value list actually matches a
+//     literal clause/literal view.
+//   - SetD3 draws a literal recursive set-membership diagram (nested boxes
+//     of elements) -- not geometric (Voronoi Map) and not a graph
+//     (Bipartite Factor Graph). §9 already flags this as unrepresented in
+//     the ratified list; confirmed rather than assumed.
+//   - DynamicTable is the same step-table ambiguity data/fixtures.js's own
+//     3-SAT "Assignment Table" instance already documents as an open,
+//     unresolved gap -- not re-litigated here.
+//   - Unimplemented means no renderer is registered at all (see
+//     Redux_GUI's Visualizations.js doc comment) -- there is no picture to
+//     classify, so "no conceptual style" is the honest value, same as the
+//     other three.
+// This is 13 of the 48 instances (2 BooleanSatisfiability + 4 SetD3 + 4
+// DynamicTable + 3 Unimplemented) -- see the handback summary.
+
+import { UNCLASSIFIED } from "./taxonomy";
+
+/**
+ * @typedef {Object} SupplementalProblemTags
+ * @property {string[]} problemType        One-element array; see file header.
+ * @property {string} [computationalModel] Omitted where not confidently knowable.
+ * @property {string[]} [complexityClass]  Quantum classes only; omitted elsewhere.
+ */
+
+/** @type {Object<string, SupplementalProblemTags>} */
+export const SUPPLEMENTAL_TAGS = {
+  "Feedback Arc Set": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Bernstein Vazirani": {
+    problemType: ["miscellaneous"],
+    computationalModel: "quantumModels",
+    complexityClass: ["eqp"],
+  },
+  "Bin Packing": { problemType: ["storageAndRetrieval"], computationalModel: "turingMachines" },
+  Clique: { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Clique Cover": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Convex Hull": {
+    problemType: ["computationalGeometry"],
+    computationalModel: "turingMachines",
+  },
+  Cut: { problemType: ["networkDesign"], computationalModel: "turingMachines" },
+  Deutsch: {
+    problemType: ["miscellaneous"],
+    computationalModel: "quantumModels",
+    complexityClass: ["eqp"],
+  },
+  "Deutsch Jozsa": {
+    problemType: ["miscellaneous"],
+    computationalModel: "quantumModels",
+    complexityClass: ["eqp"],
+  },
+  "DFA Acceptance": { problemType: ["automataAndLanguages"], computationalModel: "automata" },
+  "Directed Hamiltonian Path": {
+    problemType: ["graphTheory"],
+    computationalModel: "turingMachines",
+  },
+  "3-Dimensional Matching": {
+    problemType: ["setsAndPartitions"],
+    computationalModel: "turingMachines",
+  },
+  "Dominating Set": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Edit Distance": { problemType: ["storageAndRetrieval"], computationalModel: "turingMachines" },
+  "Exact Cover": { problemType: ["setsAndPartitions"], computationalModel: "turingMachines" },
+  "Graph Coloring": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Hamiltonian Path": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Hitting Set": { problemType: ["setsAndPartitions"], computationalModel: "turingMachines" },
+  "Independent Set": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "0-1 Integer Programming": {
+    problemType: ["mathematicalProgramming"],
+    computationalModel: "turingMachines",
+  },
+  "Job Sequencing": {
+    problemType: ["sequencingAndScheduling"],
+    computationalModel: "turingMachines",
+  },
+  "Knapsack (Binary)": {
+    problemType: ["mathematicalProgramming"],
+    computationalModel: "turingMachines",
+  },
+  "Lossless Data Compression": {
+    problemType: ["storageAndRetrieval"],
+    computationalModel: "turingMachines",
+  },
+  "Max Cut": { problemType: ["networkDesign"], computationalModel: "turingMachines" },
+  "Minimum Cut": { problemType: ["networkDesign"], computationalModel: "turingMachines" },
+  "Minimum Spanning Tree": {
+    problemType: ["networkDesign"],
+    computationalModel: "turingMachines",
+  },
+  "Minimum S-T Cut": { problemType: ["networkDesign"], computationalModel: "turingMachines" },
+  "NFA Acceptance": { problemType: ["automataAndLanguages"], computationalModel: "automata" },
+  "Feedback Node Set": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "N-Queens": { problemType: ["gamesAndPuzzles"], computationalModel: "turingMachines" },
+  Partition: { problemType: ["setsAndPartitions"], computationalModel: "turingMachines" },
+  "Prime Factorization": {
+    problemType: ["algebraAndNumberTheory"],
+    // Deliberately classical -- see file header "Deliberately NOT quantum".
+    computationalModel: "turingMachines",
+  },
+  "Pump Scheduling Cost Minimization": {
+    problemType: ["sequencingAndScheduling"],
+    computationalModel: "parallelDistributed",
+  },
+  "Pump Scheduling Emergency Resilience": {
+    problemType: ["sequencingAndScheduling"],
+    computationalModel: "parallelDistributed",
+  },
+  SAT: { problemType: ["logic"], computationalModel: "logicalFunctionalModels" },
+  "3SAT": { problemType: ["logic"], computationalModel: "logicalFunctionalModels" },
+  "Set Cover": { problemType: ["setsAndPartitions"], computationalModel: "turingMachines" },
+  "Simon's Problem": {
+    problemType: ["miscellaneous"],
+    computationalModel: "quantumModels",
+    complexityClass: ["bqp"],
+  },
+  "Single Pair Shortest Path Problem": {
+    problemType: ["networkDesign"],
+    computationalModel: "turingMachines",
+  },
+  "Single Source Shortest Path Problem": {
+    problemType: ["networkDesign"],
+    computationalModel: "turingMachines",
+  },
+  "Steiner Tree": { problemType: ["networkDesign"], computationalModel: "turingMachines" },
+  "Strongly Connected Components": {
+    problemType: ["graphTheory"],
+    computationalModel: "turingMachines",
+  },
+  "Subset Sum": { problemType: ["setsAndPartitions"], computationalModel: "turingMachines" },
+  Sudoku: { problemType: ["gamesAndPuzzles"], computationalModel: "turingMachines" },
+  "Topological Sort": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Traveling Salesperson": {
+    problemType: ["networkDesign"],
+    computationalModel: "turingMachines",
+  },
+  "Unstructured Search": {
+    problemType: ["miscellaneous"],
+    computationalModel: "quantumModels",
+    complexityClass: ["bqp"],
+  },
+  "Vertex Cover": { problemType: ["graphTheory"], computationalModel: "turingMachines" },
+  "Weighted Cut": { problemType: ["networkDesign"], computationalModel: "turingMachines" },
+};
+
+// Reduction Type: intentionally no entries anywhere in this file. Retargeted
+// to the real backend's ReductionType field (issue #31, 2026-09-02) -- see
+// data/taxonomy.js's reductionType facet comment and REDUCTION_TYPE_MAP.
+
+/**
+ * Visualization-instance-keyed conceptual visual style. Keys are the exact
+ * strings Navigation/Batch/allVisualizations returns (e.g.
+ * "ArcSetDefaultVisualization"), NOT problem names -- see file header.
+ * @type {Object<string, string>}
+ */
+export const SUPPLEMENTAL_VISUAL_STYLE = {
+  // -- GraphD3 / GraphLaTeX -> Node-Link Diagram (checked each problem's
+  // actual graph structure; none of these are inherently bipartite or
+  // acyclic-by-definition the way Topological Sort is) --
+  ArcSetDefaultVisualization: "nodeLinkDiagram",
+  CliqueDefaultVisualization: "nodeLinkDiagram",
+  CliqueLatexVisualization: "nodeLinkDiagram",
+  CliqueCoverDefaultVisualization: "nodeLinkDiagram",
+  CutDefaultVisualization: "nodeLinkDiagram",
+  DirectedHamiltonianDefaultVisualization: "nodeLinkDiagram",
+  DominatingSetDefaultVisualization: "nodeLinkDiagram",
+  GraphColoringDefaultVisualization: "nodeLinkDiagram",
+  HamiltonianDefaultVisualization: "nodeLinkDiagram",
+  IndependentSetDefaultVisualization: "nodeLinkDiagram",
+  MaxCutVisualization: "nodeLinkDiagram",
+  MinCutVisualization: "nodeLinkDiagram",
+  MinimumSpanningTreeVisualization: "nodeLinkDiagram",
+  MinSTCutVisualization: "nodeLinkDiagram",
+  NodeSetDefaultVisualization: "nodeLinkDiagram",
+  SPSPVisualization: "nodeLinkDiagram",
+  SSSPVisualization: "nodeLinkDiagram",
+  SteinerTreeDefaultVisualization: "nodeLinkDiagram",
+  TSPDefaultVisualization: "nodeLinkDiagram",
+  VertexCoverDefaultVisualization: "nodeLinkDiagram",
+  WeightedCutDefaultVisualization: "nodeLinkDiagram",
+  DFAVisualization: "nodeLinkDiagram",
+  NFAVisualization: "nodeLinkDiagram",
+
+  // -- The one genuine DAG: topological sort is undefined on a cyclic graph --
+  TopologicalSortDefaultVisualization: "dag",
+
+  // -- QuantumCircuitD3 / QuantumCircuitQjs -> Quantum Circuit (direct) --
+  BernsteinVaziraniD3Visualization: "quantumCircuit",
+  BernsteinVaziraniDefaultVisualization: "quantumCircuit",
+  DeutschD3Visualization: "quantumCircuit",
+  DeutschDefaultVisualization: "quantumCircuit",
+  DeutschJozsaD3Visualization: "quantumCircuit",
+  DeutschJozsaDefaultVisualization: "quantumCircuit",
+  ShorsDefaultVisualization: "quantumCircuit",
+  SATGroverVisualization: "quantumCircuit",
+  UnstructuredSearchVisualization: "quantumCircuit",
+
+  // -- PumpSchedule -> Gantt Chart (direct-ish, TAXONOMY_REFERENCE.md §9) --
+  PumpSchedulingCMVisualization: "ganttChart",
+  PumpSchedulingEMVisualization: "ganttChart",
+
+  // -- Checked the actual Redux_GUI renderer source; genuinely doesn't match
+  // any of the 12 ratified conceptual labels -- see file header. --
+  SatDefaultVisualization: UNCLASSIFIED,
+  Sat3DefaultVisualization: UNCLASSIFIED,
+  ExactCoverDefaultVisualization: UNCLASSIFIED,
+  HittingSetDefaultVisualization: UNCLASSIFIED,
+  PartitionDefaultVisualization: UNCLASSIFIED,
+  SetCoverDefaultVisualization: UNCLASSIFIED,
+  DFATableVisualization: UNCLASSIFIED,
+  NFATableVisualization: UNCLASSIFIED,
+  SPSPTableVisualization: UNCLASSIFIED,
+  SSSPTableVisualization: UNCLASSIFIED,
+
+  // -- Unimplemented: no renderer registered, nothing to classify --
+  ConvexHullVisualization: UNCLASSIFIED,
+  LosslessDataCompressionVisualization: UNCLASSIFIED,
+  SudokuVisualization: UNCLASSIFIED,
+};

--- a/data/taxonomy.js
+++ b/data/taxonomy.js
@@ -138,16 +138,24 @@ export const TAXONOMY = [
     label: "Reduction Type",
     accentColor: "violet",
     sidebar: true,
-    // Tier 1, mutually exclusive (TAXONOMY_REFERENCE.md §7).
+    // Retargeted 2026-09-02 (issue #31, comment thread on #7): the
+    // 2026-08-31 meeting's ratified vocabulary (Karp (Many-One), Cook
+    // (Turing), L/AP-Reductions, Parsimonious, Randomized, Parameterized,
+    // Fine-Grained) was checked against Redux's real 20 reductions before
+    // this facet was wired up for real -- every one of them is a classical
+    // Karp reduction, so that vocabulary would show Karp: 20, everything
+    // else: 0. Retargeted to the real backend's `ReductionType` enum
+    // instead: Garey & Johnson's proof-technique taxonomy
+    // (TAXONOMY_REFERENCE.md §7), which splits genuinely on the same 20
+    // reductions (Restriction: 8, LocalReplacement: 5, ComponentDesign: 7).
+    // Real-backend-derived once ReduxISU/Redux#396 merges (REDUCTION_TYPE_MAP
+    // below) -- unlike the other backend-gap facets, this one needs no
+    // supplementalTags.js overlay entry.
     multiValued: false,
     options: [
-      { key: "karp", label: "Karp (Many-One)" },
-      { key: "cook", label: "Cook (Turing)" },
-      { key: "lApReductions", label: "L/AP-Reductions" },
-      { key: "parsimonious", label: "Parsimonious" },
-      { key: "randomized", label: "Randomized" },
-      { key: "parameterized", label: "Parameterized" },
-      { key: "fineGrained", label: "Fine-Grained" },
+      { key: "restriction", label: "Restriction" },
+      { key: "localReplacement", label: "Local Replacement" },
+      { key: "componentDesign", label: "Component Design" },
     ],
   },
   {
@@ -270,5 +278,17 @@ export const REDUCTION_COST_MAP = {
   Quadratic: "quadratic",
   Cubic: "cubic",
   HigherPolynomial: "higherPolynomial",
+  Unclassified: undefined,
+};
+
+// ReductionType (backend) -> Reduction Type option key (frontend). Direct
+// map, same convention as REDUCTION_COST_MAP. Targets the proof-technique
+// vocabulary ReduxISU/Redux#396 actually built, not the reduction-
+// complexity-theory vocabulary originally ratified — see the reductionType
+// facet's own comment above, TAXONOMY_REFERENCE.md §7, and issue #31.
+export const REDUCTION_TYPE_MAP = {
+  Restriction: "restriction",
+  LocalReplacement: "localReplacement",
+  ComponentDesign: "componentDesign",
   Unclassified: undefined,
 };


### PR DESCRIPTION
Issue:  #7 (T03 — Seed supplementalTags.js with the real problem names)
Branch: task/T03-seed-supplemental-tags

Changed:
  data/supplementalTags.js   (new)

Note: data/fixtures.js and data/taxonomy.js show as modified in this branch's
diff, but that is pre-existing uncommitted work from the (unrelated,
already-finished) reduction-type-retargeting task — I didn't touch either
file. It was sitting uncommitted on task/reduction-type-retarget (which has
zero commits ahead of main), and since that branch and this one share the
same base commit, git surfaces the same uncommitted diff on both. Confirmed
via `git diff origin/main` that I introduced no changes to those two files.

Exact 49 problem names captured (2026-09-02, https://redux.isu.edu/api/redux/, via Navigation/Batch/allProblems cross-referenced against allInfo's problemName field):

Feedback Arc Set, Bernstein Vazirani, Bin Packing, Clique, Clique Cover, Convex Hull, Cut, Deutsch, Deutsch Jozsa, DFA Acceptance, Directed Hamiltonian Path, 3-Dimensional Matching, Dominating Set, Edit Distance, Exact Cover, Graph Coloring, Hamiltonian Path, Hitting Set, Independent Set, 0-1 Integer Programming, Job Sequencing, Knapsack (Binary), Lossless Data Compression, Max Cut, Minimum Cut, Minimum Spanning Tree, Minimum S-T Cut, NFA Acceptance, Feedback Node Set, N-Queens, Partition, Prime Factorization, Pump Scheduling Cost Minimization, Pump Scheduling Emergency Resilience, SAT, 3SAT, Set Cover, Simon's Problem, Single Pair Shortest Path Problem, Single Source Shortest Path Problem, Steiner Tree, Strongly Connected Components, Subset Sum, Sudoku, Topological Sort, Traveling Salesperson, Unstructured Search, Vertex Cover, Weighted Cut

Done when — met:
- Problem-name list captured from a live query, pasted above (not guessed).
- All 49 problems have a problemType entry, copied from ReduxISU/Redux#396's branch (feature/tag-system-expansion-375-379, verified directly against Problems/**/*_Class.cs, not the PR description).
- computationalModel populated for all 49, confidently — no omissions needed this pass.
- Quantum complexity class present on exactly the 5 problems that need it (Deutsch, Deutsch Jozsa, Bernstein Vazirani → eqp; Simon's Problem, Unstructured Search → bqp), copied from the same #396 branch.
- visualStyle hand-researched for all 48 real visualization instances (35 resolved, 13 explicitly UNCLASSIFIED).
- Reduction Type: no entries anywhere in the file, per the 2026-09-02 retargeting decision (#31) — confirmed still correct.
- Header comment records the date, backend URL, and full key-shape rationale.

Done when — not applicable / superseded:
- TASKLIST.md's original "Reduction Type uses a reduction-keyed shape" item is obsolete — Reduction Type was retargeted to real backend data on 2026-09-02 and needs no overlay entry at all.

Decisions and assumptions:
1. Resolved a contradiction in this task's own prompt. The prompt opens by saying only problemType and computationalModel "need this file," and that the quantum half of Complexity Class is "not part of this file" — but its own later sections give detailed, explicit instructions to source and store Quantum Complexity Class values in this file, and to hand-research visualStyle for this file too. Every other source I checked (issue #7's full comment thread, issue #31, ARCHITECTURE.md, TAXONOMY_REFERENCE.md) consistently says this file carries four overlay concepts, not two: problemType, computationalModel, the quantum half of Complexity Class, and visualStyle — only Reduction Type was dropped. I went with the four-field version as the real requirement and treated the "only two" line as a drafting slip. Flagging this rather than silently picking.
2. Problem Type single-vs-multi-valued mismatch stayed theoretical. Checked all 49 of #396's problemType assignments directly — none declares more than one value, so there was nothing to raise back on #396 this round.
3. Prime Factorization's Computational Model is turingMachines, not quantumModels, despite Shor's Algorithm being one of its solvers — its formal definition is a plain classical decomposition problem, and a quantum solver existing doesn't change the problem's own model (same reasoning as SAT having a Grover-based solver without making SAT quantum). Worth a second look if that's not the intended convention.
4. 13 of 48 visualization instances left UNCLASSIFIED for visualStyle, after checking the actual ReduxISU/Redux_GUI renderer source (StandardSATSvgReact.js, StandardSetSvgReact.js) rather than guessing from the enum name: BooleanSatisfiability draws literal clause boxes joined by "∧" (fits neither Logic Gate Schematic nor BDD), SetD3 draws a literal nested-set diagram (fits neither Bipartite Factor Graph nor Voronoi Map), DynamicTable is the same open ambiguity fixtures.js's own 3-SAT "Assignment Table" already documents, and Unimplemented means no renderer exists at all. None of these were guessed into a bucket.
5. Live catalog has 49 problems, not the ~59 the issue/TASKLIST expected from the mockup. Not something this task can fix — just documenting the gap.
6. Real backend names differ from data/fixtures.js's Phase-1 sample keys: 3SAT (not 3-SAT), Knapsack (Binary) (not 0/1 Knapsack), Hamiltonian Path (not Hamiltonian Cycle), and no Circuit-SAT or General CNF-SAT exist in the real 49 at all. fixtures.js is Shell-phase-only and isn't wired to this file, so nothing breaks today — but whoever builds T23/useCatalogIndex should key off this file's real names, not fixtures.js's.
7. Created .env.local (gitignored, not in this diff) pointing at the live production backend, per the issue's setup step — needed to run the queries this task required.

Closes #7