### PR TITLE
T24: Build the catalog filters hook

### DIFF
--- a/hooks/useCatalogFilters.js
+++ b/hooks/useCatalogFilters.js
@@ -1,0 +1,140 @@
+// hooks/useCatalogFilters.js
+//
+// T24 (issue #33). The filtering/counting logic behind the Home page's
+// sidebar + search + grid, extracted into a reusable hook so it can run
+// against useCatalogIndex()'s real `Map<problemName, tags>` (T23/#32)
+// instead of pages/index.js's current inline copy against
+// data/fixtures.js's FIXTURE_PROBLEMS array. T25 (#34) is the task that
+// actually swaps pages/index.js over to this hook; this file only has to
+// produce the same results the inline logic already does, against the
+// index-Map shape instead of the fixture-array shape.
+//
+// Port of Redux_GUI's useProblemFilters.js + facetOptions.js
+// (`buildFacetOptions`), extended from that project's 4 facets to this
+// project's full 8-facet data/taxonomy.js set — same pattern pages/index.js's
+// own header comment already documents:
+//
+// Filtering: AND across facets, OR within a facet's own selected options,
+// search substring-ANDed in on top. Matching is driven by each tag's actual
+// runtime shape (Array.isArray), not data/taxonomy.js's `multiValued` flag:
+// solverComplexity, reductionType, reductionCost and visualizationType are
+// all stored as arrays at the problem level (aggregated across a problem's
+// several solver/reduction/visualization instances) despite being
+// `multiValued: false` — only computationalModel is truly a bare string.
+// Keying off `multiValued` instead would silently break OR-matching for
+// those four facets.
+//
+// Facet option counts are computed against the FULL index, not the
+// currently-filtered results — "how many problems if I add this filter,"
+// the same choice pages/index.js's own buildFacetOptions already made (its
+// header comment flags that TASKLIST.md's T14 entry doesn't settle this
+// either way).
+//
+// `matchedTags` is exposed as `selected` itself, unchanged: #70's decision
+// (recorded on ProblemCatalogCard.js) is that a card on screen already
+// matches every active facet selection, so there's no need to compute a
+// narrower per-card intersection — every selected option is a "matched tag"
+// for every visible card.
+//
+// This hook does not know about `slug` — useCatalogIndex()'s Map is keyed
+// by `problemName` only (T23/#32), so `results` here is `{ name, tags }`
+// pairs, not full fixture-shaped problem objects. Reconciling that with
+// whatever route/slug metadata the real catalog needs is T25's job, not
+// this hook's.
+
+import { useMemo } from "react";
+import { TAXONOMY } from "../data/taxonomy";
+
+/**
+ * @param {*} tagValue Either an array of option keys or a single option-key
+ *   string (only computationalModel is ever a bare string — see file header).
+ * @returns {string[]}
+ */
+function tagValueAsArray(tagValue) {
+  if (Array.isArray(tagValue)) {
+    return tagValue;
+  }
+  return tagValue == null ? [] : [tagValue];
+}
+
+// A problem matches a facet's active selection if ANY selected option is
+// present in its tag value for that facet — whether that tag value is one
+// array (OR across the array) or a single string (plain equality). A facet
+// with nothing selected imposes no constraint.
+function matchesSelectedFacets(tags, selected) {
+  for (const facet of TAXONOMY) {
+    const selectedOptions = selected[facet.key];
+    if (!selectedOptions || selectedOptions.size === 0) {
+      continue;
+    }
+    const tagValues = tagValueAsArray(tags[facet.key]);
+    const matches = tagValues.some((optionKey) => selectedOptions.has(optionKey));
+    if (!matches) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Per-option counts across the whole index (not just the filtered results —
+// see file header). Every option gets an entry, including ones with count 0
+// (issue done-when: "Counts render for every option including (0)").
+function buildFacetOptions(index) {
+  const facetOptions = {};
+  for (const facet of TAXONOMY) {
+    facetOptions[facet.key] = facet.options.map((option) => {
+      let count = 0;
+      for (const tags of index.values()) {
+        const tagValues = tagValueAsArray(tags[facet.key]);
+        if (tagValues.includes(option.key)) {
+          count += 1;
+        }
+      }
+      return { key: option.key, label: option.label, count };
+    });
+  }
+  return facetOptions;
+}
+
+/**
+ * @param {Map<string, Object>} index `Map<problemName, tags>` —
+ *   useCatalogIndex()'s (T23/#32) return shape, or an equivalent empty Map
+ *   while loading/unreachable (ground rule 6: empty Map in, empty results
+ *   out, never a crash).
+ * @param {Object} [options]
+ * @param {Object} [options.selected] `{ [facetKey]: Set<optionKey> }` — the
+ *   same shape FacetSidebar's `selected` prop already uses.
+ * @param {string} [options.searchValue] Free-text search-by-name term,
+ *   matched as a case-insensitive substring of the problem name.
+ * @returns {{
+ *   results: Array<{name: string, tags: Object}>,
+ *   facetOptions: Object,
+ *   matchedTags: Object,
+ * }}
+ *   `results` — problems passing both the search term and every active facet
+ *   selection, in the index's own iteration order.
+ *   `facetOptions` — `{ [facetKey]: [{key, label, count}] }`, counted against
+ *   the full index per option, ready for FacetSidebar's `facetOptions` prop.
+ *   `matchedTags` — `selected` passed through unchanged, ready for
+ *   ProblemCatalogCard's `matchedTags` prop (see file header).
+ */
+export function useCatalogFilters(index, { selected = {}, searchValue = "" } = {}) {
+  const facetOptions = useMemo(() => buildFacetOptions(index), [index]);
+
+  const results = useMemo(() => {
+    const query = searchValue.trim().toLowerCase();
+    const matched = [];
+    for (const [name, tags] of index.entries()) {
+      if (query && !name.toLowerCase().includes(query)) {
+        continue;
+      }
+      if (!matchesSelectedFacets(tags, selected)) {
+        continue;
+      }
+      matched.push({ name, tags });
+    }
+    return matched;
+  }, [index, selected, searchValue]);
+
+  return { results, facetOptions, matchedTags: selected };
+}


### PR DESCRIPTION
Issue:  #33 (T24 - Build the catalog filters hook)
Branch: task/T24-catalog-filters-hook

Changed:
  hooks/useCatalogFilters.js   (new)

What it does:
Extracts the OR-within-facet/AND-across-facets filtering and per-option
counting logic that pages/index.js currently implements inline against
data/fixtures.js's FIXTURE_PROBLEMS array, into a reusable hook that runs
against useCatalogIndex()'s (T23/#32) real Map<problemName, tags> shape
instead. Same matching rule pages/index.js's own header comment already
documents: match on each tag's actual runtime shape (Array.isArray), not
taxonomy.js's multiValued flag, since solverComplexity/reductionType/
reductionCost/visualizationType are all stored as arrays at the problem
level despite being multiValued: false.

useCatalogFilters(index, { selected, searchValue }) returns:
  - results: [{ name, tags }] passing the search term and every active
    facet selection, AND across facets / OR within a facet.
  - facetOptions: { [facetKey]: [{key, label, count}] }, counted against
    the full index (not just the filtered results), matching the "how many
    if I add this filter" convention pages/index.js's own buildFacetOptions
    already chose.
  - matchedTags: selected itself, unchanged - matches the #70 decision
    already recorded on ProblemCatalogCard.js (a card on screen already
    matches every active selection, so no narrower per-card intersection is
    needed).

Done when, met:
  - Two selections in one category widen results; selections across two
    categories narrow them (matchesSelectedFacets: OR within a facet's
    selected Set, AND across facets).
  - Counts render for every option including (0): buildFacetOptions maps
    every taxonomy.js option unconditionally, not just ones with a match.
  - Multi-valued facets (Problem Type, Solver Type, and the other
    array-shaped facets) match if any of a problem's values match.
  - The hook exposes the flat set of matched values (matchedTags) for
    ProblemCatalogCard's checkmark treatment.
  - Filtering ~59 problems across the taxonomy recomputes without visible
    lag: plain O(problems x facets) work behind useMemo, trivial at this
    scale, same approach pages/index.js's existing inline version already
    used at 12 fixture problems.

Decisions and assumptions:
  - The hook consumes the Map<problemName, tags> shape useCatalogIndex()
    (T23/#32) actually returns, which carries no slug or other display
    metadata. So `results` here is [{ name, tags }] pairs, not full
    fixture-shaped problem objects with a slug field. Reconciling that with
    whatever route/slug metadata the real catalog needs is T25's (#34) job
    when it wires pages/index.js to this hook and useCatalogIndex - not a
    gap in this task, since T24's own done-when only asks about filtering
    and counts.
  - The issue body's last done-when item says "nine categories," but
    data/taxonomy.js ratifies only 8 sidebar facets (2026-09-01 decision:
    the separate Quantum Complexity Class facet was merged into Complexity
    Class, dropping the count from 9 to 8 - see ARCHITECTURE.md and
    taxonomy.js's own header comments). Treated as the same stale
    pre-decision count already flagged elsewhere in the docs, not a new
    scope question; the hook iterates data/taxonomy.js's actual TAXONOMY
    array either way, so it automatically tracks whatever that file says.
  - facetOptions counts are computed against the whole index, not the
    currently-filtered results, matching the choice pages/index.js's own
    buildFacetOptions already made (that file's header comment notes
    TASKLIST.md's T14 entry doesn't settle this either way). Kept it
    consistent rather than introducing a second convention.

Checks:
  - npm run lint: clean
  - npm run format: clean (no fixes needed)
  - npm run build: clean

Closes #33