### PR TITLE
T25: Switch the Home page to real data

### DIFF
--- a/components/ProblemCatalogCard.js
+++ b/components/ProblemCatalogCard.js
@@ -3,15 +3,22 @@
 // T12 (#16) — one card in the Home page grid: problem name, status icon, and
 // three rows of derived tag badges (Complexity, Solver Type, Problem Type).
 //
-// The whole card is a link to the problem's detail page (`/${problem.slug}`,
-// ARCHITECTURE.md's top-level route structure) -- but only when the problem
-// is complete. #6 item 4 (2026-08-31) ratifies that an incomplete problem's
-// detail page must not be reachable at all, so #16's 2026-08-31 comment
-// requires an incomplete card to render as genuinely non-interactive: not a
-// link, not a tab stop, visibly distinct -- not a link that swallows the
-// click. isProblemComplete() (components/StatusIcon.js) is the one place
+// The whole card is a link to the problem's detail page -- but only when the
+// problem is complete. #6 item 4 (2026-08-31) ratifies that an incomplete
+// problem's detail page must not be reachable at all, so #16's 2026-08-31
+// comment requires an incomplete card to render as genuinely non-interactive:
+// not a link, not a tab stop, visibly distinct -- not a link that swallows
+// the click. isProblemComplete() (components/StatusIcon.js) is the one place
 // that predicate lives; this file imports it rather than re-deriving "has a
 // solver/visualization/verifier" on its own.
+//
+// T25 (#34): the link target is `/${encodeURIComponent(problem.name)}`, not
+// `/${problem.slug}` -- the real backend has no slug concept, and T26
+// (#35)'s pages/[problem].js resolves its route param against the real
+// problem's display name (Next.js decodes the segment automatically before
+// the match, so no manual decoding is needed on that end either). `slug`
+// itself is kept, but only as the id-safe basis for this card's own
+// `key`/`id` (see toCardProblem in pages/index.js), never for routing.
 //
 // No visual reference exists for the non-interactive treatment: both Home
 // mockups predate the 2026-08-31 amendment that introduced the rule. The
@@ -125,7 +132,9 @@ export default function ProblemCatalogCard({ problem, matchedTags = {} }) {
     <Paper
       id={`problem-card-${problem.slug}`}
       aria-label={problem.name}
-      {...(complete ? { component: Link, href: `/${problem.slug}` } : { component: "div" })}
+      {...(complete
+        ? { component: Link, href: `/${encodeURIComponent(problem.name)}` }
+        : { component: "div" })}
       sx={{
         display: "block",
         p: 2,

--- a/hooks/useCatalogIndex.js
+++ b/hooks/useCatalogIndex.js
@@ -9,14 +9,24 @@
 // -----------------------------------------------------------------------
 // Shape contract (read data/fixtures.js's header before changing either side)
 // -----------------------------------------------------------------------
-// Returns `{ index, loading, error }`. `index` is a `Map<problemName, tags>`
-// where `tags` matches data/fixtures.js's `FixtureProblem.tags` shape
-// exactly, key for key: every facet key from data/taxonomy.js's TAXONOMY
-// array, valued as an array of option keys (or, for computationalModel
-// only, a single option-key string — the one facet that's genuinely
-// single-valued per problem). A value with no known real or overlay value is
-// omitted from its array rather than appearing as a bare "Unclassified"
-// entry, matching fixtures.js's own convention and this issue's done-when.
+// Returns `{ index, completeness, loading, error }`. `index` is a
+// `Map<problemName, tags>` where `tags` matches data/fixtures.js's
+// `FixtureProblem.tags` shape exactly, key for key: every facet key from
+// data/taxonomy.js's TAXONOMY array, valued as an array of option keys (or,
+// for computationalModel only, a single option-key string — the one facet
+// that's genuinely single-valued per problem). A value with no known real or
+// overlay value is omitted from its array rather than appearing as a bare
+// "Unclassified" entry, matching fixtures.js's own convention and this
+// issue's done-when.
+//
+// `completeness` is a same-keyed `Map<problemName, {hasSolver,
+// hasVisualization, hasVerifier}>` — added by T25 (#34) so Home's cards can
+// drive components/StatusIcon.js's isProblemComplete() rule from real
+// declared-item presence, since `tags` alone can't: a solver/visualization
+// with a backend type this hook doesn't map to a taxonomy option is still a
+// declared item for completeness purposes even though it contributes
+// nothing to `tags`. Deliberately a second Map rather than extra keys on
+// `tags` itself, so the shape contract above stays exact.
 //
 // The Map is keyed by the real backend's human-readable `problemName`
 // (e.g. "Clique", "3SAT", "Deutsch Jozsa"), NOT the raw class/reflection
@@ -92,6 +102,7 @@ import {
   requestAllInfo,
   requestAllProblems,
   requestAllSolvers,
+  requestAllVerifiers,
   requestAllVisualizations,
   requestReductionGraph,
 } from "../lib/redux";
@@ -188,6 +199,28 @@ function buildProblemTags(
 }
 
 /**
+ * Presence-only signal for StatusIcon's isProblemComplete() rule (at least
+ * one declared solver, visualization and verifier) — deliberately raw
+ * declared-item counts, not the tags object above. A solver/visualization
+ * whose backend-reported type has no entry in SOLVER_TYPE_MAP /
+ * mergeVisualStyle's own fallback is still a declared solver/visualization
+ * for completeness purposes even though it contributes nothing to `tags`.
+ * @returns {{hasSolver: boolean, hasVisualization: boolean, hasVerifier: boolean}}
+ */
+function buildCompleteness(
+  problemCode,
+  solversByProblem,
+  visualizationsByProblem,
+  verifiersByProblem,
+) {
+  return {
+    hasSolver: (solversByProblem[problemCode]?.length ?? 0) > 0,
+    hasVisualization: (visualizationsByProblem[problemCode]?.length ?? 0) > 0,
+    hasVerifier: (verifiersByProblem[problemCode]?.length ?? 0) > 0,
+  };
+}
+
+/**
  * Fetches the whole catalog and builds `Map<problemName, tags>` — see file
  * header for the exact shape contract this must satisfy against
  * data/fixtures.js.
@@ -199,10 +232,16 @@ function buildProblemTags(
  * the empty Map it started as, never a crash (#5).
  *
  * @param {string} url Base API URL, e.g. `/api/redux/`.
- * @returns {{index: Map<string, Object>, loading: boolean, error: Error|null}}
+ * @returns {{
+ *   index: Map<string, Object>,
+ *   completeness: Map<string, {hasSolver: boolean, hasVisualization: boolean, hasVerifier: boolean}>,
+ *   loading: boolean,
+ *   error: Error|null,
+ * }}
  */
 export function useCatalogIndex(url) {
   const [index, setIndex] = useState(new Map());
+  const [completeness, setCompleteness] = useState(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -214,20 +253,28 @@ export function useCatalogIndex(url) {
       setError(null);
 
       try {
-        const [problemCodes, info, solversByProblem, visualizationsByProblem, reductionGraph] =
-          await Promise.all([
-            requestAllProblems(url),
-            requestAllInfo(url),
-            requestAllSolvers(url),
-            requestAllVisualizations(url),
-            requestReductionGraph(url),
-          ]);
+        const [
+          problemCodes,
+          info,
+          solversByProblem,
+          visualizationsByProblem,
+          verifiersByProblem,
+          reductionGraph,
+        ] = await Promise.all([
+          requestAllProblems(url),
+          requestAllInfo(url),
+          requestAllSolvers(url),
+          requestAllVisualizations(url),
+          requestAllVerifiers(url),
+          requestReductionGraph(url),
+        ]);
 
         if (cancelled) return;
 
         const reductionEdgesByProblem = indexReductionEdgesByProblem(reductionGraph ?? {});
 
         const map = new Map();
+        const completenessMap = new Map();
         for (const problemCode of problemCodes ?? []) {
           const { problemName, tags } = buildProblemTags(
             problemCode,
@@ -237,9 +284,19 @@ export function useCatalogIndex(url) {
             reductionEdgesByProblem,
           );
           map.set(problemName, tags);
+          completenessMap.set(
+            problemName,
+            buildCompleteness(
+              problemCode,
+              solversByProblem ?? {},
+              visualizationsByProblem ?? {},
+              verifiersByProblem ?? {},
+            ),
+          );
         }
 
         setIndex(map);
+        setCompleteness(completenessMap);
       } catch (caughtError) {
         if (!cancelled) setError(caughtError);
       } finally {
@@ -252,5 +309,5 @@ export function useCatalogIndex(url) {
     };
   }, [url]);
 
-  return { index, loading, error };
+  return { index, completeness, loading, error };
 }

--- a/pages/api/redux/[...path].js
+++ b/pages/api/redux/[...path].js
@@ -64,8 +64,19 @@ export default async function handler(req, res) {
   }
 
   res.status(upstream.status);
+  // Node's fetch (undici) transparently decompresses a gzip/br response body before
+  // upstream.arrayBuffer() below ever sees it -- so forwarding the upstream
+  // content-encoding/content-length headers verbatim lies to the browser about what
+  // res.end() actually sends: it claims a still-compressed body of the original
+  // (compressed) byte length, which is neither. Chromium then fails every such
+  // response with ERR_CONTENT_DECODING_FAILED. Dropping both lets Node recompute a
+  // correct content-length for the plain body we actually send.
   for (const [key, value] of upstream.headers) {
-    if (!["transfer-encoding", "connection"].includes(key.toLowerCase())) {
+    if (
+      !["transfer-encoding", "connection", "content-encoding", "content-length"].includes(
+        key.toLowerCase(),
+      )
+    ) {
       res.setHeader(key, value);
     }
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,22 +7,13 @@
 // and ProblemGrid's matchedTags together (issue body: "Filter state lives
 // here and flows down").
 //
-// Reads data/fixtures.js's FIXTURE_PROBLEMS directly -- Shell-phase sample
-// data (12 problems), not the real ~59-problem backend catalog. Every count
-// shown (subtitle, result count, sidebar option counts) is computed from it
-// rather than hardcoded, so nothing here needs to change once T25 swaps
-// this for the real useCatalogIndex() data.
-//
-// Filtering: AND across facets, OR within a facet's own selected options,
-// search substring-ANDed in on top. Matching is driven by each tag's actual
-// runtime shape (Array.isArray), not data/taxonomy.js's `multiValued` flag:
-// that file's own shape-contract comment documents that solverComplexity,
-// reductionType, reductionCost and visualizationType are all stored as
-// arrays at the problem level (aggregated across a problem's several
-// solver/reduction/visualization instances) despite being `multiValued:
-// false` -- only computationalModel is truly a bare string. Keying off
-// `multiValued` instead would silently break OR-matching for those four
-// facets. See this task's handback summary.
+// T25 (#34): reads the real backend via useCatalogIndex() (T23/#32) +
+// useCatalogFilters() (T24/#33) instead of data/fixtures.js's sample set.
+// Filtering/counting logic itself now lives in useCatalogFilters -- this
+// file only assembles filter state, the loading/error/empty presentation
+// (#5's settled banner decision, quoted below), and the card-shaped objects
+// ProblemGrid/ProblemCatalogCard need that useCatalogFilters's plain
+// `{name, tags}` results don't carry (see toCardProblem below).
 
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -33,13 +24,27 @@ import NavBar from "../components/NavBar";
 import ProblemGrid from "../components/ProblemGrid";
 import SearchBar from "../components/SearchBar";
 import { thinScrollbarSx } from "../components/theme";
-import { FIXTURE_PROBLEMS } from "../data/fixtures";
 import { TAXONOMY } from "../data/taxonomy";
+import { useCatalogFilters } from "../hooks/useCatalogFilters";
+import { useCatalogIndex } from "../hooks/useCatalogIndex";
 
 // #68: 280 was too narrow -- the longest option labels ("Algebra and Number
 // Theory", "Logical/Functional Models") wrapped to a second line against
 // their checkbox + count. Widened so every option renders on one line.
 const SIDEBAR_WIDTH = 340;
+
+// Same-origin proxy base lib/redux/index.js's own JSDoc documents (keeps
+// the real backend origin server-side, pages/api/redux/[...path].js).
+const API_BASE_URL = "/api/redux/";
+
+// #5's settled decision (ratified 2026-08-31): a reachable-but-empty
+// catalog reads "0 problems" with no banner; only a genuinely unreachable
+// backend gets this message, full width beneath the search bar. Written
+// with a period rather than the decision comment's own em dash, per this
+// project's no-em-dash rule -- flagged as a decision in this task's
+// handback summary since the ratified copy itself used one.
+const BACKEND_UNREACHABLE_MESSAGE =
+  "Couldn't reach the Redux backend. The catalog can't load right now.";
 
 function buildEmptySelection() {
   const selection = {};
@@ -47,45 +52,6 @@ function buildEmptySelection() {
     selection[facet.key] = new Set();
   }
   return selection;
-}
-
-// A problem matches a facet's active selection if ANY selected option is
-// present in its tag value for that facet -- whether that tag value is one
-// array (OR across the array) or a single string (plain equality). A facet
-// with nothing selected imposes no constraint.
-function matchesSelectedFacets(problem, selected) {
-  for (const facet of TAXONOMY) {
-    const selectedOptions = selected[facet.key];
-    if (!selectedOptions || selectedOptions.size === 0) {
-      continue;
-    }
-    const tagValue = problem.tags[facet.key];
-    const matches = Array.isArray(tagValue)
-      ? tagValue.some((optionKey) => selectedOptions.has(optionKey))
-      : selectedOptions.has(tagValue);
-    if (!matches) {
-      return false;
-    }
-  }
-  return true;
-}
-
-// Sidebar option counts, computed once against the full fixture set rather
-// than the currently-filtered results -- "how many problems if I add this
-// filter," the common faceted-search convention. TASKLIST.md's T14 entry
-// doesn't settle this either way; see this task's handback summary.
-function buildFacetOptions(problems) {
-  const facetOptions = {};
-  for (const facet of TAXONOMY) {
-    facetOptions[facet.key] = facet.options.map((option) => {
-      const count = problems.filter((problem) => {
-        const tagValue = problem.tags[facet.key];
-        return Array.isArray(tagValue) ? tagValue.includes(option.key) : tagValue === option.key;
-      }).length;
-      return { key: option.key, label: option.label, count };
-    });
-  }
-  return facetOptions;
 }
 
 function formatResultCount(count, filtersActive) {
@@ -97,31 +63,51 @@ function formatResultCount(count, filtersActive) {
   return `${count} ${noun} ${verb} your filters`;
 }
 
+// Id-safe stand-in for the fixture-only `slug` field ProblemCatalogCard uses
+// for its own `key`/`id` -- not a routing target. Card navigation itself
+// targets the real problem's display name (`/${encodeURIComponent(name)}`),
+// matching how T26 (#35)'s pages/[problem].js resolves the route param
+// against the real backend, which has no slug concept of its own.
+function slugify(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+// useCatalogFilters's `results` are plain `{name, tags}` pairs (T24/#33's
+// own header: it doesn't know about slugs or completeness). This assembles
+// the rest of what ProblemCatalogCard/StatusIcon need: an id-safe slug, and
+// presence-only stand-ins for StatusIcon's solvers/visualizations/verifier
+// length/null checks, sourced from useCatalogIndex's `completeness` map
+// (T25/#34's addition to T23) rather than the fixture's full detail arrays,
+// which the catalog-index hook never fetches.
+function toCardProblem(result, completeness) {
+  const flags = completeness.get(result.name) ?? {};
+  return {
+    name: result.name,
+    slug: slugify(result.name),
+    tags: result.tags,
+    solvers: flags.hasSolver ? [true] : [],
+    visualizations: flags.hasVisualization ? [true] : [],
+    verifier: flags.hasVerifier ? {} : null,
+  };
+}
+
 export default function Home() {
   const [selected, setSelected] = useState(buildEmptySelection);
   const [searchValue, setSearchValue] = useState("");
 
-  const facetOptions = useMemo(() => buildFacetOptions(FIXTURE_PROBLEMS), []);
+  const { index, completeness, loading, error } = useCatalogIndex(API_BASE_URL);
+  const { results, facetOptions, matchedTags } = useCatalogFilters(index, {
+    selected,
+    searchValue,
+  });
 
   const filtersActive =
     searchValue.trim().length > 0 || Object.values(selected).some((options) => options.size > 0);
 
-  const filteredProblems = useMemo(() => {
-    const query = searchValue.trim().toLowerCase();
-    return FIXTURE_PROBLEMS.filter((problem) => {
-      if (query && !problem.name.toLowerCase().includes(query)) {
-        return false;
-      }
-      return matchesSelectedFacets(problem, selected);
-    });
-  }, [selected, searchValue]);
-
-  // #70: passed straight through, not sliced to a fixed subset of facets --
-  // `selected` is already `{ [facetKey]: Set<optionKey> }`, exactly the
-  // shape ProblemCatalogCard's `matchedTags` prop wants, and a card now adds
-  // a row for ANY facet with an active selection, not only the three it
-  // renders by default.
-  const matchedTags = selected;
+  const problems = useMemo(
+    () => results.map((result) => toCardProblem(result, completeness)),
+    [results, completeness],
+  );
 
   const handleFacetChange = (facetKey, nextSet) => {
     setSelected((prev) => ({ ...prev, [facetKey]: nextSet }));
@@ -160,8 +146,9 @@ export default function Home() {
             Home
           </Typography>
           <Typography variant="body1" sx={{ color: "text.secondary", mt: 0.5 }}>
-            {FIXTURE_PROBLEMS.length} catalogued problems across complexity classes, solvers, and
-            visualizations.
+            {loading
+              ? "Loading the problem catalog…"
+              : `${index.size} catalogued problems across complexity classes, solvers, and visualizations.`}
           </Typography>
         </Box>
 
@@ -180,6 +167,21 @@ export default function Home() {
             onClearAll={handleClearAll}
           />
         </Box>
+
+        {/* #5's settled decision: full width, beneath the search bar,
+            above the sidebar-and-results row, not dismissible -- it clears
+            itself as soon as a request succeeds. */}
+        {error ? (
+          <Box
+            id="catalog-error-banner"
+            role="alert"
+            sx={{ px: 2, py: 1.5, borderRadius: 2, bgcolor: "error.dark" }}
+          >
+            <Typography variant="body2" sx={{ color: "error.contrastText" }}>
+              {BACKEND_UNREACHABLE_MESSAGE}
+            </Typography>
+          </Box>
+        ) : null}
 
         <Box sx={{ flex: 1, minHeight: 0, display: "flex", gap: 4 }}>
           {/* #68: the one scrollbar for the whole filter panel -- expanded
@@ -205,10 +207,14 @@ export default function Home() {
 
           <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", gap: 1.5 }}>
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              {formatResultCount(filteredProblems.length, filtersActive)}
+              {loading ? "Loading…" : formatResultCount(problems.length, filtersActive)}
             </Typography>
             <Box sx={{ flex: 1, minHeight: 0 }}>
-              <ProblemGrid problems={filteredProblems} matchedTags={matchedTags} />
+              <ProblemGrid
+                problems={problems}
+                matchedTags={matchedTags}
+                emptyMessage={loading ? "Loading problems…" : "No problems match your filters."}
+              />
             </Box>
           </Box>
         </Box>


### PR DESCRIPTION
Issue:  #34 (T25: Switch the Home page to real data)
Branch: task/T25-home-real-data

Changed:
  hooks/useCatalogIndex.js         - added a `completeness` Map alongside `index` (hasSolver/hasVisualization/hasVerifier per problem, from raw declared-item counts rather than the derived tag sets) so Home's cards can drive StatusIcon's real completeness rule.
  pages/index.js                   - swapped the data/fixtures.js import for useCatalogIndex + useCatalogFilters; added the loading/no-flash presentation and the #5 "couldn't reach backend" banner.
  components/ProblemCatalogCard.js - card link now targets `/${encodeURIComponent(problem.name)}`, matching how T26 (#35)'s pages/[problem].js resolves a route param (the real backend has no slug concept); `slug` is kept only as the id-safe basis for this card's own `id`/`key`.
  pages/api/redux/[...path].js     - bug fix, not part of T25's stated scope: dropped the forwarded content-encoding/content-length headers. Node's fetch already decompresses a gzip response before the proxy re-sends it, so forwarding the original headers told the browser the body was still compressed at its original length, and every gzip'd batch endpoint (allInfo, allSolvers, allVisualizations, allVerifiers, the reduction graph) failed client-side with ERR_CONTENT_DECODING_FAILED. Found and fixed because it was the reason Home couldn't render real data at all against the live backend -- without it, T25's own "renders identically with a backend up" done-when box could not be verified.

Done when, met:
  - Home renders the real backend's ~49 problems (verified against the live backend at https://redux.isu.edu, 39 complete / 10 incomplete by StatusIcon's rule), with search, sidebar facet filtering/counts, active-filter chips and matched-tag badges all working the same way they did against fixtures.
  - With no backend reachable: subtitle reads "0 catalogued problems...", the grid shows a loading/no-results message instead of cards, no crash, and the #5-decided banner appears ("Couldn't reach the Redux backend...") -- verified by aborting every /api/redux/ request in a real browser session.
  - The loading state never shows "0 problems": subtitle reads "Loading the problem catalog...", the result line reads "Loading...", and the grid shows "Loading problems..." instead of the empty-results message, until the fetch settles.

Done when, not met: none.

Decisions and assumptions:
  1. Card routing switched from the fixture-only `/${problem.slug}` to `/${encodeURIComponent(problem.name)}`, matching T26 (#35)'s own pages/[problem].js resolution scheme (open PR #82) -- the real backend has no slug field at all. Until T26 merges, clicking a card on this branch alone lands on the fixture-slug-based [problem].js and shows "not found" for every real problem name; this exact transient gap is already flagged reciprocally in T26's own PR notes and should resolve itself once both land. Not fixed here since rewriting [problem].js is explicitly T26's task, not T25's.
  2. StatusIcon completeness (has a solver/visualization/verifier) has no equivalent in useCatalogFilters's plain `{name, tags}` results, and the derived `tags.solverType`/`tags.visualizationType` sets aren't a reliable proxy (a solver/visualization with a backend type this hook doesn't map to a taxonomy option is still declared but wouldn't appear in either set). Extended useCatalogIndex (T23/#32) with a second `completeness` Map built from the same allSolvers/allVisualizations batch calls it already makes, plus a new allVerifiers call, rather than changing the `tags` shape contract itself. This is a T23-hook change made under T25 rather than a separate task, since T25 is what needed it and T23's own PR is long since merged; flagging here in case the project owner would rather this lived elsewhere.
  3. Banner text uses a period instead of the em dash in #5's own ratified decision text ("Couldn't reach the Redux backend [em dash] the catalog can't load right now.") to satisfy this project's no-em-dash rule (CLAUDE.md ground rule 9). The ratified decision comment on #5 itself uses an em dash; flagging the conflict rather than silently picking one.
  4. The pages/api/redux/[...path].js content-encoding/content-length fix (see Changed, above) is outside T25's literal scope -- it belongs to T20's already-merged proxy work -- but is included here since it was the actual, unambiguous cause of Home being unable to load real data at all, and is a one-line correctness fix rather than a design call.

Closes #34