### PR TITLE
T30: Build the Playwright end-to-end test suite

### DIFF
--- a/components/FacetSidebar.js
+++ b/components/FacetSidebar.js
@@ -168,6 +168,13 @@ function FacetFilterGroup({ facet, options, selected, onChange }) {
                     size="small"
                     checked={selected.has(optionKey)}
                     onChange={() => toggleOption(optionKey)}
+                    // T30 (#39): a machine-readable count, so a Playwright
+                    // spec can pick "an option with a nonzero count" without
+                    // parsing it back out of the rendered "(N)" label text --
+                    // the done-when wants tests keyed to stable attributes,
+                    // not text scraping, and the label's own wording is
+                    // free to change without breaking that.
+                    slotProps={{ input: { "data-count": count } }}
                   />
                 }
                 label={

--- a/components/ProblemDetailLayout.js
+++ b/components/ProblemDetailLayout.js
@@ -199,7 +199,12 @@ export default function ProblemDetailLayout({ problem }) {
         }}
       >
         <DragIndicatorIcon aria-hidden="true" fontSize="small" sx={{ color: "text.secondary" }} />
+        {/* T30 (#39): id added so tests/e2e/detail.spec.js can read the
+            current order back out of real page text (this line is the only
+            place it's rendered as text) rather than reimplementing "what
+            order are the sections in" via a separate DOM query. */}
         <Typography
+          id="detail-layout-status"
           variant="body2"
           component="span"
           sx={{ color: "text.secondary", flex: 1, minWidth: 0 }}

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,6 +14,12 @@
 // (#5's settled banner decision, quoted below), and the card-shaped objects
 // ProblemGrid/ProblemCatalogCard need that useCatalogFilters's plain
 // `{name, tags}` results don't carry (see toCardProblem below).
+//
+// T30 (#39): `id="home-subtitle"`/`id="home-result-count"` added to the two
+// dynamic-text Typography elements below so tests/e2e/home.spec.js can read
+// the real, currently-displayed counts (never a hardcoded one, per that
+// issue's done-when) instead of scraping for a number inside less specific
+// text.
 
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
@@ -145,7 +151,7 @@ export default function Home() {
           <Typography variant="h1" component="h1">
             Home
           </Typography>
-          <Typography variant="body1" sx={{ color: "text.secondary", mt: 0.5 }}>
+          <Typography id="home-subtitle" variant="body1" sx={{ color: "text.secondary", mt: 0.5 }}>
             {loading
               ? "Loading the problem catalog…"
               : `${index.size} catalogued problems across complexity classes, solvers, and visualizations.`}
@@ -206,7 +212,7 @@ export default function Home() {
           </Box>
 
           <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", gap: 1.5 }}>
-            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            <Typography id="home-result-count" variant="body2" sx={{ color: "text.secondary" }}>
               {loading ? "Loading…" : formatResultCount(problems.length, filtersActive)}
             </Typography>
             <Box sx={{ flex: 1, minHeight: 0 }}>

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,40 @@
+// playwright.config.js
+//
+// T30 (#39). Playwright, `@playwright/test`, and the Chromium install step
+// (`.devcontainer/post-create.sh`) all predate this file -- this is what
+// gives `npm run test:e2e` (already wired up in package.json) something to
+// actually run.
+//
+// PLAYWRIGHT_BASE_URL lets this point at an already-running instance
+// instead of starting its own dev server -- T32 (#41) is expected to set it
+// when `rbs.toml`'s `[integration]` section runs these tests against a
+// built container rather than `next dev`, so `webServer` below is skipped
+// entirely in that case rather than fighting the container for port 3000.
+// Locally, with no override, `npm run test:e2e` starts `next dev` itself
+// and waits for it to answer `/api/health` (pages/api/health.js) before any
+// spec runs.
+
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: "npm run dev",
+        url: `${baseURL}/api/health`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/tests/e2e/detail.spec.js
+++ b/tests/e2e/detail.spec.js
@@ -1,0 +1,70 @@
+// tests/e2e/detail.spec.js
+//
+// T30 (#39). Covers the issue's Problem Detail bullets: clicking a card
+// reaches the detail page, sections collapse/expand, sections can be
+// reordered with the keyboard, and "Reset to default" restores the order.
+//
+// Never names a specific problem -- every test opens whichever problem the
+// live catalog happens to put first (helpers.js's gotoFirstProblemDetail),
+// same "don't hardcode catalog contents" reasoning as home.spec.js.
+
+import { expect, test } from "./fixtures";
+import { gotoFirstProblemDetail, reorderFirstSectionWithKeyboard } from "./helpers";
+
+// The five section titles in their default order (components/
+// ProblemDetailLayout.js's own SECTIONS constant) -- fixed application
+// structure, not catalog-derived data, so asserting this literal text is
+// not the kind of hardcoding this issue's done-when warns against (that's
+// about problem counts, which do change as the catalog grows; this list
+// doesn't).
+const DEFAULT_LAYOUT_STATUS =
+  "Drag any section by its grip to reorder. Click a chevron to expand. Current layout: " +
+  "Overview, Visualizations, Solvers, Verifier, Reductions.";
+
+test("clicking a card reaches its detail page", async ({ page }) => {
+  const { name } = await gotoFirstProblemDetail(page, { expect });
+
+  expect(new URL(page.url()).pathname).toBe(`/${encodeURIComponent(name)}`);
+  await expect(page.locator('nav[aria-label="Breadcrumb"]')).toContainText(name);
+});
+
+test("sections collapse and expand", async ({ page }) => {
+  await gotoFirstProblemDetail(page, { expect });
+
+  const toggle = page.locator("#section-overview-toggle");
+  const body = page.locator("#section-overview-body");
+
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(body).toBeVisible();
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(body).toBeHidden();
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(body).toBeVisible();
+});
+
+test("sections can be reordered using the keyboard", async ({ page }) => {
+  await gotoFirstProblemDetail(page, { expect });
+
+  const status = page.locator("#detail-layout-status");
+  await expect(status).toHaveText(DEFAULT_LAYOUT_STATUS);
+
+  await reorderFirstSectionWithKeyboard(page);
+
+  await expect(status).not.toHaveText(DEFAULT_LAYOUT_STATUS);
+});
+
+test("Reset to default restores the canonical section order", async ({ page }) => {
+  await gotoFirstProblemDetail(page, { expect });
+
+  const status = page.locator("#detail-layout-status");
+  await reorderFirstSectionWithKeyboard(page);
+  await expect(status).not.toHaveText(DEFAULT_LAYOUT_STATUS);
+
+  await page.locator("#detail-layout-reset").click();
+
+  await expect(status).toHaveText(DEFAULT_LAYOUT_STATUS);
+});

--- a/tests/e2e/fixtures-wrapper.spec.js
+++ b/tests/e2e/fixtures-wrapper.spec.js
@@ -1,0 +1,45 @@
+// tests/e2e/fixtures-wrapper.spec.js
+//
+// T30 (#39) done-when: "the fixtures wrapper fails on silent network
+// errors, and there's a test proving it does." Every other spec relies on
+// tests/e2e/fixtures.js's `test` catching a request that fails without any
+// assertion in the test noticing -- this file is the proof that reliance is
+// warranted, not just an assumption.
+//
+// Marked `test.fail()`: this test is SUPPOSED to fail, because the wrapper
+// is supposed to catch the silent 500 below and throw. Playwright reports
+// an expected failure as a pass for the overall run (`npm run test:e2e`
+// still exits 0), and flips to a real failure only if this test
+// unexpectedly *passes* -- which is exactly what would happen if the
+// wrapper in fixtures.js ever stopped doing its job. That's the proof: a
+// working wrapper keeps this file green; a broken one turns it red.
+
+import { expect, test } from "./fixtures";
+
+test.describe("the fixtures wrapper", () => {
+  test("fails a test when an API request fails without being asserted on", async ({ page }) => {
+    test.fail();
+
+    // Deliberately do NOT call page.allowNetworkFailures() -- that's the
+    // whole point here, unlike every other test that breaks the network on
+    // purpose (tests/e2e/network-resilience.spec.js).
+    await page.route("**/api/redux/**", (route) =>
+      route.fulfill({ status: 500, body: "manufactured failure for this test" }),
+    );
+
+    await page.goto("/");
+    // The catalog fetch this manufactured 500 breaks happens client-side
+    // after the initial page load (a useEffect, not part of navigation), so
+    // page.goto() resolving is not enough -- without waiting for it to
+    // actually settle, this test function would return (and the wrapper's
+    // teardown would run) before the 500 the route above manufactures has
+    // even happened, and there would be nothing to catch. Once it settles,
+    // this waits for the *page* to say something's wrong (the loading text
+    // clearing) -- deliberately not written as an assertion of its own,
+    // since the point of this test is that nothing here needs to notice the
+    // failure for the wrapper to still catch it.
+    await expect(page.locator("#home-result-count")).not.toContainText("Loading", {
+      timeout: 20_000,
+    });
+  });
+});

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -1,0 +1,90 @@
+// tests/e2e/fixtures.js
+//
+// T30 (#39). Wraps Playwright's own `test` so a network request that fails
+// silently -- one no assertion in the test happens to notice -- still fails
+// the test. Every spec in this directory imports `test`/`expect` from here,
+// never from "@playwright/test" directly (mirrors Redux_GUI's own
+// tests/e2e/fixtures.js pattern, per this issue's own instruction to start
+// with it).
+//
+// This matters more here than in a typical project: this whole app's #5
+// decision exists because the sibling Redux_GUI project's fetch layer was
+// found to silently swallow failed requests -- a broken backend renders a
+// page that "looks fine," per that project's own TESTING.md. A test suite
+// built the ordinary way, asserting only what each test author explicitly
+// thought to check, would happily pass against that same kind of failure if
+// this codebase ever regressed back toward it. This file is the net
+// underneath every assertion in every other spec, not a substitute for
+// them -- see tests/e2e/fixtures-wrapper.spec.js for a test proving the net
+// actually catches something, not just that this file exists.
+//
+// Scoped to this app's own same-origin `/api/` calls (lib/redux/index.js's
+// requests all go through pages/api/redux/[...path].js at that path), not
+// every request the browser happens to make -- a missing favicon (this repo
+// has no public/ directory yet) or some Next.js dev-only asset 404ing isn't
+// the kind of "quiet failure" #5/this issue care about, and treating it as
+// one would make this wrapper too noisy to trust.
+//
+// A test that deliberately breaks the network on purpose (e.g. simulating
+// an unreachable backend, tests/e2e/network-resilience.spec.js) calls the
+// `page.allowNetworkFailures()` escape hatch this fixture adds, opting out
+// of this check for that one test -- there, a failed request is the
+// expected behavior under test, not a bug.
+
+import { test as base, expect } from "@playwright/test";
+
+const API_PATH_PATTERN = /\/api\//;
+
+function isApiRequest(url) {
+  return API_PATH_PATTERN.test(new URL(url).pathname);
+}
+
+export const test = base.extend({
+  // Playwright's own fixture convention names this second callback
+  // parameter "use" -- renamed to `provideFixture` here purely to dodge a
+  // false positive from eslint-plugin-react-hooks (bundled in
+  // eslint-config-next), which flags any function invoking something
+  // literally named `use(...)` as if it were React 19's `use()` hook.
+  // Playwright doesn't care what this parameter is called; only its
+  // position matters.
+  page: async ({ page }, provideFixture, testInfo) => {
+    const failures = [];
+    let allowed = false;
+
+    page.allowNetworkFailures = () => {
+      allowed = true;
+    };
+
+    const onRequestFailed = (request) => {
+      if (isApiRequest(request.url())) {
+        failures.push(
+          `${request.method()} ${request.url()} -- ${request.failure()?.errorText ?? "failed"}`,
+        );
+      }
+    };
+
+    const onResponse = (response) => {
+      if (isApiRequest(response.url()) && !response.ok()) {
+        failures.push(
+          `${response.request().method()} ${response.url()} -- responded ${response.status()}`,
+        );
+      }
+    };
+
+    page.on("requestfailed", onRequestFailed);
+    page.on("response", onResponse);
+
+    await provideFixture(page);
+
+    page.off("requestfailed", onRequestFailed);
+    page.off("response", onResponse);
+
+    if (!allowed && failures.length > 0) {
+      throw new Error(
+        `Network request(s) to this app's own API failed silently during "${testInfo.title}":\n${failures.join("\n")}`,
+      );
+    }
+  },
+});
+
+export { expect };

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -1,0 +1,148 @@
+// tests/e2e/helpers.js
+//
+// T30 (#39). Shared DOM helpers for the Home/detail specs. Kept out of
+// tests/e2e/fixtures.js on purpose -- that file's only job is the `test`/
+// `expect` wrapper itself (see its own header comment); this file is
+// ordinary test-support code that happens to be reused across specs, no
+// different in kind from a page-object module.
+//
+// Every helper here locates elements by the real ids/attributes the app
+// itself renders (never a hardcoded problem name or count -- this issue's
+// own done-when), matching this project's ground rule 4 that every
+// interactive element gets a unique id.
+
+/**
+ * Navigates to Home and waits for the initial catalog fetch to settle
+ * (loading text gone from #home-result-count -- see pages/index.js's own
+ * T30 comment on that id). Doesn't assert anything about the *result* --
+ * callers check for cards, an empty state, or the error banner themselves.
+ */
+export async function gotoHomeAndWaitForLoad(page, { expect }) {
+  await page.goto("/");
+  await expect(page.locator("#home-result-count")).not.toContainText("Loading", {
+    timeout: 20_000,
+  });
+}
+
+/**
+ * @returns the integer result count Home's own text currently reports
+ *   (`"N problems"` / `"N problems match your filters"`), read fresh off
+ *   the page rather than assumed -- this is how every test avoids
+ *   hardcoding a catalog size.
+ */
+export async function readResultCount(page) {
+  const text = (await page.locator("#home-result-count").textContent()) ?? "";
+  const match = text.match(/^(\d+)/);
+  if (!match) {
+    throw new Error(`Couldn't parse a result count out of "${text}"`);
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Navigates Home -> the first complete problem's detail page by actually
+ * clicking its card (only a complete problem's card renders as a real link
+ * -- components/ProblemCatalogCard.js's own `isProblemComplete` gate), and
+ * waits for the detail page's H1 to show that same name. Never assumes a
+ * specific problem exists; whichever one the live catalog puts first is
+ * used.
+ * @returns {Promise<{name: string}>}
+ */
+export async function gotoFirstProblemDetail(page, { expect }) {
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  const firstCard = page.locator('a[id^="problem-card-"]').first();
+  const name = await firstCard.getAttribute("aria-label");
+  if (!name) {
+    throw new Error(
+      "No complete (linkable) problem card found on Home to open a detail page from.",
+    );
+  }
+
+  await firstCard.click();
+  await expect(page.getByRole("heading", { level: 1, name })).toBeVisible();
+  return { name };
+}
+
+/**
+ * Picks up the Overview section's drag grip with the keyboard, moves it
+ * down one position, and drops it -- @dnd-kit's own KeyboardSensor
+ * start/move/end sequence (Space, ArrowDown, Space; see
+ * components/ProblemDetailLayout.js's own T18 comment on why a
+ * KeyboardSensor is registered at all).
+ *
+ * The short pauses between key presses are load-bearing, not padding:
+ * @dnd-kit recomputes every sortable item's position on an animation frame,
+ * and the drop's collision detection reads that just-recomputed position --
+ * three `press()` calls fired back-to-back (no yield to the event loop in
+ * between) can deliver the drop before the preceding move has actually been
+ * measured, which drops the item back where it started with no visible
+ * reorder. Confirmed by hand: the same three presses with a wait after each
+ * one reorders correctly every time; with no wait, the drop is a same-
+ * position no-op. `page.waitForTimeout` is normally the wrong tool in a
+ * Playwright test (locator assertions auto-retry, so waiting is usually
+ * unnecessary) -- this is the genuine exception, since there's no DOM
+ * signal to await between "the move was requested" and "@dnd-kit finished
+ * measuring it," only real time.
+ */
+export async function reorderFirstSectionWithKeyboard(page) {
+  const grip = page.locator("#section-overview-grip");
+  await grip.focus();
+  await grip.press("Space");
+  await page.waitForTimeout(300);
+  await grip.press("ArrowDown");
+  await page.waitForTimeout(300);
+  await grip.press("Space");
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Every sidebar facet checkbox currently on the page, with its real
+ * server-computed count (components/FacetSidebar.js's own `data-count`,
+ * T30's addition -- read as a DOM attribute, not parsed back out of the
+ * "(N)" label text).
+ * @returns {Promise<Array<{id: string, facetKey: string, optionKey: string, count: number}>>}
+ */
+export async function readFacetOptions(page) {
+  const checkboxes = page.locator('nav[aria-label="Filter problems"] input[type="checkbox"]');
+  const ids = await checkboxes.evaluateAll((elements) =>
+    elements.map((el) => ({ id: el.id, count: Number(el.dataset.count) })),
+  );
+  return ids.map(({ id, count }) => {
+    const match = id.match(/^facet-(.+)-option-(.+)$/);
+    if (!match) {
+      throw new Error(
+        `Facet checkbox id "${id}" didn't match the expected facet-<key>-option-<key> shape`,
+      );
+    }
+    const [, facetKey, optionKey] = match;
+    return { id, facetKey, optionKey, count };
+  });
+}
+
+/**
+ * Picks a facet option whose real count is strictly between 0 and
+ * `catalogSize` -- guarantees selecting it will actually narrow the result
+ * set (some problems match, but not every problem does) rather than being a
+ * no-op or a filter nothing matches, without ever naming a specific facet
+ * or problem.
+ * @param {Array} options From readFacetOptions.
+ * @param {number} catalogSize The unfiltered total (readResultCount()
+ *   before any filter is applied).
+ * @param {Object} [constraints]
+ * @param {string} [constraints.excludeFacetKey] Skip options from this
+ *   facet -- used to guarantee two picks come from different categories.
+ */
+export function pickNarrowingOption(options, catalogSize, { excludeFacetKey } = {}) {
+  const candidate = options.find(
+    (option) =>
+      option.count > 0 && option.count < catalogSize && option.facetKey !== excludeFacetKey,
+  );
+  if (!candidate) {
+    throw new Error(
+      "No facet option currently has a count strictly between 0 and the catalog size -- " +
+        "can't pick a narrowing filter to test with.",
+    );
+  }
+  return candidate;
+}

--- a/tests/e2e/home.spec.js
+++ b/tests/e2e/home.spec.js
@@ -1,0 +1,112 @@
+// tests/e2e/home.spec.js
+//
+// T30 (#39). Covers the issue's Home-page bullets: renders cards, search
+// narrows results, a filter narrows results and updates counts, filters
+// across two categories narrow rather than widen, and chips + "Clear all."
+//
+// Every count used below is read off the live page (helpers.js), never
+// written as a literal -- the done-when is explicit that a test asserting a
+// specific catalog size breaks the day someone adds a problem.
+
+import { expect, test } from "./fixtures";
+import {
+  gotoHomeAndWaitForLoad,
+  pickNarrowingOption,
+  readFacetOptions,
+  readResultCount,
+} from "./helpers";
+
+test("the Home page renders cards", async ({ page }) => {
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  // Matches whichever id the error banner currently has -- `main` has
+  // `catalog-error-banner` as of this task; T29 (#38, a sibling branch off
+  // the same `main` this task also branched from) renames it to the shared
+  // `backend-error-banner` once it merges. Checking for its absence under
+  // either name means this assertion doesn't need updating either way.
+  await expect(page.locator("#backend-error-banner, #catalog-error-banner")).toHaveCount(0);
+  await expect(page.locator('[id^="problem-card-"]').first()).toBeVisible();
+});
+
+test("search narrows the results to the searched-for problem", async ({ page }) => {
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  const initialCount = await readResultCount(page);
+  const firstCard = page.locator('a[id^="problem-card-"]').first();
+  const problemName = await firstCard.getAttribute("aria-label");
+  expect(problemName).toBeTruthy();
+
+  await page.locator("#search-bar-input").fill(problemName);
+
+  await expect(page.locator("#home-result-count")).not.toContainText("Loading");
+  const narrowedCount = await readResultCount(page);
+  expect(narrowedCount).toBeGreaterThan(0);
+  expect(narrowedCount).toBeLessThanOrEqual(initialCount);
+  await expect(page.locator(`[id^="problem-card-"][aria-label="${problemName}"]`)).toBeVisible();
+});
+
+test("ticking a filter narrows the results and updates the count", async ({ page }) => {
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  const catalogSize = await readResultCount(page);
+  const options = await readFacetOptions(page);
+  const option = pickNarrowingOption(options, catalogSize);
+
+  await page.locator(`#${option.id}`).check();
+
+  await expect(page.locator("#home-result-count")).toContainText(String(option.count));
+  const narrowedCount = await readResultCount(page);
+  expect(narrowedCount).toBe(option.count);
+  expect(narrowedCount).toBeLessThan(catalogSize);
+});
+
+test("filters across two categories narrow rather than widen", async ({ page }) => {
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  const catalogSize = await readResultCount(page);
+  const options = await readFacetOptions(page);
+  const first = pickNarrowingOption(options, catalogSize);
+
+  await page.locator(`#${first.id}`).check();
+  await expect(page.locator("#home-result-count")).toContainText(String(first.count));
+  const afterFirst = await readResultCount(page);
+  expect(afterFirst).toBe(first.count);
+
+  // Facet option counts are computed against the full index regardless of
+  // which filters are already active (hooks/useCatalogFilters.js's own
+  // header comment), so `options` read before checking the first box is
+  // still valid for picking the second one.
+  const second = pickNarrowingOption(options, catalogSize, { excludeFacetKey: first.facetKey });
+  await page.locator(`#${second.id}`).check();
+  await expect(page.locator(`#${second.id}`)).toBeChecked();
+
+  // AND-across-facets: adding a second category's filter must never
+  // increase the result count past what the first filter alone produced --
+  // it may legitimately stay the same (every problem matching the first
+  // filter also happens to match the second) rather than strictly
+  // decreasing, so this only asserts non-increase, never inequality.
+  const afterBoth = await readResultCount(page);
+  expect(afterBoth).toBeLessThanOrEqual(afterFirst);
+  expect(afterBoth).toBeLessThanOrEqual(second.count);
+});
+
+test("chips appear for active filters, and Clear all empties everything", async ({ page }) => {
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  const catalogSize = await readResultCount(page);
+  const options = await readFacetOptions(page);
+  const option = pickNarrowingOption(options, catalogSize);
+
+  await page.locator(`#${option.id}`).check();
+
+  const removeButton = page.locator(
+    `#active-filter-chip-${option.facetKey}-${option.optionKey}-remove`,
+  );
+  await expect(removeButton).toBeVisible();
+
+  await page.locator("#active-filter-chips-clear-all").click();
+
+  await expect(removeButton).toHaveCount(0);
+  await expect(page.locator(`#${option.id}`)).not.toBeChecked();
+  await expect(page.locator("#home-result-count")).toContainText(String(catalogSize));
+});

--- a/tests/e2e/network-resilience.spec.js
+++ b/tests/e2e/network-resilience.spec.js
@@ -1,0 +1,48 @@
+// tests/e2e/network-resilience.spec.js
+//
+// T30 (#39). Covers the issue's last Home bullet -- "With no backend, the
+// empty state appears rather than an error" -- which is really this whole
+// project's #5 decision (ARCHITECTURE.md) under test: a broken backend must
+// degrade to the visible banner + empty grid, never a crash or a silently
+// blank page.
+//
+// The backend is "switched off" here by intercepting this app's own same-
+// origin proxy route and returning the exact 502 pages/api/redux/[...path].js
+// itself returns when the real upstream is unreachable (see that file's own
+// `catch` block) -- the most realistic simulation available without an
+// actually-unreachable REDUX_BASE_URL, and it exercises the same code path
+// a real outage would.
+
+import { expect, test } from "./fixtures";
+import { gotoHomeAndWaitForLoad } from "./helpers";
+
+test("with no backend reachable, the page explains itself instead of crashing", async ({
+  page,
+}) => {
+  // This test's whole point is a deliberately broken backend -- opts out of
+  // tests/e2e/fixtures.js's default "no request fails silently" check for
+  // this one test (see that file's header comment).
+  page.allowNetworkFailures();
+
+  await page.route("**/api/redux/**", (route) =>
+    route.fulfill({
+      status: 502,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Upstream unreachable" }),
+    }),
+  );
+
+  await gotoHomeAndWaitForLoad(page, { expect });
+
+  // Matches whichever id the error banner currently has -- see
+  // home.spec.js's identical comment on this same selector.
+  await expect(page.locator("#backend-error-banner, #catalog-error-banner")).toBeVisible();
+  await expect(page.locator('[id^="problem-card-"]')).toHaveCount(0);
+
+  // No crash: page chrome still renders around the banner.
+  await expect(page.locator("#navbar-wordmark-link")).toBeVisible();
+
+  // Ground rule 6 / T29's done-when in spirit: nothing anywhere prints a
+  // raw JS-ism instead of real copy.
+  await expect(page.locator("body")).not.toContainText(/undefined|NaN|\[object Object\]/);
+});


### PR DESCRIPTION
## Summary

Builds the first automated test suite for this project, per #39: `tests/e2e/`, using Playwright, run against a real browser and the real live Redux backend (`.env.local`'s default, per this repo's existing setup).

## What's here

- **`tests/e2e/fixtures.js`** — the wrapper every other spec imports `test`/`expect` from instead of `@playwright/test` directly (mirrors Redux_GUI's own `tests/e2e/fixtures.js`, per the issue's own instruction). It fails a test if any of this app's own same-origin `/api/` requests fails (network-level failure, or a non-2xx response) without the test opting out via a `page.allowNetworkFailures()` escape hatch. Scoped to `/api/` specifically, not every request the browser makes -- this repo has no `public/` directory yet, so a missing favicon would otherwise make the wrapper too noisy to trust.
- **`tests/e2e/fixtures-wrapper.spec.js`** — the done-when's "there's a test proving it does." Manufactures a silent 500 on `/api/redux/**` and asserts nothing about it itself; marked `test.fail()` so the wrapper correctly failing this test counts as a *pass* for `npm run test:e2e` overall, and the run only goes red if the wrapper ever stops catching this (an "unexpected pass").
- **`tests/e2e/home.spec.js`** — renders cards; search narrows to the searched-for problem; ticking a filter narrows the results and updates the count; filters across two categories narrow (never widen) the result; chips appear for active filters and "Clear all" empties everything.
- **`tests/e2e/detail.spec.js`** — clicking a card reaches its detail page; sections collapse and expand; sections reorder with the keyboard (dnd-kit's own KeyboardSensor -- Space/Arrow/Space, not custom code); "Reset to default" restores the canonical order.
- **`tests/e2e/network-resilience.spec.js`** — with the backend simulated unreachable (intercepting `/api/redux/**` with the same 502 the real proxy returns on a real outage, `pages/api/redux/[...path].js`), the error banner appears, the grid shows no cards, page chrome still renders, and nothing prints `undefined`/`NaN`/`[object Object]` -- this is #5's whole decision under test.
- **`tests/e2e/helpers.js`** — shared DOM helpers (wait for load, read the live result count, read every facet checkbox's real count, pick a filter option guaranteed to narrow, the keyboard-reorder sequence).
- **`playwright.config.js`** — starts `next dev` and waits on `/api/health` when `PLAYWRIGHT_BASE_URL` isn't set (the local case); skips starting its own server when it is, leaving a clean seam for T32 (#41) to point this at a running container instead.

## Small testability-only additions along the way

- `id="home-subtitle"` / `id="home-result-count"` on Home's two dynamic-text lines (`pages/index.js`), and `id="detail-layout-status"` on the detail page's order-summary line (`components/ProblemDetailLayout.js`) -- so tests can read real displayed values instead of scraping less specific text.
- `data-count` on each facet checkbox (`components/FacetSidebar.js`) -- a machine-readable version of the count already shown in its "(N)" label text, so tests don't parse rendered text to find a filter to test with.

None of these change what's rendered visually; they're read-only anchors for the ids ground rule already asks every interactive element to have anyway.

## A genuine bug the suite caught while writing it

The keyboard-reorder test originally failed against the real app: three `press()` calls (Space, ArrowDown, Space) fired back-to-back landed the drop before @dnd-kit had finished measuring the preceding move on its own animation frame, so the item silently dropped back where it started. Confirmed by hand with a throwaway debug script before concluding it wasn't an app bug -- the same three presses **with** a short pause after each one reorder correctly every time. `reorderFirstSectionWithKeyboard` (`tests/e2e/helpers.js`) has the full writeup; the pauses are commented as load-bearing, not padding.

## Done when

- [x] `npm run test:e2e` passes locally against a running backend -- verified directly: 11/11 passed, exit code 0, run several times.
- [x] The fixtures wrapper fails on silent network errors, and there's a test proving it does.
- [x] Tests find elements by unique ids, not fragile text or CSS paths.
- [x] No test hardcodes a problem count -- every count (`readResultCount`, `readFacetOptions`) is read off the live page.

## Decisions / assumptions

- T30 depends only on T25 (#34) and T26 (#35) per the issue itself, not on T28/T29 (open sibling PRs off the same `main`). `home.spec.js`'s and `network-resilience.spec.js`'s error-banner check matches either the current id (`catalog-error-banner`) or T29's renamed one (`backend-error-banner`) so it keeps working whichever merges first.
- No `public/` directory exists yet, so the fixtures wrapper is deliberately scoped to `/api/` requests only (see its own header comment) rather than every request the browser makes.