### PR TITLE
T27: Add aria-labels to visualization scrubber buttons

### DIFF
--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -175,13 +175,23 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
                 borderColor: "divider",
               }}
             >
-              <IconButton id="visualizations-scrubber-previous" size="small" disabled>
+              <IconButton
+                id="visualizations-scrubber-previous"
+                size="small"
+                disabled
+                aria-label="Previous step"
+              >
                 <SkipPreviousIcon fontSize="small" />
               </IconButton>
-              <IconButton id="visualizations-scrubber-play" size="small" disabled>
+              <IconButton id="visualizations-scrubber-play" size="small" disabled aria-label="Play">
                 <PlayArrowIcon fontSize="small" />
               </IconButton>
-              <IconButton id="visualizations-scrubber-next" size="small" disabled>
+              <IconButton
+                id="visualizations-scrubber-next"
+                size="small"
+                disabled
+                aria-label="Next step"
+              >
                 <SkipNextIcon fontSize="small" />
               </IconButton>
               <Box


### PR DESCRIPTION
## Summary

Adds `aria-label` attributes to the three disabled playback controls in the
visualization scrubber (`components/detail/VisualizationsSection.js`):
Previous step, Play, Next step. These are icon-only `IconButton`s with no
visible text, so without a label they have no accessible name for screen
readers.

Per CLAUDE.md, these controls are intentionally inert for v1 (no working
step playback), but inert doesn't mean invisible to assistive tech --
they're disabled `<button>` elements, which drop from the tab order on
their own, but still need a name if a screen reader user inspects them.

This is a partial pass at #36 (T27: Accessibility audit and fixes) --
scoped to the one fix that actually landed. The broader audit also
reportedly touched SolversSection.js and ReductionsSection.js, but those
changes didn't make it into this branch, so this PR does not close #36.

## Test plan

- [x] Verify the three scrubber buttons in the visualization section have
      accessible names in a screen reader / accessibility tree inspector.
- [x] Confirm no visual change (aria-label doesn't affect rendering).
