### PR TITLE
T28: Make both pages work at narrow widths

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -14,15 +14,29 @@
 // Redux_GUI instance to link to, so guessing a domain felt worse than
 // leaving them inert — swap in a real href once the project owner
 // confirms one.
+//
+// T28 (#37): below `sm` (600px) there isn't room for "REDUX" + "Home" + two
+// full-width pill buttons on one row without wrapping or crowding the home
+// link. Each chrome link renders as two elements — a labeled Button (sm and
+// up) and an icon-only IconButton (below sm, same disabled/inert state,
+// `aria-label` carrying the name a sighted user would otherwise read off the
+// button text) — switched by CSS `display`, not a JS media-query hook, so
+// there's no hydration-time layout flicker. Both are real `disabled`
+// elements, so exactly one is ever in the tab order at a time regardless of
+// viewport (a disabled control isn't focusable), never two overlapping stops
+// for the same action.
 
+import HelpOutlineIcon from "@mui/icons-material/HelpOutlineOutlined";
+import PeopleAltOutlinedIcon from "@mui/icons-material/PeopleAltOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
 const CHROME_LINKS = [
-  { id: "navbar-help-button", label: "Help" },
-  { id: "navbar-contribute-button", label: "Contribute" },
+  { id: "navbar-help-button", label: "Help", Icon: HelpOutlineIcon },
+  { id: "navbar-contribute-button", label: "Contribute", Icon: PeopleAltOutlinedIcon },
 ];
 
 export default function NavBar() {
@@ -36,14 +50,14 @@ export default function NavBar() {
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        gap: 3,
-        px: { xs: 3, sm: 5 },
+        gap: { xs: 1.5, sm: 3 },
+        px: { xs: 2, sm: 5 },
         py: 2.5,
         borderBottom: "1px solid",
         borderColor: "divider",
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 5 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 2, sm: 5 } }}>
         <Box
           id="navbar-wordmark-link"
           component={Link}
@@ -76,11 +90,30 @@ export default function NavBar() {
         </Box>
       </Box>
 
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-        {CHROME_LINKS.map(({ id, label }) => (
-          <Button key={id} id={id} variant="outlined" disabled>
-            {label}
-          </Button>
+      <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 1, sm: 1.5 } }}>
+        {CHROME_LINKS.map(({ id, label, Icon }) => (
+          <Box key={id} sx={{ display: "contents" }}>
+            <Button
+              id={id}
+              variant="outlined"
+              disabled
+              sx={{ display: { xs: "none", sm: "inline-flex" } }}
+            >
+              {label}
+            </Button>
+            <IconButton
+              id={`${id}-icon`}
+              aria-label={label}
+              disabled
+              sx={{
+                display: { xs: "inline-flex", sm: "none" },
+                border: "1px solid",
+                borderColor: "divider",
+              }}
+            >
+              <Icon fontSize="small" />
+            </IconButton>
+          </Box>
         ))}
       </Box>
     </Box>

--- a/components/ProblemGrid.js
+++ b/components/ProblemGrid.js
@@ -14,9 +14,13 @@
 // Column count is a named constant, not a literal repeated across
 // properties, so T28 (#37) -- which owns the narrow-width breakpoints and
 // whether/how this becomes responsive -- has one place to change rather
-// than a hunt through this file. Phase 1 is desktop-only; going to 2 and
-// then 1 column at narrower widths is explicitly T28's call, not this
-// task's, so no breakpoint object is added here.
+// than a hunt through this file.
+//
+// T28 (#37): 1 column below `sm` (600px), 2 from `sm` up through `md`
+// (600-1199px, which covers both the 768px and 1024px reference widths --
+// at 1024 the sidebar is back to its fixed 340px column per pages/index.js,
+// so 2 columns fit the remaining width better than 3 would), 3 at `lg`
+// (1200px) and up.
 //
 // Owns its own vertical scroll (`overflowY: "auto"`) rather than leaving it
 // to an ancestor, because the mockup's results column scrolls independently
@@ -40,7 +44,7 @@ import Typography from "@mui/material/Typography";
 import ProblemCatalogCard from "./ProblemCatalogCard";
 import { thinScrollbarSx } from "./theme";
 
-const DESKTOP_COLUMN_COUNT = 3;
+const COLUMN_COUNT_BY_BREAKPOINT = { xs: 1, sm: 2, lg: 3 };
 
 /**
  * @param {Object} props
@@ -73,7 +77,12 @@ export default function ProblemGrid({
         height: "100%",
         overflowY: "auto",
         display: "grid",
-        gridTemplateColumns: `repeat(${DESKTOP_COLUMN_COUNT}, minmax(0, 1fr))`,
+        gridTemplateColumns: Object.fromEntries(
+          Object.entries(COLUMN_COUNT_BY_BREAKPOINT).map(([breakpoint, count]) => [
+            breakpoint,
+            `repeat(${count}, minmax(0, 1fr))`,
+          ]),
+        ),
         alignItems: "start",
         // #69: row gap trimmed independently of column gap -- the issue is
         // specifically about vertical space between cards, not horizontal.

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -20,6 +20,11 @@
 // available" message instead — same spirit as this project's documented
 // "Assignment Table" visualizationType gap. See this task's PR for the
 // decision writeup.
+//
+// T28 (#37): the solver-list-plus-detail-pane split stacks below `md`
+// (900px), same breakpoint components/detail/VisualizationsSection.js's
+// identically-shaped rail/pane split uses. The rail's fixed width only
+// applies at `md` and up; stacked, it's full width.
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -130,11 +135,16 @@ export default function SolversSection({ problem, dragHandleProps }) {
           />
         </Paper>
 
-        <Box sx={{ display: "flex", gap: 2 }}>
+        <Box sx={{ display: "flex", flexDirection: { xs: "column", md: "row" }, gap: 2 }}>
           {solvers.length === 0 ? (
             <Typography
               variant="body2"
-              sx={{ width: 260, flexShrink: 0, color: "text.secondary", fontStyle: "italic" }}
+              sx={{
+                width: { xs: "100%", md: 260 },
+                flexShrink: 0,
+                color: "text.secondary",
+                fontStyle: "italic",
+              }}
             >
               No solvers declared for this problem.
             </Typography>
@@ -147,7 +157,7 @@ export default function SolversSection({ problem, dragHandleProps }) {
                 listStyle: "none",
                 m: 0,
                 p: 0,
-                width: 260,
+                width: { xs: "100%", md: 260 },
                 flexShrink: 0,
                 maxHeight: RAIL_MAX_HEIGHT,
                 overflowY: "auto",

--- a/components/detail/VerifierSection.js
+++ b/components/detail/VerifierSection.js
@@ -86,7 +86,15 @@ export default function VerifierSection({ problem, dragHandleProps }) {
             Check a Certificate — matches the format above
           </Typography>
 
-          <Box sx={{ mt: 1.5, display: "flex", gap: 1.5, alignItems: "flex-start" }}>
+          <Box
+            sx={{
+              mt: 1.5,
+              display: "flex",
+              flexDirection: { xs: "column", sm: "row" },
+              gap: 1.5,
+              alignItems: { xs: "stretch", sm: "flex-start" },
+            }}
+          >
             <Box component="label" htmlFor={inputId} sx={visuallyHiddenSx}>
               Certificate to check
             </Box>

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -15,6 +15,12 @@
 // Only 3-SAT's fixture entries carry `stepLabel`/`stepNarration` — every
 // other problem's visualizations only have `{ name, type, caption }`, so
 // both are rendered conditionally rather than assumed present.
+//
+// T28 (#37): the rail-plus-pane split stacks below `md` (900px) -- same
+// breakpoint components/detail/OverviewSection.js already uses for its own
+// two-card split, and the width pages/index.js switches the Home sidebar
+// into a drawer at, kept consistent rather than picking a third number. The
+// rail's fixed width only applies at `md` and up; stacked, it's full width.
 
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import SkipNextIcon from "@mui/icons-material/SkipNext";
@@ -91,7 +97,7 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
           No visualizations declared for this problem.
         </Typography>
       ) : (
-        <Box sx={{ display: "flex", gap: 2 }}>
+        <Box sx={{ display: "flex", flexDirection: { xs: "column", md: "row" }, gap: 2 }}>
           <Box
             component="ul"
             role="listbox"
@@ -100,7 +106,7 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
               listStyle: "none",
               m: 0,
               p: 0,
-              width: 220,
+              width: { xs: "100%", md: 220 },
               flexShrink: 0,
               maxHeight: RAIL_MAX_HEIGHT,
               overflowY: "auto",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,25 @@
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
+import Head from "next/head";
 import "../styles/globals.css";
 import theme from "../components/theme";
 
+// T28 (#37): the Pages Router doesn't inject a viewport meta tag on its own
+// (unlike the App Router's automatic metadata handling), and doesn't want
+// one added via a custom pages/_document.js either -- Next.js warns against
+// that specifically (no-document-viewport-meta) since _document only
+// renders once per full page load, not per client-side navigation. _app.js
+// is the router's own recommended place for it. Without this, every
+// breakpoint below is inert on a real phone or tablet: the browser assumes
+// a ~980px desktop layout and zooms out to fit it instead of rendering at
+// the device's own width.
 export default function App({ Component, pageProps }) {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
       <Component {...pageProps} />
     </ThemeProvider>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,8 +15,15 @@
 // ProblemGrid/ProblemCatalogCard need that useCatalogFilters's plain
 // `{name, tags}` results don't carry (see toCardProblem below).
 
+import CloseIcon from "@mui/icons-material/Close";
+import TuneIcon from "@mui/icons-material/Tune";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Drawer from "@mui/material/Drawer";
+import IconButton from "@mui/material/IconButton";
+import { useTheme } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useMemo, useState } from "react";
 import ActiveFilterChips from "../components/ActiveFilterChips";
 import FacetSidebar from "../components/FacetSidebar";
@@ -32,6 +39,28 @@ import { useCatalogIndex } from "../hooks/useCatalogIndex";
 // Theory", "Logical/Functional Models") wrapped to a second line against
 // their checkbox + count. Widened so every option renders on one line.
 const SIDEBAR_WIDTH = 340;
+
+// T28 (#37): below this width the sidebar can't hold a fixed 340px column
+// next to a usable results area (at 768px, 340px + even a single comfortable
+// card column doesn't fit), so it moves behind a "Filters" drawer instead --
+// same breakpoint components/detail/OverviewSection.js already uses to
+// stack its two side-by-side cards, kept consistent rather than picking a
+// second, unrelated number. `md` is MUI's 900px default.
+//
+// This has to be a real JS media query (useMediaQuery below), not just a
+// CSS `display` toggle: FacetSidebar's checkbox/toggle ids are static
+// (`facet-${key}-option-${key}`, ground rule 4), so mounting both the fixed
+// column and the drawer's copy at once -- one merely hidden with
+// `display: none` -- would put two elements with the same id in the DOM
+// simultaneously, invalid HTML and exactly the kind of collision that rule
+// exists to prevent. Gating which one actually *mounts* keeps it to one.
+const SIDEBAR_BREAKPOINT = "md";
+
+// MUI's Drawer (built on Modal) already provides everything the "narrow
+// widths" issue asks of it: Escape closes it, focus is trapped inside while
+// open, and focus returns to the trigger button on close -- so none of that
+// is custom code here, just configuration.
+const FILTERS_DRAWER_ID = "home-filters-drawer";
 
 // Same-origin proxy base lib/redux/index.js's own JSDoc documents (keeps
 // the real backend origin server-side, pages/api/redux/[...path].js).
@@ -94,6 +123,14 @@ function toCardProblem(result, completeness) {
 export default function Home() {
   const [selected, setSelected] = useState(buildEmptySelection);
   const [searchValue, setSearchValue] = useState("");
+  const [filtersDrawerOpen, setFiltersDrawerOpen] = useState(false);
+
+  const theme = useTheme();
+  // Defaults to `false` (narrow) on the server and on first client render,
+  // matching Next.js SSR having no real viewport to measure -- see the
+  // SIDEBAR_BREAKPOINT comment above for why this has to gate mounting
+  // rather than just CSS visibility.
+  const isWideLayout = useMediaQuery(theme.breakpoints.up(SIDEBAR_BREAKPOINT));
 
   const { index, completeness, loading, error } = useCatalogIndex(API_BASE_URL);
   const { results, facetOptions, matchedTags } = useCatalogFilters(index, {
@@ -101,8 +138,8 @@ export default function Home() {
     searchValue,
   });
 
-  const filtersActive =
-    searchValue.trim().length > 0 || Object.values(selected).some((options) => options.size > 0);
+  const activeFilterCount = Object.values(selected).reduce((sum, options) => sum + options.size, 0);
+  const filtersActive = searchValue.trim().length > 0 || activeFilterCount > 0;
 
   const problems = useMemo(
     () => results.map((result) => toCardProblem(result, completeness)),
@@ -183,27 +220,96 @@ export default function Home() {
           </Box>
         ) : null}
 
+        {/* T28 (#37): the drawer trigger only exists below SIDEBAR_BREAKPOINT
+            -- above it the fixed sidebar column is already visible, so a
+            button that opens a drawer holding a second copy of it would be
+            redundant chrome with nothing to do. */}
+        {!isWideLayout && (
+          <Box>
+            <Button
+              id="home-filters-drawer-trigger"
+              variant="outlined"
+              startIcon={<TuneIcon fontSize="small" />}
+              aria-haspopup="dialog"
+              aria-controls={FILTERS_DRAWER_ID}
+              aria-expanded={filtersDrawerOpen}
+              onClick={() => setFiltersDrawerOpen(true)}
+            >
+              Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+            </Button>
+          </Box>
+        )}
+
+        <Drawer
+          anchor="left"
+          open={filtersDrawerOpen && !isWideLayout}
+          onClose={() => setFiltersDrawerOpen(false)}
+          slotProps={{
+            paper: {
+              id: FILTERS_DRAWER_ID,
+              role: "dialog",
+              "aria-modal": true,
+              "aria-label": "Filter problems",
+              sx: {
+                width: { xs: "85vw", sm: 360 },
+                maxWidth: 360,
+                p: 2.5,
+                overflowY: "auto",
+                ...thinScrollbarSx,
+              },
+            },
+          }}
+        >
+          <Box
+            sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 2 }}
+          >
+            <Typography variant="h2" component="h2" sx={{ fontSize: "1.0625rem" }}>
+              Filters
+            </Typography>
+            <IconButton
+              id="home-filters-drawer-close"
+              aria-label="Close filters"
+              onClick={() => setFiltersDrawerOpen(false)}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+          <FacetSidebar
+            facetOptions={facetOptions}
+            selected={selected}
+            onChange={handleFacetChange}
+            onClearFilters={handleClearAll}
+          />
+        </Drawer>
+
         <Box sx={{ flex: 1, minHeight: 0, display: "flex", gap: 4 }}>
           {/* #68: the one scrollbar for the whole filter panel -- expanded
               facet groups render every option in full (FacetSidebar no
               longer caps/scrolls internally), so this is the only way the
-              sidebar scrolls. */}
-          <Box
-            sx={{
-              width: SIDEBAR_WIDTH,
-              flexShrink: 0,
-              overflowY: "auto",
-              pr: 1,
-              ...thinScrollbarSx,
-            }}
-          >
-            <FacetSidebar
-              facetOptions={facetOptions}
-              selected={selected}
-              onChange={handleFacetChange}
-              onClearFilters={handleClearAll}
-            />
-          </Box>
+              sidebar scrolls.
+              T28 (#37): only mounted at/above SIDEBAR_BREAKPOINT -- the
+              Drawer above is the narrow-width equivalent, and only one of
+              the two is ever mounted at a time (see isWideLayout's comment),
+              so there's never two copies of the same filter controls (and
+              their duplicate ids) in the DOM together. */}
+          {isWideLayout && (
+            <Box
+              sx={{
+                width: SIDEBAR_WIDTH,
+                flexShrink: 0,
+                overflowY: "auto",
+                pr: 1,
+                ...thinScrollbarSx,
+              }}
+            >
+              <FacetSidebar
+                facetOptions={facetOptions}
+                selected={selected}
+                onChange={handleFacetChange}
+                onClearFilters={handleClearAll}
+              />
+            </Box>
+          )}
 
           <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", gap: 1.5 }}>
             <Typography variant="body2" sx={{ color: "text.secondary" }}>


### PR DESCRIPTION
## Summary

Makes Home and the Problem Detail page usable at narrow widths, per #37. There's no mobile mockup to check against, so per the issue's own instruction, every layout decision made here is written down below rather than left for the project owner to discover on a phone.

## Breakpoints and layout decisions

All breakpoints are MUI's own defaults (`sm` 600px, `md` 900px, `lg` 1200px) rather than custom numbers, and reuse the one breakpoint (`md`/900px) `components/detail/OverviewSection.js` already used to stack its own two side-by-side cards, so the whole app now stacks on one consistent number instead of several independently-chosen ones.

- **Filter sidebar (Home).** Fixed 340px column at `md` (900px) and up. Below that, it moves into a MUI `Drawer` (temporary, left-anchored) opened by a new "Filters" button, which shows the active-filter count when non-zero. MUI's `Drawer`/`Modal` already implements everything the issue's done-when list asks for keyboard-wise (Escape closes it, focus is trapped inside while open, focus returns to the trigger button on close), so none of that needed custom code.
  - The sidebar column and the drawer's copy of `FacetSidebar` are gated by a real `useMediaQuery` check (`theme.breakpoints.up('md')`), not just CSS `display`. `FacetSidebar`'s checkbox/toggle ids are static strings (`facet-<key>-option-<key>`, ground rule 4) -- if both were simply CSS-hidden/shown, a narrow-then-resized-wide session (or a wide session where the drawer state happened to be `true`) could mount both at once, putting two identical ids in the DOM. Gating which one actually *mounts* by the query result (and gating the Drawer's `open` by `!isWideLayout` too) keeps it to exactly one, always.
- **Card grid.** 1 column below `sm` (600px), 2 from `sm` through `md` (600-1199px -- this deliberately covers both the 768px and 1024px reference widths, since at 1024px the sidebar is back to its fixed 340px column, and 2 columns fit the remaining ~570px better than 3 would), 3 columns at `lg` (1200px) and up.
- **NavBar's Help/Contribute buttons.** Below `sm` (600px) they switch from labeled pill buttons to icon-only buttons (same disabled/inert state, `aria-label` carrying the name). Implemented as two elements per button toggled by CSS `display`, not a JS check -- both are real `disabled` HTML buttons, so exactly one is ever in the tab order regardless of viewport.
- **Visualizations/Solvers sections.** Their rail-plus-detail-pane splits stack (`flexDirection: column`) below `md`, same breakpoint as everywhere else; the rail goes full-width when stacked instead of keeping its fixed 220px/260px desktop width.
- **Verifier's "check a certificate" row.** Stacks below `sm` so the mono-font input and the Verify button don't get squeezed together at 375px.
- **Overview's two side-by-side cards** were already stacking at this same `md` breakpoint from an earlier task -- confirmed working, no change needed.
- **Viewport meta tag.** There wasn't one anywhere in the app before this PR -- the Pages Router doesn't add one automatically the way the App Router's metadata API does, so without it a real phone/tablet would've assumed a ~980px desktop layout and zoomed out to fit it, making every breakpoint above inert outside of devtools' device emulation (which sets the viewport directly and would have masked this). Added via `next/head` in `pages/_app.js` -- a `pages/_document.js` with the tag was tried first, but Next.js explicitly warns against that placement (`no-document-viewport-meta`) since `_document` doesn't re-render on client-side navigation.

## Verified

- `npm run lint`, `npm run format`, `npm run build` all clean.
- Checked the server-rendered HTML at both routes: the narrow-width "Filters" trigger and both NavBar button variants render correctly server-side (the `useMediaQuery`-gated sidebar defaults to narrow on SSR, matching Next.js having no real viewport to measure there), and the viewport meta tag is present in the response.
- No browser tool was available in this session to visually check the four reference widths (375/768/1024/1440) in an actual rendered page -- the above is verified by code review, a clean build, and the SSR HTML checks above, not by eye. Flagging this explicitly per this project's "say so rather than claiming success" instruction for UI changes that can't be visually tested.

## Done when

- [x] Both pages are usable and not cramped at roughly 375px, 768px, 1024px and 1440px. (Not visually verified -- see note above.)
- [x] No horizontal scrolling of the page itself at any width. Wide content scrolls inside its own box.
- [x] The drawer can be opened and closed with the keyboard, keeps focus inside while open, and closes on Escape. (MUI Drawer/Modal's built-in behavior, not custom code.)
- [x] The pull request lists every breakpoint and layout decision made -- see above.