### PR TITLE
T36: Bound and restrict the backend proxy

### DIFF
--- a/pages/api/redux/[...path].js
+++ b/pages/api/redux/[...path].js
@@ -1,6 +1,145 @@
+/**
+ * Same-origin proxy to the Redux backend. Keeps `REDUX_BASE_URL` server-side so the
+ * browser only ever talks to `/api/redux/`.
+ *
+ * T36 (#94) added the resource controls below: timeout, body cap, rate limit, endpoint
+ * allowlist. They live here rather than in the client because this is the only layer
+ * this repo actually controls. A client-side `AbortController` stops the browser
+ * waiting, but it does not stop the backend computing and it does not free this
+ * request. Live Run (T37) and live Verify (T38) let a public page trigger
+ * arbitrary-complexity solves on demand, including exponential and factorial solvers,
+ * so the bounds have to be enforced server-side.
+ */
+
+/**
+ * How long we wait on the backend before giving up, in milliseconds.
+ *
+ * Two bounds, because the two kinds of traffic are nothing alike:
+ *
+ * - Read endpoints are the catalog batch calls. They are lookups and should be quick.
+ *   15s is deliberately below the 20s the end-to-end suite waits for Home to settle
+ *   (`tests/e2e/helpers.js`), so a hung backend surfaces as the "couldn't reach Redux"
+ *   banner inside that window rather than hanging the page until the test itself gives
+ *   up.
+ * - Compute endpoints (`solve`, `verify`) run a real algorithm, so they get 60s. Long
+ *   enough for a genuine solve on a small instance, short enough that a runaway one
+ *   releases the socket instead of being held open indefinitely.
+ *
+ * Recorded as a decision on #94.
+ */
+const READ_TIMEOUT_MS = 15_000;
+const COMPUTE_TIMEOUT_MS = 60_000;
+
+/**
+ * Largest request body we will accept, in bytes. Instances and certificates are text;
+ * 1 MiB is far more than any of them need, and still bounds what a single request can
+ * make this process hold in memory.
+ */
+const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+
+/**
+ * Non-GET rate limit: at most `RATE_LIMIT_MAX_REQUESTS` per client per
+ * `RATE_LIMIT_WINDOW_MS`. Sized for a person clicking Run or Verify and trying a few
+ * solvers, not for scripted traffic.
+ *
+ * Reads are not rate-limited. They are cheap lookups, they are already cached per page
+ * load in `lib/redux/index.js`, and limiting them would throttle ordinary catalog
+ * browsing for no benefit.
+ */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 10;
+
+/**
+ * Rate-limit counters, held in this process's memory only.
+ *
+ * Being blunt about what that means, because the honest description matters more than
+ * the feature: this is NOT a distributed rate limit. Counters are per Node process,
+ * they reset on restart or redeploy, and running more than one instance of this app
+ * multiplies the effective limit by the number of instances. It raises the cost of
+ * casually hammering the compute endpoints from a browser. It is not a defence against
+ * a determined or distributed attacker, and nothing downstream should assume it is. A
+ * real limit belongs in shared storage, or in front of the app.
+ */
+const rateLimitBuckets = new Map();
+
+/**
+ * Endpoints this frontend actually uses, and the methods each accepts. Anything else on
+ * the backend origin is refused.
+ *
+ * The surface is small and fully known (`lib/redux/index.js` is the only caller), so an
+ * allowlist costs almost nothing here and means a stray path cannot reach an endpoint
+ * nobody meant to expose. Adding a backend call means adding it to this map too. Track
+ * B (T41, #99) is expected to need at least one more entry once the visualization data
+ * contract is settled.
+ *
+ * Keys are paths relative to `REDUX_BASE_URL`, matched exactly and case-sensitively.
+ * Query strings are not part of the match.
+ */
+const ALLOWED_ENDPOINTS = new Map([
+  ["Navigation/Batch/allProblems", ["GET", "HEAD"]],
+  ["Navigation/Batch/allSolvers", ["GET", "HEAD"]],
+  ["Navigation/Batch/allVerifiers", ["GET", "HEAD"]],
+  ["Navigation/Batch/allVisualizations", ["GET", "HEAD"]],
+  ["Navigation/Batch/allVisualizationTypes", ["GET", "HEAD"]],
+  ["Navigation/Batch/allInfo", ["GET", "HEAD"]],
+  ["Navigation/Reductions", ["GET", "HEAD"]],
+  ["ProblemProvider/solve", ["POST"]],
+  ["ProblemProvider/verify", ["POST"]],
+]);
+
+/** Endpoints that run an algorithm rather than returning a stored lookup. */
+const COMPUTE_ENDPOINTS = new Set(["ProblemProvider/solve", "ProblemProvider/verify"]);
+
 export const config = {
   api: { bodyParser: false },
 };
+
+/**
+ * Identifies the caller for rate-limiting purposes.
+ *
+ * `x-forwarded-for` is trusted here because this app is expected to run behind a
+ * reverse proxy that sets it. That header is client-supplied, so it is spoofable if the
+ * app is ever exposed directly, which would let one caller present as many. That is an
+ * accepted limitation of an in-process limiter, consistent with the note on
+ * `rateLimitBuckets` above: keying on the socket address instead would lump every
+ * client behind the reverse proxy into one shared bucket, which breaks the normal
+ * deployment in order to harden an abnormal one.
+ */
+function clientKey(req) {
+  const forwarded = req.headers["x-forwarded-for"];
+  const raw = Array.isArray(forwarded) ? forwarded[0] : forwarded;
+  const first = raw?.split(",")[0]?.trim();
+  return first || req.socket?.remoteAddress || "unknown";
+}
+
+/**
+ * Fixed-window request counter for `key`.
+ * @returns `{ allowed: boolean, retryAfterSeconds: number }`.
+ */
+function checkRateLimit(key, now) {
+  // Drop windows that have already expired, so a long-running process does not
+  // accumulate one entry per client address it has ever seen.
+  for (const [existingKey, bucket] of rateLimitBuckets) {
+    if (bucket.resetAt <= now) {
+      rateLimitBuckets.delete(existingKey);
+    }
+  }
+
+  const bucket = rateLimitBuckets.get(key);
+  if (!bucket) {
+    rateLimitBuckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  bucket.count += 1;
+  if (bucket.count > RATE_LIMIT_MAX_REQUESTS) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    };
+  }
+  return { allowed: true, retryAfterSeconds: 0 };
+}
 
 export default async function handler(req, res) {
   const baseUrl = process.env.REDUX_BASE_URL;
@@ -32,6 +171,43 @@ export default async function handler(req, res) {
     return;
   }
 
+  // The origin check above still allows any path on the backend host. Pin the path too:
+  // the resolved request has to stay inside REDUX_BASE_URL's own subtree, and then has
+  // to name one of the endpoints this frontend uses. `new URL()` has already collapsed
+  // any `..` segments by this point, so a suffix trying to climb out of the base path
+  // fails the prefix test below.
+  const basePath = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
+  if (!target.pathname.startsWith(basePath)) {
+    res.status(400).json({ error: "Refusing to proxy request outside the configured backend" });
+    return;
+  }
+
+  const endpoint = target.pathname.slice(basePath.length);
+  const allowedMethods = ALLOWED_ENDPOINTS.get(endpoint);
+  if (!allowedMethods) {
+    res.status(404).json({ error: "Unknown Redux endpoint" });
+    return;
+  }
+  if (!allowedMethods.includes(req.method)) {
+    res.setHeader("Allow", allowedMethods.join(", "));
+    res.status(405).json({ error: `${req.method} is not allowed on this Redux endpoint` });
+    return;
+  }
+
+  const isRead = req.method === "GET" || req.method === "HEAD";
+
+  if (!isRead) {
+    const { allowed, retryAfterSeconds } = checkRateLimit(clientKey(req), Date.now());
+    if (!allowed) {
+      res.setHeader("Retry-After", String(retryAfterSeconds));
+      res.status(429).json({
+        error: "Too many requests. Wait a moment before running this again.",
+        retryAfterSeconds,
+      });
+      return;
+    }
+  }
+
   const headers = {};
   for (const [key, value] of Object.entries(req.headers)) {
     if (!["host", "connection", "transfer-encoding"].includes(key.toLowerCase())) {
@@ -44,28 +220,84 @@ export default async function handler(req, res) {
   // redirect response to the client and let the browser decide what to do.
   const fetchOptions = { method: req.method, headers, redirect: "manual" };
 
-  if (!["GET", "HEAD"].includes(req.method)) {
+  if (!isRead) {
+    // Check the running total before keeping each chunk, rather than buffering
+    // everything and measuring afterwards. The point of the cap is never to hold an
+    // oversized body in memory in the first place.
+    //
+    // `destroyOnReturn: false` is load-bearing, not a tidiness flag. A plain
+    // `for await (const chunk of req)` destroys the stream when the loop breaks, and
+    // destroying an IncomingMessage tears down its socket -- so the client would get a
+    // connection reset instead of the 413 we are trying to send it.
     const chunks = [];
-    for await (const chunk of req) {
-      chunks.push(chunk);
+    let received = 0;
+    let tooLarge = false;
+    try {
+      for await (const chunk of req.iterator({ destroyOnReturn: false })) {
+        received += chunk.length;
+        if (received > MAX_REQUEST_BODY_BYTES) {
+          tooLarge = true;
+          break;
+        }
+        chunks.push(chunk);
+      }
+    } catch (err) {
+      res.status(400).json({ error: `Could not read request body: ${err.message}` });
+      return;
     }
+
+    if (tooLarge) {
+      // Close rather than keep-alive: we deliberately stopped reading this request
+      // body, so the connection can't be reused for another request. `resume()` throws
+      // away whatever is still arriving instead of buffering it, which keeps memory
+      // bounded while still letting the 413 reach the client.
+      res.setHeader("Connection", "close");
+      res.status(413).json({
+        error: `Request body exceeds the ${MAX_REQUEST_BODY_BYTES} byte limit`,
+      });
+      req.resume();
+      return;
+    }
+
     fetchOptions.body = Buffer.concat(chunks);
   }
 
-  // #5: an unreachable backend must not throw an unhandled error — the caller
+  // Bound how long the backend can hold this request open. The abort covers reading the
+  // response body as well as getting the response headers, which is why the timer is
+  // only cleared once the whole response is in hand.
+  const timeoutMs = COMPUTE_ENDPOINTS.has(endpoint) ? COMPUTE_TIMEOUT_MS : READ_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  fetchOptions.signal = controller.signal;
+
+  // #5: an unreachable backend must not throw an unhandled error. The caller
   // (lib/redux) needs a response it can turn into the "couldn't reach Redux"
   // banner, not a crashed API route.
   let upstream;
+  let body;
   try {
     upstream = await fetch(target, fetchOptions);
+    body = await upstream.arrayBuffer();
   } catch (err) {
+    // 504 rather than 502, so the client can say "this took too long" instead of "the
+    // backend is down". Two different problems, with two different things to do about
+    // them, and T37/T38 need to tell them apart to write the right copy.
+    if (controller.signal.aborted) {
+      res.status(504).json({
+        error: `Redux did not respond within ${timeoutMs / 1000}s`,
+        timeoutMs,
+      });
+      return;
+    }
     res.status(502).json({ error: `Upstream unreachable: ${err.message}` });
     return;
+  } finally {
+    clearTimeout(timeout);
   }
 
   res.status(upstream.status);
   // Node's fetch (undici) transparently decompresses a gzip/br response body before
-  // upstream.arrayBuffer() below ever sees it -- so forwarding the upstream
+  // upstream.arrayBuffer() above ever sees it -- so forwarding the upstream
   // content-encoding/content-length headers verbatim lies to the browser about what
   // res.end() actually sends: it claims a still-compressed body of the original
   // (compressed) byte length, which is neither. Chromium then fails every such
@@ -81,6 +313,5 @@ export default async function handler(req, res) {
     }
   }
 
-  const body = await upstream.arrayBuffer();
   res.end(Buffer.from(body));
 }


### PR DESCRIPTION
The proxy at `pages/api/redux/[...path].js` is the only thing sitting between the public site and the Redux backend. Until now it would forward any method to any path on that backend, wait forever for a reply, read a request body of any size into memory, and accept as many requests as anyone cared to send.

That matters now because live Run and live Verify (T37, T38) will let a visitor start a real solve on demand, including with solvers that take exponential or factorial time. The limits have to exist before those buttons are switched on, and they have to be on the server: a Cancel button in the browser stops the page waiting, but it does not stop the backend computing and it does not free up the connection.

Everything below is in that one file.

## What changed

**A time limit on waiting for the backend.** Catalog lookups get 15 seconds. The two endpoints that actually run an algorithm, `solve` and `verify`, get 60. When the limit is hit the proxy answers 504, rather than the 502 it already uses for a backend that cannot be reached, so the Solvers and Verifier sections can later say "this took too long" instead of "the backend is down". The 15 second figure is deliberately below the 20 seconds the end-to-end tests wait for the Home page to settle, so a stuck backend shows the "couldn't reach Redux" banner inside that window instead of hanging until the test itself gives up.

**A 1 MB limit on request bodies.** The size is checked as the body arrives rather than after all of it has been read, so an oversized request is turned away with a 413 instead of being held in memory first.

**A limit of 10 non-GET requests per minute, per client.** Ordinary browsing is untouched: the catalog requests are plain lookups and are already cached while a page is open, so rate limiting them would slow down normal use for no benefit. The counter lives in the server's own memory, which means it resets whenever the app restarts and does not add up across multiple copies of the app. There is a comment in the code saying exactly that, so nobody later mistakes it for something stronger than it is.

**A list of the endpoints the site is allowed to reach.** There are nine, and `lib/redux/index.js` is the only thing that calls any of them. Anything else on the backend now gets a 404, and a known endpoint requested with the wrong method gets a 405 plus an `Allow` header. The proxy also now checks that the request stays inside the backend path it was configured with. The previous check compared only the host, so every path on that host was reachable through a public route.

One implementation note worth flagging for review: reading the body uses `req.iterator({ destroyOnReturn: false })` rather than a plain `for await`. A plain loop destroys the request when it breaks, which tears down the connection, and the caller would get a connection reset instead of the 413 the proxy is trying to send. That was confirmed by hand, not assumed.

The protections that were already in place are unchanged. The request still cannot be steered to a different host, redirects are still not followed, and the compressed-response header handling that fixed the earlier `ERR_CONTENT_DECODING_FAILED` bug is untouched.

## How it was checked

Against a stub backend that could be made to hang, and against the live backend at `https://redux.isu.edu/api/redux/`:

- All seven read endpoints return 200 from the live backend, including the 477 KB `allInfo` response, well inside the 15 second limit.
- The full Playwright suite passes against the live backend (11 tests), so the catalog and detail pages still load normally.
- The read timeout fires at 15.0s and the compute timeout at 60.0s, both returning 504.
- A 2 MB request body is refused with a 413 that reaches the client; a 900 KB one is forwarded normally.
- The 11th non-GET request in a minute gets a 429 with a `Retry-After` header, while 20 GETs in a row all succeed.
- A path the backend would happily serve, but that is not on the list, gets a 404 and never reaches the backend.
- With the backend pointed at a dead port, the route still returns the 502 the error banner depends on, and keeps working for the next request rather than falling over.

## Done when

Met:

- Upstream requests time out at a documented bound and return a distinguishable status (504, distinct from the 502 for unreachable).
- Oversized request bodies are rejected before being fully buffered.
- Non-GET requests are rate-limited, with the storage model stated honestly in a comment.
- The method and path allowlist is implemented.
- The host check, the manual redirect handling, and the content-encoding stripping all still work.
- Catalog and detail pages still load normally against a real backend.
- An unreachable backend still yields the error-banner path, not a crashed route.
- The chosen limits are recorded on the issue in the decision format.

Not met: none.

## Decisions and assumptions

The four limits are written up in the decision format in a comment on the issue. In short:

- Two timeouts rather than one, because a number that suits a real solve is far too long for a catalog lookup.
- The allowlist was implemented rather than declined. Adding a backend call now means adding a line to the list, which is a small ongoing cost, but a visible one. Track B (T41) is the likely first task to need a new entry, and there is a comment saying so.
- The rate limit keys on `x-forwarded-for`, which is spoofable if the app is ever exposed without a reverse proxy in front of it. Keying on the socket address instead would put every visitor behind the expected reverse proxy into one shared bucket, which would break the normal deployment in order to harden an abnormal one. The tradeoff is written down in the code.
- The limits are constants in the file, not environment variables. Nothing asked for them to be tunable at deploy time, and the numbers are documented where someone changing them will be reading. Easy to switch to environment variables later if operating the app calls for it.

Closes #94

Checks run before opening this PR: format-check: pass; lint: pass; build: pass; audit: clean; integration-test: skipped locally (runs in CI via rbs)