### PR TITLE
T33: Final verification pass

### DIFF
--- a/components/FacetSidebar.js
+++ b/components/FacetSidebar.js
@@ -45,7 +45,7 @@ import { TAXONOMY } from "../data/taxonomy";
 import { getFacetAccentColor } from "./theme";
 
 function FacetFilterGroup({ facet, options, selected, onChange, loading }) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(false);
   const toggleId = `facet-${facet.key}-toggle`;
   const listId = `facet-${facet.key}-options`;
   const selectedCount = selected.size;

--- a/components/ProblemGrid.js
+++ b/components/ProblemGrid.js
@@ -59,7 +59,14 @@ const COLUMN_COUNT_BY_BREAKPOINT = { xs: 1, sm: 2, lg: 3 };
 const SKELETON_CARD_COUNT = 6;
 
 const gridContainerSx = {
-  height: "100%",
+  // maxHeight, not height: a filtered-down result set should shrink to fit
+  // its own cards rather than always claiming the full height of its flex
+  // parent (pages/index.js's results column) and leaving dead space below
+  // the last row where the unfiltered grid's remaining cards used to be.
+  // Capping at 100% (of that parent's own bounded, flex:1 height) keeps the
+  // scroll-independently-of-the-sidebar behavior this file's header comment
+  // describes for the case that still needs it -- more results than fit.
+  maxHeight: "100%",
   overflowY: "auto",
   display: "grid",
   gridTemplateColumns: Object.fromEntries(

--- a/components/SearchBar.js
+++ b/components/SearchBar.js
@@ -31,13 +31,19 @@ import { useEffect, useRef } from "react";
 const SEARCH_INPUT_ID = "search-bar-input";
 
 // Standard visually-hidden clip pattern -- the label needs to exist for
-// screen readers without displacing the visible placeholder text.
+// screen readers without displacing the visible placeholder text. Width/
+// height/margin are written as unit strings, not bare numbers: MUI's `sx`
+// reinterprets a bare number for a sizing prop as a percentage (`1` ->
+// `100%`) and for a spacing prop as a multiple of the theme spacing unit
+// (`-1` -> `-8px`) -- either one silently turns this into a full-size box
+// that's clipped from view but still counted in the page's scrollable
+// area (T33/#42 caught this as a real, if tiny, horizontal-overflow bug).
 const visuallyHiddenSx = {
   position: "absolute",
-  width: 1,
-  height: 1,
+  width: "1px",
+  height: "1px",
   padding: 0,
-  margin: -1,
+  margin: "-1px",
   overflow: "hidden",
   clip: "rect(0, 0, 0, 0)",
   whiteSpace: "nowrap",

--- a/components/detail/SectionShell.js
+++ b/components/detail/SectionShell.js
@@ -64,7 +64,7 @@ import { useState } from "react";
  *   drag activator. Omitted, the grip stays decorative (`aria-hidden`).
  */
 export default function SectionShell({ sectionKey, title, summary, children, dragHandleProps }) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(false);
   const toggleId = `section-${sectionKey}-toggle`;
   const bodyId = `section-${sectionKey}-body`;
   const gripId = `section-${sectionKey}-grip`;

--- a/components/detail/VerifierSection.js
+++ b/components/detail/VerifierSection.js
@@ -185,13 +185,18 @@ const disabledActionButtonSx = {
 
 // Standard visually-hidden clip pattern (same as components/SearchBar.js) --
 // the label needs to exist for screen readers without displacing the
-// visible input.
+// visible input. Width/height/margin are unit strings, not bare numbers:
+// MUI's `sx` reinterprets a bare number for a sizing prop as a percentage
+// (`1` -> `100%`) and for a spacing prop as a multiple of the theme spacing
+// unit (`-1` -> `-8px`) -- either one silently turns this into a full-size
+// box that's clipped from view but still counted in the page's scrollable
+// area (T33/#42 caught this as a real, if tiny, horizontal-overflow bug).
 const visuallyHiddenSx = {
   position: "absolute",
-  width: 1,
-  height: 1,
+  width: "1px",
+  height: "1px",
   padding: 0,
-  margin: -1,
+  margin: "-1px",
   overflow: "hidden",
   clip: "rect(0, 0, 0, 0)",
   whiteSpace: "nowrap",

--- a/pages/[problem].js
+++ b/pages/[problem].js
@@ -58,14 +58,12 @@ import { useProblemDetail } from "../hooks/useProblemDetail";
 const API_BASE_URL = "/api/redux/";
 
 // Badge row order per the mockup (NP-Complete, NP, Boolean Logic): complexity
-// badges first, then problem type. Same chip-family naming as
-// ProblemCatalogCard's BADGE_ROWS (components/theme.js's BADGE_FAMILIES) so
+// badges first, then problem type. Chip variant is keyed straight off
+// facetKey (`${facetKey}Outlined`), same as ProblemCatalogCard's TagRow
+// (components/theme.js registers one outlined/filled pair per facet.key) so
 // the colors match the card the visitor clicked through from — but always
 // outlined here, since a detail page has no "matched active filter" concept.
-const BADGE_ROWS = [
-  { facetKey: "complexityClass", chipFamily: "complexity" },
-  { facetKey: "problemType", chipFamily: "problemType" },
-];
+const BADGE_FACET_KEYS = ["complexityClass", "problemType"];
 
 const TAXONOMY_BY_KEY = new Map(TAXONOMY.map((facet) => [facet.key, facet]));
 
@@ -205,12 +203,12 @@ export default function ProblemDetail() {
             {problem.oneLiner}
           </Typography>
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, mt: 1.5 }}>
-            {BADGE_ROWS.flatMap(({ facetKey, chipFamily }) =>
+            {BADGE_FACET_KEYS.flatMap((facetKey) =>
               (problem.tags[facetKey] ?? []).map((optionKey) => (
                 <Chip
                   key={`${facetKey}-${optionKey}`}
                   size="small"
-                  variant={`${chipFamily}Outlined`}
+                  variant={`${facetKey}Outlined`}
                   label={optionLabel(facetKey, optionKey)}
                 />
               )),

--- a/tests/e2e/detail.spec.js
+++ b/tests/e2e/detail.spec.js
@@ -34,16 +34,17 @@ test("sections collapse and expand", async ({ page }) => {
   const toggle = page.locator("#section-overview-toggle");
   const body = page.locator("#section-overview-body");
 
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
-  await expect(body).toBeVisible();
-
-  await toggle.click();
+  // Sections default to collapsed (components/detail/SectionShell.js).
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
   await expect(body).toBeHidden();
 
   await toggle.click();
   await expect(toggle).toHaveAttribute("aria-expanded", "true");
   await expect(body).toBeVisible();
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  await expect(body).toBeHidden();
 });
 
 test("sections can be reordered using the keyboard", async ({ page }) => {

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -97,6 +97,19 @@ export async function reorderFirstSectionWithKeyboard(page) {
 }
 
 /**
+ * Expands a sidebar facet group by its facet key, if it isn't already
+ * expanded. Facet groups default to collapsed (components/FacetSidebar.js),
+ * so any test that needs to click one of a group's checkboxes must open the
+ * group first -- exactly what a real visitor would do.
+ */
+export async function expandFacetGroup(page, facetKey) {
+  const toggle = page.locator(`#facet-${facetKey}-toggle`);
+  if ((await toggle.getAttribute("aria-expanded")) !== "true") {
+    await toggle.click();
+  }
+}
+
+/**
  * Every sidebar facet checkbox currently on the page, with its real
  * server-computed count (components/FacetSidebar.js's own `data-count`,
  * T30's addition -- read as a DOM attribute, not parsed back out of the

--- a/tests/e2e/home.spec.js
+++ b/tests/e2e/home.spec.js
@@ -10,6 +10,7 @@
 
 import { expect, test } from "./fixtures";
 import {
+  expandFacetGroup,
   gotoHomeAndWaitForLoad,
   pickNarrowingOption,
   readFacetOptions,
@@ -52,6 +53,7 @@ test("ticking a filter narrows the results and updates the count", async ({ page
   const options = await readFacetOptions(page);
   const option = pickNarrowingOption(options, catalogSize);
 
+  await expandFacetGroup(page, option.facetKey);
   await page.locator(`#${option.id}`).check();
 
   await expect(page.locator("#home-result-count")).toContainText(String(option.count));
@@ -67,6 +69,7 @@ test("filters across two categories narrow rather than widen", async ({ page }) 
   const options = await readFacetOptions(page);
   const first = pickNarrowingOption(options, catalogSize);
 
+  await expandFacetGroup(page, first.facetKey);
   await page.locator(`#${first.id}`).check();
   await expect(page.locator("#home-result-count")).toContainText(String(first.count));
   const afterFirst = await readResultCount(page);
@@ -77,6 +80,7 @@ test("filters across two categories narrow rather than widen", async ({ page }) 
   // header comment), so `options` read before checking the first box is
   // still valid for picking the second one.
   const second = pickNarrowingOption(options, catalogSize, { excludeFacetKey: first.facetKey });
+  await expandFacetGroup(page, second.facetKey);
   await page.locator(`#${second.id}`).check();
   await expect(page.locator(`#${second.id}`)).toBeChecked();
 
@@ -97,6 +101,7 @@ test("chips appear for active filters, and Clear all empties everything", async 
   const options = await readFacetOptions(page);
   const option = pickNarrowingOption(options, catalogSize);
 
+  await expandFacetGroup(page, option.facetKey);
   await page.locator(`#${option.id}`).check();
 
   const removeButton = page.locator(


### PR DESCRIPTION
## Summary

Runs `ARCHITECTURE.md`'s "Verification (once the catalog UI is implemented)" checklist against the whole finished application, using the live production backend (`https://redux.isu.edu/api/redux/`, 49 problems) and, later, a local checkout of the backend's in-review tag-system-expansion branch (`ReduxISU/Redux#396`). This is the last task in the plan -- closing it also closes the tracking epic (#43).

Verified with a headless-Chromium driver script (Playwright, already a devDependency) since no interactive browser was available in this session, plus a full run of the existing `tests/e2e/` suite. Grew into a few small follow-up fixes and two UI changes requested by the project owner mid-review -- all summarized below.

## Done when (original verification checklist)

- [x] `npm run dev` against a real backend; both `/` and a problem page load.
- [x] Filter checkboxes work with correct counts across every tag category -- the five backed by the backend and the four filled in by the overlay. All 9 groups render with sane counts, including documented backend-gap buckets correctly showing `(0)`. Ticking two facets across two categories: 49 -> 12, counts updated live, no `NaN`/`undefined`/`[object Object]` anywhere.
- [x] Filter chips and "Clear all" work, and matching tags highlight on the cards.
- [x] The card grid matches the Home mockups.
- [x] Sections on the detail page reorder by dragging and by keyboard, and collapse by chevron.
- [x] Overview shows `Input:` and `Output:` -- not set notation. `Output:` renders blank (not "undefined") when the backend's `certificateFormat` is unset -- `hooks/useProblemDetail.js`'s own documented, deliberate behavior, not a bug.
- [x] Solvers and Verifier show real declared data, with canned Run and Verify output.
- [x] With no backend reachable: renders the "Couldn't reach the Redux backend" banner plus "Can't show results right now." rather than a crash. Per the #5 decision, this unreachable-backend copy is deliberately distinct from the reachable-but-empty "0 problems" wording -- both are graceful, neither is an error page.
- [x] `npm run lint` is clean.
- [x] `npm run build` is clean.

## Bugs found and fixed during the pass

1. **Horizontal overflow on mobile.** Spot-checked T28's responsive breakpoints (flagged in that PR as never visually verified). Found a real 2px overflow at 375px on the Problem Detail page. Root cause: the "visually-hidden label" pattern in `components/SearchBar.js` and `components/detail/VerifierSection.js` set `width: 1`, `height: 1`, `margin: -1` as bare numbers -- MUI's `sx` reinterprets a bare number for a sizing prop as a percentage and for a spacing prop as a theme-spacing multiple, so the label rendered full-size (clipped from paint via `clip: rect(0,0,0,0)`, but still counted toward the page's scrollable area). Fixed with explicit unit strings (`"1px"`, `"-1px"`). Confirmed zero horizontal overflow at 375/768/1024/1440px on both pages afterward.
2. **Detail-page complexity badges rendering unstyled.** `pages/[problem].js` had its own `chipFamily` field mapping `"complexityClass"` -> `"complexity"`, which doesn't match any chip variant `components/theme.js` actually registers (one per `facet.key`, e.g. `"complexityClassOutlined"`) -- so NP-complete/NP/NP-hard fell back to default grey MUI chip styling on the detail page while the card grid's badges (which key off `facetKey` directly) looked correct. `problemType` happened to match by coincidence, which is why only the complexity badges looked wrong. Fixed by keying the variant off `facetKey` directly, matching `ProblemCatalogCard.js`'s existing pattern.
3. **Dead space below filtered results.** `pages/index.js`'s results column always claims the full remaining viewport height (`flex: 1, minHeight: 0`), and `ProblemGrid.js` matched it with `height: "100%"` -- so narrowing to a handful of cards left a large empty gap below the last row instead of the grid shrinking to fit. Switched to `maxHeight: "100%"` so the grid shrink-wraps its content and only claims (and scrolls within) the available space when there's actually enough content to need it. Verified both directions: a 1-result filter now renders a grid exactly as tall as that one card; the unfiltered 49-result grid still caps at the available height and scrolls to reach every row.

## UI changes requested mid-review

4. **Collapsed-by-default.** Home's sidebar facet groups and the Problem Detail page's five sections now default to collapsed instead of expanded (`FacetSidebar.js`, `SectionShell.js`). Updated the two e2e specs that assumed the old expanded-by-default state, and added an `expandFacetGroup` test helper.

## Also tested against the backend's in-review tag-system branch

Checked out `ReduxISU/Redux#396` (`feature/tag-system-expansion-375-379`) locally (`dotnet run`, `http://127.0.0.1:27000/`) and re-ran the same verification pass against it. Confirmed the frontend needs **zero code changes** to pick up that branch's new fields -- exactly the "boring swap" `ARCHITECTURE.md` calls for: real quantum complexity classes (BQP/EQP/QMA/QCMA/QIP/MIP\*, replacing the placeholder NPIntermediate/QuantumOracle handling) and real Reduction Type data (Restriction/Local Replacement/Component Design) both populated correctly, no console errors, no `NaN`/`undefined` artifacts. `.env.local` (gitignored, not part of this PR) is back on the production default after this check.

## Outstanding items for the project owner

- **T28 (#37)'s breakpoint/layout decisions** were made without a design reference (documented candidly in that PR's own description). Now visually spot-checked at the four reference widths on both pages and confirmed uncramped with no horizontal scroll.
- **T03 (#7)'s overlay coverage**: spot-checked, not exhaustively audited. Sidebar's Quantum Complexity Class options (QMA/QCMA/QIP/MIP*) show `(0)` against both backends today -- only BQP/EQP are populated, matching `ARCHITECTURE.md`'s note that only five specific problems were in scope for that research. Whether more problems should carry a quantum complexity class is a content question, not a code defect.
- **A stale code comment**: `components/detail/OverviewSection.js`'s header comment still describes the retired `data/fixtures.js` Shell-phase data shape (T31 deleted that file). Harmless, worth a follow-up cleanup pass.

## Verified

- `npm run lint`, `npm run build` both clean (checked after every change in this PR).
- `npm run test:e2e` -- 11/11 passing (the one test marked `✘` is `fixtures-wrapper.spec.js`'s intentional `test.fail()`).
- Manually driven with headless Chromium against both the live production backend and the local #396 branch: Home, filtering, chips, detail navigation, drag/keyboard reorder, collapse, no-backend state, all four responsive reference widths on both routes, and the two new default-collapsed / grid-sizing behaviors.

Closes #42