### PR TITLE
T23: Build the catalog data hook

### DIFF
--- a/data/taxonomy.js
+++ b/data/taxonomy.js
@@ -292,3 +292,18 @@ export const REDUCTION_TYPE_MAP = {
   ComponentDesign: "componentDesign",
   Unclassified: undefined,
 };
+
+// SolverComplexityBucket (backend) -> Solver Complexity option key (frontend).
+// Direct map, same convention as the others above. The backend enum only
+// covers 3 of the 8 ratified buckets (TAXONOMY_REFERENCE.md §6) — Constant,
+// Logarithmic, Linear, Log-linear and Quadratic have no backend member yet,
+// so solvers that are actually one of those are over-bucketed into
+// Polynomial today. Sidebar checkboxes for the missing 5 legitimately show
+// (0) until the backend enum is extended; that's correct behavior, not a bug
+// in this map.
+export const SOLVER_COMPLEXITY_MAP = {
+  Polynomial: "polynomial",
+  Exponential: "exponential",
+  Factorial: "factorial",
+  Unclassified: undefined,
+};

--- a/hooks/useCatalogIndex.js
+++ b/hooks/useCatalogIndex.js
@@ -1,0 +1,256 @@
+// hooks/useCatalogIndex.js
+//
+// T23 (issue #32). Fetches the whole catalog from the real Redux backend and
+// turns it into the tag data every catalog component reads — same role
+// Redux_GUI's useProblemIndex.js plays there, adapted to this project's
+// 8-facet taxonomy and its real+overlay merge seam (mergeSupplementalTags.js,
+// T22/#31).
+//
+// -----------------------------------------------------------------------
+// Shape contract (read data/fixtures.js's header before changing either side)
+// -----------------------------------------------------------------------
+// Returns `{ index, loading, error }`. `index` is a `Map<problemName, tags>`
+// where `tags` matches data/fixtures.js's `FixtureProblem.tags` shape
+// exactly, key for key: every facet key from data/taxonomy.js's TAXONOMY
+// array, valued as an array of option keys (or, for computationalModel
+// only, a single option-key string — the one facet that's genuinely
+// single-valued per problem). A value with no known real or overlay value is
+// omitted from its array rather than appearing as a bare "Unclassified"
+// entry, matching fixtures.js's own convention and this issue's done-when.
+//
+// The Map is keyed by the real backend's human-readable `problemName`
+// (e.g. "Clique", "3SAT", "Deutsch Jozsa"), NOT the raw class/reflection
+// code Navigation/Batch/allProblems itself returns (e.g. "CLIQUE", "SAT3").
+// This deliberately diverges from Redux_GUI's useProblemIndex.js, which
+// keys by the raw code — done here because data/supplementalTags.js's
+// SUPPLEMENTAL_TAGS overlay and data/fixtures.js's sample entries are both
+// keyed by the same display name (confirmed by querying the live production
+// backend directly: all 49 of Navigation/Batch/allProblems's codes' `info[
+// code].problemName` values match SUPPLEMENTAL_TAGS's key list exactly), so
+// keying this Map the same way lets mergeSupplementalTags(problemName, ...)
+// be called with no separate name-translation step.
+//
+// -----------------------------------------------------------------------
+// Where each facet's value actually comes from
+// -----------------------------------------------------------------------
+// problemType, computationalModel, complexityClass — resolved by
+// mergeSupplementalTags(problemName, { complexityClass }) (T22/#31): prefers
+// a real backend value, falls back to the data/supplementalTags.js overlay,
+// falls back to Unclassified. Only complexityClass has a real backend value
+// today (the live backend has no problemType/computationalModel field yet —
+// confirmed against the live payload, not assumed).
+//
+// solverType, solverComplexity — aggregated across every solver the problem
+// declares (Navigation/Batch/allSolvers), reading each solver's own
+// Navigation/Batch/allInfo entry (`solverType`, `complexityBucket`) through
+// SOLVER_TYPE_MAP / SOLVER_COMPLEXITY_MAP.
+//
+// visualizationType — aggregated across every visualization the problem
+// declares (Navigation/Batch/allVisualizations), through
+// mergeVisualStyle(visualizationName, undefined) (T22/#31). This facet is
+// wholly overlay-driven per the #6 decision (TAXONOMY_REFERENCE.md §9) — the
+// backend's VisualizationType enum is a renderer-implementation contract,
+// not the conceptual style this facet shows, so no real value is ever passed
+// through here.
+//
+// reductionCost, reductionType — aggregated across every reduction edge
+// touching the problem (Navigation/Reductions), in either direction: a
+// reduction the problem has TO another problem and one FROM another problem
+// both count toward its own tags (matches fixtures.js's own 3-SAT entry,
+// which unions its reduces-to and reduces-from costs/types the same way).
+// reductionCost reads each edge's `cost` field through REDUCTION_COST_MAP.
+//
+// reductionType is written against the shape the live API is expected to
+// have once ReduxISU/Redux#396 merges (ARCHITECTURE.md's 2026-09-01 note:
+// "T23's backend-value translation step should be written against the
+// post-#396 shape... there is no reason to write it against a shape already
+// known to be temporary") — it reads `edge.reductionType` through
+// REDUCTION_TYPE_MAP. Flagged prominently: queried the live production
+// Navigation/Reductions endpoint directly while building this hook, and its
+// edges do not yet carry a reductionType field at all (only className,
+// endpoint, inputType, outputType, fromComplexity, toComplexity, cost) —
+// matching this repo's own lib/redux/index.js JSDoc for that endpoint, and
+// consistent with #396 still being unmerged. Nor is there a ported
+// single-item endpoint (requestReductionInfo) that carries it — T21 (#30)
+// deliberately left every non-batch request helper out, and Redux_GUI's own
+// reductionType value comes from exactly that non-batch endpoint, not from
+// the batch reduction graph. So reductionType legitimately comes back empty
+// for every problem today; the read is still written defensively (reads the
+// field if present) so nothing here needs to change the day the batch
+// endpoint actually grows it. See this task's handback summary.
+
+import { useEffect, useState } from "react";
+import { mergeSupplementalTags, mergeVisualStyle } from "../data/mergeSupplementalTags";
+import {
+  REDUCTION_COST_MAP,
+  REDUCTION_TYPE_MAP,
+  SOLVER_COMPLEXITY_MAP,
+  SOLVER_TYPE_MAP,
+  UNCLASSIFIED,
+} from "../data/taxonomy";
+import {
+  requestAllInfo,
+  requestAllProblems,
+  requestAllSolvers,
+  requestAllVisualizations,
+  requestReductionGraph,
+} from "../lib/redux";
+
+/**
+ * Flattens the reduction graph's `{ from: { to: [edge] } }` adjacency map
+ * into `Map<problemCode, edge[]>`, one entry per problem covering both
+ * directions it appears in (as the FROM problem and as the TO problem).
+ * @param {Object} reductionGraph Raw `requestReductionGraph` result.
+ * @returns {Map<string, Object[]>}
+ */
+function indexReductionEdgesByProblem(reductionGraph) {
+  const edgesByProblem = new Map();
+
+  const addEdge = (problemCode, edge) => {
+    if (!edgesByProblem.has(problemCode)) edgesByProblem.set(problemCode, []);
+    edgesByProblem.get(problemCode).push(edge);
+  };
+
+  for (const [fromProblem, toMap] of Object.entries(reductionGraph)) {
+    for (const [toProblem, edges] of Object.entries(toMap)) {
+      for (const edge of edges) {
+        addEdge(fromProblem, edge);
+        addEdge(toProblem, edge);
+      }
+    }
+  }
+
+  return edgesByProblem;
+}
+
+/**
+ * Builds one problem's full tags object (see file header for the shape
+ * contract and per-field sourcing).
+ * @param {string} problemCode Raw class/reflection code (e.g. "CLIQUE").
+ * @param {Object} info Full `requestAllInfo` result.
+ * @param {Object} solversByProblem Full `requestAllSolvers` result.
+ * @param {Object} visualizationsByProblem Full `requestAllVisualizations` result.
+ * @param {Map<string, Object[]>} reductionEdgesByProblem From `indexReductionEdgesByProblem`.
+ * @returns {{problemName: string, tags: Object}}
+ */
+function buildProblemTags(
+  problemCode,
+  info,
+  solversByProblem,
+  visualizationsByProblem,
+  reductionEdgesByProblem,
+) {
+  const problemInfo = info[problemCode] ?? {};
+  const problemName = problemInfo.problemName ?? problemCode;
+
+  const { problemType, computationalModel, complexityClass } = mergeSupplementalTags(problemName, {
+    complexityClass: problemInfo.complexityClass,
+  });
+
+  const solverType = new Set();
+  const solverComplexity = new Set();
+  for (const solverClassName of solversByProblem[problemCode] ?? []) {
+    const solverInfo = info[solverClassName];
+    const mappedType = SOLVER_TYPE_MAP[solverInfo?.solverType];
+    if (mappedType) solverType.add(mappedType);
+    const mappedComplexity = SOLVER_COMPLEXITY_MAP[solverInfo?.complexityBucket];
+    if (mappedComplexity) solverComplexity.add(mappedComplexity);
+  }
+
+  const visualizationType = new Set();
+  for (const visualizationClassName of visualizationsByProblem[problemCode] ?? []) {
+    const style = mergeVisualStyle(visualizationClassName, undefined);
+    if (style !== UNCLASSIFIED) visualizationType.add(style);
+  }
+
+  const reductionCost = new Set();
+  const reductionType = new Set();
+  for (const edge of reductionEdgesByProblem.get(problemCode) ?? []) {
+    const mappedCost = REDUCTION_COST_MAP[edge.cost];
+    if (mappedCost) reductionCost.add(mappedCost);
+    const mappedType = REDUCTION_TYPE_MAP[edge.reductionType];
+    if (mappedType) reductionType.add(mappedType);
+  }
+
+  return {
+    problemName,
+    tags: {
+      problemType,
+      computationalModel,
+      complexityClass,
+      solverType: Array.from(solverType),
+      solverComplexity: Array.from(solverComplexity),
+      reductionType: Array.from(reductionType),
+      reductionCost: Array.from(reductionCost),
+      visualizationType: Array.from(visualizationType),
+    },
+  };
+}
+
+/**
+ * Fetches the whole catalog and builds `Map<problemName, tags>` — see file
+ * header for the exact shape contract this must satisfy against
+ * data/fixtures.js.
+ *
+ * Calls each batch endpoint exactly once per mount (lib/redux/index.js's
+ * own in-memory cache also collapses any incidental repeat call, e.g. React
+ * StrictMode's double-invoke, into a single network request). No backend
+ * reachable -> the batch calls reject -> `error` is set and `index` stays
+ * the empty Map it started as, never a crash (#5).
+ *
+ * @param {string} url Base API URL, e.g. `/api/redux/`.
+ * @returns {{index: Map<string, Object>, loading: boolean, error: Error|null}}
+ */
+export function useCatalogIndex(url) {
+  const [index, setIndex] = useState(new Map());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [problemCodes, info, solversByProblem, visualizationsByProblem, reductionGraph] =
+          await Promise.all([
+            requestAllProblems(url),
+            requestAllInfo(url),
+            requestAllSolvers(url),
+            requestAllVisualizations(url),
+            requestReductionGraph(url),
+          ]);
+
+        if (cancelled) return;
+
+        const reductionEdgesByProblem = indexReductionEdgesByProblem(reductionGraph ?? {});
+
+        const map = new Map();
+        for (const problemCode of problemCodes ?? []) {
+          const { problemName, tags } = buildProblemTags(
+            problemCode,
+            info ?? {},
+            solversByProblem ?? {},
+            visualizationsByProblem ?? {},
+            reductionEdgesByProblem,
+          );
+          map.set(problemName, tags);
+        }
+
+        setIndex(map);
+      } catch (caughtError) {
+        if (!cancelled) setError(caughtError);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return { index, loading, error };
+}


### PR DESCRIPTION
Issue: #32 (T23 — Build the catalog data hook)
Branch: task/T23-catalog-data-hook

Changed:
  hooks/useCatalogIndex.js   (new)
  data/taxonomy.js           (added SOLVER_COMPLEXITY_MAP, which didn't exist yet)

What it does:
Fetches the whole catalog via lib/redux/index.js's batch functions (requestAllProblems,
requestAllInfo, requestAllSolvers, requestAllVisualizations, requestReductionGraph) and
builds Map<problemName, tags> matching data/fixtures.js's FixtureProblem.tags shape
exactly. problemType/computationalModel/complexityClass go through
mergeSupplementalTags (T22); visualizationType goes through mergeVisualStyle (T22);
solverType/solverComplexity/reductionCost/reductionType go through new translation
against real backend data (SOLVER_TYPE_MAP, the new SOLVER_COMPLEXITY_MAP,
REDUCTION_COST_MAP, REDUCTION_TYPE_MAP), aggregated per problem across all of its
solvers/visualizations/reduction edges.

Verified all field-shape assumptions (camelCase field names, exact JSON shape of
Navigation/Reductions edges, allInfo entry shapes) against the live production backend
(https://redux.isu.edu/api/redux/) directly rather than guessing from the ported JSDoc
comments alone — one of those comments turned out to be stale (requestAllProblems's
JSDoc says "an object mapping problem names"; it actually returns a plain array of
problem codes). Also ran the hook's core logic standalone against the live backend
(all 49 problems) to confirm the output shape and that no bare "Unclassified" string
ever leaks into a tags array.

Done when — met:
  - The returned shape matches data/fixtures.js's tags shape exactly, field for field.
  - No backend running gives an empty Map and no crash — the batch calls are wrapped in
    try/catch; a failure sets `error` and leaves `index` at its empty-Map initial state.
  - The batch endpoints are called once per mount via one Promise.all, not once per card
    (and lib/redux/index.js's own cachedRequest collapses any incidental repeat call,
    e.g. React StrictMode's double-invoke, into a single network request).
  - Unclassified values don't leak into any tags array — confirmed with a live-data run
    across all 49 problems, zero leaks. solverType/solverComplexity/reductionCost/
    reductionType map to `undefined` (skipped) for anything with no translation;
    visualizationType explicitly filters out mergeVisualStyle's UNCLASSIFIED fallback.

Done when — not met:
  - "All five backend-backed categories are populated from real data": four of five are
    (complexityClass, solverType, solverComplexity, reductionCost) — reductionType is
    not. Queried the live Navigation/Reductions endpoint directly: its edges carry only
    {className, endpoint, inputType, outputType, fromComplexity, toComplexity, cost} —
    no reductionType field, matching this repo's own lib/redux/index.js JSDoc for that
    endpoint. The only endpoint that does carry it (the single-item
    requestReductionInfo, which is what Redux_GUI's own reductionType display actually
    reads from) was deliberately not ported by T21 (#30) — T21's issue only asked for
    the 7 batch functions plus the 2 deferred solve/verify ones. So reductionType comes
    back as an empty array for every problem today. The code still reads
    `edge.reductionType` defensively and maps it through REDUCTION_TYPE_MAP, per
    ARCHITECTURE.md's instruction to write this translation step against the shape the
    live API will have once ReduxISU/Redux#396 merges — it'll start populating on its
    own the day the batch endpoint (or #396) actually adds the field, no code change
    needed here. Flagging rather than working around it by porting a new single-item
    request function, since that's outside T23's and T21's stated scope and would also
    violate the "batch endpoints only, not per-card" done-when if called per reduction.

Decisions and assumptions:
  - The Map is keyed by the real backend's human-readable `problemName` (e.g. "Clique",
    "3SAT"), not the raw class/reflection code (e.g. "CLIQUE", "SAT3") Redux_GUI's own
    useProblemIndex.js keys by. Deliberate divergence, documented in the file header:
    data/supplementalTags.js's overlay and data/fixtures.js's sample entries are both
    keyed by the display name, and querying the live backend confirmed all 49 problem
    codes' `info[code].problemName` values match supplementalTags.js's key list exactly
    — keying this Map the same way needs no separate name-translation step anywhere
    downstream.
  - Added `SOLVER_COMPLEXITY_MAP` to data/taxonomy.js — it didn't exist yet, and
    solverComplexity had no backend-to-frontend translation table despite being one of
    the five real-backed facets. Followed the exact same convention as the file's other
    maps (SOLVER_TYPE_MAP, REDUCTION_COST_MAP, REDUCTION_TYPE_MAP).
  - requestAllVerifiers and requestAllVisualizationTypes (2 of T21's 7 ported batch
    functions) are not called here — not needed for any of the 8 facets this hook
    computes. Left for whichever task needs them next (Verifier/Detail-page work, or a
    future need for the raw renderer-technology value).
  - reductionCost/reductionType aggregation counts a reduction in either direction (the
    problem as the FROM side and as the TO side) toward that problem's own tags —
    matches data/fixtures.js's own 3-SAT entry, which unions its reduces-to and
    reduces-from costs/types into one tag set the same way.

Checks:
  - npm run lint: clean
  - npm run format: clean (one file auto-reformatted by Biome, a multiline destructure
    reflow, no logic change)
  - npm run build: clean

Closes #32