### PR TITLE
T26: Switch the problem detail page to real data

### DIFF
--- a/hooks/useProblemDetail.js
+++ b/hooks/useProblemDetail.js
@@ -1,0 +1,270 @@
+// hooks/useProblemDetail.js
+//
+// T26 (issue #35). Fetches one problem's full detail-page data from the real
+// Redux backend and assembles it into the same shape data/fixtures.js's
+// FixtureProblem uses, so pages/[problem].js and every components/detail/*
+// section can consume it unchanged.
+//
+// -----------------------------------------------------------------------
+// Why this can't just reuse useCatalogIndex (T23/#32)
+// -----------------------------------------------------------------------
+// useCatalogIndex only builds the 8-facet `tags` object every card needs.
+// It deliberately does not build overview/solvers/visualizations/verifier/
+// reductions -- data/fixtures.js's own header says that convenience shape
+// is this task's job, not T23's. So this hook fetches the same five batch
+// endpoints independently and assembles the detail-page shape from them.
+//
+// -----------------------------------------------------------------------
+// Problem name -> problem code
+// -----------------------------------------------------------------------
+// The route gives this hook a problem's human-readable display name (e.g.
+// "Clique"), matching how a card would link to it. But every batch endpoint
+// except allInfo's own problemName field is keyed by the class/reflection
+// code (e.g. "CLIQUE") -- allProblems returns codes, and allSolvers/
+// allVerifiers/allVisualizations/the reduction graph are all keyed by code
+// too (confirmed directly against Redux's Nav_Solvers.cs/Nav_Verifiers.cs/
+// Nav_Reductions.cs: their `problemName` entry field is actually
+// `problemType.Name`, the code, despite the field's name). So this hook
+// resolves the given display name to its code via allInfo[code].problemName
+// before it can look anything else up -- same code/name distinction
+// useCatalogIndex.js's own header documents.
+//
+// -----------------------------------------------------------------------
+// Overview's Input/Output mapping (this task's most interpretive call)
+// -----------------------------------------------------------------------
+// The ratified UI wants explicit `Input:`/`Output:` fields, not the formal
+// set-notation definition (ARCHITECTURE.md, issue #6 conflict C3). The real
+// backend has no field that is literally "Input" or "Output" -- IProblem's
+// closest fields are `instanceFormat` ("a short descriptive sentence with
+// an embedded concrete example" of a valid instance) and `certificateFormat`
+// (the same, for a valid certificate). Both default to "" and are populated
+// on only 12 of ~49 problems today (confirmed against Redux/Problems/**).
+// `problemDefinition` (free-text, always populated -- it's a required
+// interface member, not a defaulted one) is the fallback for Input so the
+// field isn't blank for the other 37. Output has no such fallback: rather
+// than fabricate a generic "True or False"-style answer that isn't true for
+// every problem in the catalog, Output stays undefined (renders "Not yet
+// documented"-style blank via OverviewSection) when certificateFormat is
+// unset. See this task's handback summary for the alternative considered
+// and rejected (a generic decision-problem answer sentence).
+
+import { useEffect, useState } from "react";
+import { mergeSupplementalTags, mergeVisualStyle } from "../data/mergeSupplementalTags";
+import {
+  REDUCTION_COST_MAP,
+  REDUCTION_TYPE_MAP,
+  SOLVER_COMPLEXITY_MAP,
+  SOLVER_TYPE_MAP,
+} from "../data/taxonomy";
+import {
+  requestAllInfo,
+  requestAllProblems,
+  requestAllSolvers,
+  requestAllVerifiers,
+  requestAllVisualizations,
+  requestReductionGraph,
+} from "../lib/redux";
+
+// Detail-page-only identifier, used solely to keep element ids unique
+// (VerifierSection's certificate input/button ids) -- unrelated to routing,
+// which matches on the real problem name (see pages/[problem].js).
+function slugify(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+function buildSolvers(solverClassNames, info) {
+  return (solverClassNames ?? []).map((className) => {
+    const solverInfo = info[className] ?? {};
+    return {
+      name: solverInfo.solverName ?? className,
+      type: SOLVER_TYPE_MAP[solverInfo.solverType],
+      complexityBucket: SOLVER_COMPLEXITY_MAP[solverInfo.complexityBucket],
+      bigO: solverInfo.complexity || undefined,
+    };
+  });
+}
+
+function buildVisualizations(visualizationClassNames, info) {
+  return (visualizationClassNames ?? []).map((className) => {
+    const visualizationInfo = info[className] ?? {};
+    return {
+      name: visualizationInfo.visualizationName ?? className,
+      type: mergeVisualStyle(className, undefined),
+      caption: visualizationInfo.visualizationDefinition ?? "",
+    };
+  });
+}
+
+// Generic "Default Verifier" naming convention (ARCHITECTURE.md's Naming
+// convention section) -- a problem can declare more than one verifier class,
+// but the detail page shows exactly one, so this always takes the first.
+function buildVerifier(verifierClassNames, info, problemInfo) {
+  const [firstVerifierClassName] = verifierClassNames ?? [];
+  if (!firstVerifierClassName) return null;
+
+  const verifierInfo = info[firstVerifierClassName] ?? {};
+  return {
+    certificateDescription: verifierInfo.verifierDefinition ?? "",
+    certificateFormat: problemInfo.certificateFormat || "",
+    exampleCertificate: verifierInfo.certificate || undefined,
+  };
+}
+
+function buildReductions(problemCode, reductionGraph, codeToName) {
+  const to = [];
+  const from = [];
+
+  for (const [fromCode, toMap] of Object.entries(reductionGraph)) {
+    for (const [toCode, edges] of Object.entries(toMap)) {
+      for (const edge of edges) {
+        if (fromCode === problemCode) {
+          to.push({
+            target: codeToName.get(toCode) ?? toCode,
+            cost: REDUCTION_COST_MAP[edge.cost],
+            type: REDUCTION_TYPE_MAP[edge.reductionType],
+          });
+        }
+        if (toCode === problemCode) {
+          from.push({
+            source: codeToName.get(fromCode) ?? fromCode,
+            cost: REDUCTION_COST_MAP[edge.cost],
+            type: REDUCTION_TYPE_MAP[edge.reductionType],
+          });
+        }
+      }
+    }
+  }
+
+  return { to, from };
+}
+
+function buildProblem(problemCode, info, batches, codeToName) {
+  const problemInfo = info[problemCode] ?? {};
+  const { solversByProblem, verifiersByProblem, visualizationsByProblem, reductionGraph } = batches;
+
+  const contributors = Array.isArray(problemInfo.contributors) ? problemInfo.contributors : [];
+
+  // Only the badge row (pages/[problem].js's H1 complexity/problem-type
+  // chips) reads `tags`, and only these two facets -- same real-value-then-
+  // overlay-then-Unclassified precedence useCatalogIndex.js uses for the
+  // whole catalog, called here with just this one problem's own
+  // complexityClass so the detail page's badges can never disagree with the
+  // card grid's for the same problem.
+  const tags = mergeSupplementalTags(problemInfo.problemName ?? problemCode, {
+    complexityClass: problemInfo.complexityClass,
+  });
+
+  return {
+    name: problemInfo.problemName ?? problemCode,
+    slug: slugify(problemInfo.problemName ?? problemCode),
+    oneLiner: problemInfo.problemDefinition ?? "",
+    tags,
+    overview: {
+      input: problemInfo.instanceFormat || problemInfo.problemDefinition || undefined,
+      output: problemInfo.certificateFormat || undefined,
+      source: problemInfo.source || undefined,
+      contributedBy: contributors.length > 0 ? contributors.join(", ") : undefined,
+    },
+    solvers: buildSolvers(solversByProblem[problemCode], info),
+    visualizations: buildVisualizations(visualizationsByProblem[problemCode], info),
+    verifier: buildVerifier(verifiersByProblem[problemCode], info, problemInfo),
+    reductions: buildReductions(problemCode, reductionGraph, codeToName),
+  };
+}
+
+/**
+ * Fetches and assembles one problem's full detail-page data -- see file
+ * header for the shape contract (matches data/fixtures.js's FixtureProblem)
+ * and the name/code resolution and Overview-mapping notes.
+ *
+ * No backend reachable, or `problemName` matches no real problem -> `error`
+ * is set or `problem` stays null, never a crash (#5) -- pages/[problem].js
+ * renders its existing "not found" state either way.
+ *
+ * @param {string} url Base API URL, e.g. `/api/redux/`.
+ * @param {string|null} problemName Exact real problem display name (e.g.
+ *   "Clique"), or null/undefined while the route param isn't known yet.
+ * @returns {{problem: Object|null, loading: boolean, error: Error|null}}
+ */
+export function useProblemDetail(url, problemName) {
+  const [problem, setProblem] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      if (!problemName) {
+        if (!cancelled) {
+          setProblem(null);
+          setLoading(false);
+          setError(null);
+        }
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [
+          problemCodes,
+          info,
+          solversByProblem,
+          verifiersByProblem,
+          visualizationsByProblem,
+          reductionGraph,
+        ] = await Promise.all([
+          requestAllProblems(url),
+          requestAllInfo(url),
+          requestAllSolvers(url),
+          requestAllVerifiers(url),
+          requestAllVisualizations(url),
+          requestReductionGraph(url),
+        ]);
+
+        if (cancelled) return;
+
+        const safeInfo = info ?? {};
+        const codeToName = new Map();
+        for (const code of problemCodes ?? []) {
+          codeToName.set(code, safeInfo[code]?.problemName ?? code);
+        }
+
+        const problemCode = (problemCodes ?? []).find(
+          (code) => codeToName.get(code) === problemName,
+        );
+
+        if (!problemCode) {
+          setProblem(null);
+          return;
+        }
+
+        setProblem(
+          buildProblem(
+            problemCode,
+            safeInfo,
+            {
+              solversByProblem: solversByProblem ?? {},
+              verifiersByProblem: verifiersByProblem ?? {},
+              visualizationsByProblem: visualizationsByProblem ?? {},
+              reductionGraph: reductionGraph ?? {},
+            },
+            codeToName,
+          ),
+        );
+      } catch (caughtError) {
+        if (!cancelled) setError(caughtError);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url, problemName]);
+
+  return { problem, loading, error };
+}

--- a/pages/[problem].js
+++ b/pages/[problem].js
@@ -6,23 +6,31 @@
 //
 // Route sits at the top level (`/{slug}`, not `/catalog/{slug}`) per
 // ARCHITECTURE.md's Directory / Route Structure section — this project's
-// only job is the catalog. Resolves against data/fixtures.js's `slug`
-// field, not the raw display name: ProblemCatalogCard already links to
-// `/${problem.slug}` (e.g. "/3-sat"), so matching on slug is what makes a
-// card's own link actually land here.
+// only job is the catalog.
 //
-// No getStaticProps/getStaticPaths — same plain-fixture-import pattern as
-// pages/index.js. useRouter().query.problem resolves once the router is
-// ready; nothing here fetches data server-side (T26 is the real-data
-// wiring task; this page stays a one-line swap away from it per T09's
-// fixture-shape contract).
+// T26 (#35) real-data wiring: the route segment is the problem's real
+// display name (e.g. "3SAT" resolves against Navigation/Batch/allInfo's
+// `problemName` field via useProblemDetail), not a fixture-only `slug` --
+// the real backend has no slug concept (confirmed: no field on IProblem
+// resembles one). Next.js decodes the route segment automatically, so a
+// name with spaces or punctuation arrives here already readable; nothing
+// further needs decoding. ProblemCatalogCard's own link generation
+// (currently `/${problem.slug}` against fixture data) is T25's concern, not
+// this page's -- until T25 lands, Home's card links and this resolution
+// step are built from two different data sources, a known transient gap
+// (see this task's handback summary).
+//
+// No getStaticProps/getStaticPaths. useRouter().query.problem resolves once
+// the router is ready; useProblemDetail then fetches client-side.
 //
 // Per #6 item 4 / components/StatusIcon.js's isProblemComplete(): an
 // "incomplete" (grey-status) problem's detail page is unreachable by
 // direct URL, not just hidden from the card grid (TASKLIST.md's T13 entry:
-// "the detail page is not accessible (by URL either)"). So a slug that
-// resolves to a real but incomplete fixture renders the same not-found
-// state as an unknown slug, rather than a half-declared page.
+// "the detail page is not accessible (by URL either)"). So a name that
+// resolves to a real but incomplete problem renders the same not-found
+// state as an unknown name, rather than a half-declared page. A backend
+// error is folded into the same not-found state for now -- T29 (#38) is
+// where a dedicated error banner (#5) gets built site-wide.
 
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
@@ -33,8 +41,11 @@ import Breadcrumb from "../components/Breadcrumb";
 import NavBar from "../components/NavBar";
 import ProblemDetailLayout from "../components/ProblemDetailLayout";
 import { isProblemComplete } from "../components/StatusIcon";
-import { getFixtureProblemBySlug } from "../data/fixtures";
 import { TAXONOMY } from "../data/taxonomy";
+import { useProblemDetail } from "../hooks/useProblemDetail";
+
+// Same same-origin proxy base lib/redux/index.js's own JSDoc documents.
+const API_BASE_URL = "/api/redux/";
 
 // Badge row order per the mockup (NP-Complete, NP, Boolean Logic): complexity
 // badges first, then problem type. Same chip-family naming as
@@ -102,16 +113,21 @@ function NotFound() {
 
 export default function ProblemDetail() {
   const router = useRouter();
-  const { problem: slug } = router.query;
+  const { problem: routeProblemName } = router.query;
 
-  // Before the router hydrates, `query` is empty on every route — render
-  // just the chrome rather than guessing, so a fast unknown-slug flash never
-  // briefly shows the not-found state for a slug that's actually valid.
-  if (!router.isReady) {
+  const { problem, loading } = useProblemDetail(
+    API_BASE_URL,
+    typeof routeProblemName === "string" ? routeProblemName : null,
+  );
+
+  // Before the router hydrates, `query` is empty on every route, and while
+  // useProblemDetail's fetch is still in flight — render just the chrome
+  // rather than guessing in either case, so a fast unknown-name flash never
+  // briefly shows the not-found state for a name that's actually valid, and
+  // the page never briefly shows a wrong/empty detail view either.
+  if (!router.isReady || loading) {
     return <PageShell />;
   }
-
-  const problem = typeof slug === "string" ? getFixtureProblemBySlug(slug) : null;
 
   if (!problem || !isProblemComplete(problem)) {
     return <NotFound />;


### PR DESCRIPTION
Issue:  #35 (T26 - Switch the detail page to real data)
Branch: task/T26-detail-page-real-data

Changed:
  hooks/useProblemDetail.js   (new) - fetches allInfo/allSolvers/allVerifiers/
                               allVisualizations/Navigation-Reductions for one
                               problem and assembles it into the exact shape
                               data/fixtures.js's FixtureProblem uses.
  pages/[problem].js          - swapped getFixtureProblemBySlug for
                               useProblemDetail; route now resolves against the
                               real problem's display name instead of a
                               fixture-only slug; added a loading gate so the
                               page never flashes "not found" while the fetch
                               is in flight.

Done when, met:
  - All five sections show real declared data for a real problem (Overview,
    Visualizations, Solvers, Verifier, Reductions all wired to their batch
    endpoints; no changes needed to the section components themselves, they
    already matched the fixture contract this hook now produces).
  - Overview shows Input/Output fields, not the raw formal-definition blob
    (see Decisions below for exactly what backend fields feed them).
  - A problem missing a verifier/visualizations/reductions still renders:
    buildVerifier returns null on no declared verifier, the others default to
    empty arrays - same "empty but intact" pattern the components already had.
  - Problem names with spaces/punctuation work in the URL: Next.js decodes
    the route segment automatically, resolution is an exact string match
    against the real problemName, no manual encode/decode needed.
  - An unknown problem name still shows the "not found" page (folds a
    backend error into the same state for now - see Decisions).

Done when, not met: none. All five boxes are covered.

Decisions and assumptions (this issue left the field-level mapping open):

  1. Overview Input/Output mapping. The real backend has no field literally
     called "Input" or "Output". IProblem's closest fields are
     instanceFormat and certificateFormat - both free-text with an
     embedded example, but both default to "" and are populated on only 12
     of ~49 problems today (checked directly against Redux/Problems/**).
     Input = instanceFormat, falling back to the always-populated
     problemDefinition when instanceFormat is empty. Output = certificateFormat,
     left undefined (renders blank, not fabricated) when unset - considered
     and rejected inventing a generic "True or False"-style sentence for every
     problem, since that isn't actually true for all of them and the project's
     own architecture doc is explicit about not inventing mock data. Worth a
     look from the project owner if a nicer Output fallback is wanted.

  2. Tags on the assembled problem. The detail page's H1 badge row reads
     problem.tags.complexityClass/.problemType. Rather than duplicate
     useCatalogIndex's full tag-aggregation logic (or call that whole-catalog
     hook a second time just for two fields), useProblemDetail calls
     mergeSupplementalTags directly with just this problem's own
     complexityClass - same precedence rule, so these badges can't disagree
     with the card grid's for the same problem once T25 lands.

  3. Verifier: a problem can declare more than one verifier class; the
     section always shows the first one, per the ratified generic
     "Default Verifier" naming convention (no problem currently declares more
     than one in the data inspected, so this hasn't been exercised against a
     real multi-verifier problem).

  4. Known integration gap, not fixed here (out of T26's scope): Home's
     ProblemCatalogCard still links to /${problem.slug} from fixture data
     (T25 hasn't landed). This page now resolves on the real problem's
     display name, not a slug - until T25 switches Home to real data too, a
     card click from today's fixture-backed Home page won't resolve here.
     Flagged in both files' headers.

  5. Backend-unreachable / not-found are folded into one state for now. The
     issue's own scope note says the dedicated error banner is T29's job
     (T29 depends on both T25 and T26); this page currently shows the
     same "Problem not found" screen for an unreachable backend and a
     genuinely unknown name, rather than distinguishing them.

Checks:
  - npm run lint: clean
  - npm run format: clean (no fixes needed)
  - npm run build: clean
  - Verified the page returns 200 and serves without server errors with no
    backend running (dev server, no REDUX_BASE_URL reachable) - confirms
    ground rule 6 (no crash on empty/failed catalog) holds for this page too.

Closes #35
