### PR TITLE
T35: Give Solvers and Verifier a real, editable problem instance

### DIFF
--- a/components/ProblemDetailLayout.js
+++ b/components/ProblemDetailLayout.js
@@ -51,6 +51,22 @@
 // item overview was moved...". SECTION_ANNOUNCEMENTS below overrides them
 // with text naming the real section title instead.
 //
+// --- Decision: the problem instance is one shared value, owned here --------
+// T35 (#93). Solvers and Verifier both need a problem instance, and this
+// component holds the single copy of it. Both sections render their own
+// editable input bound to that one value, so editing either updates both.
+//
+// Ratified on #93 by the project owner: verifying a certificate against a
+// different instance than the one that was solved is a silent, meaningless
+// error, and two independent inputs allow exactly that with no signal to
+// the user. One value makes it impossible. Both sections still get their
+// own control because sections are independently collapsible (and default
+// to collapsed) and drag-reorderable, so a single control living inside
+// one section can be hidden, or can sit below the section that needs it.
+// This component is the right owner because it already holds section-order
+// state and already renders both sections from SECTIONS. pages/[problem].js
+// passes only `problem` and stays that way.
+//
 // --- No persistence ---------------------------------------------------------
 // `order` is plain component-local useState. No localStorage, no URL
 // params — per the issue body and TASKLIST.md's T18 entry ("do not add
@@ -86,11 +102,15 @@ import VisualizationsSection from "./detail/VisualizationsSection";
 // Default order per the ratified "move Reduce pane below Verify" decision
 // (TASKLIST.md T18 entry) — Reductions goes last deliberately, not by
 // omission.
+//
+// `usesInstance` marks the two sections that take the shared problem
+// instance (T35/#93, see header) -- the other three are rendered with
+// `problem` alone, exactly as before.
 const SECTIONS = [
   { key: "overview", title: "Overview", Component: OverviewSection },
   { key: "visualizations", title: "Visualizations", Component: VisualizationsSection },
-  { key: "solvers", title: "Solvers", Component: SolversSection },
-  { key: "verifier", title: "Verifier", Component: VerifierSection },
+  { key: "solvers", title: "Solvers", Component: SolversSection, usesInstance: true },
+  { key: "verifier", title: "Verifier", Component: VerifierSection, usesInstance: true },
   { key: "reductions", title: "Reductions", Component: ReductionsSection },
 ];
 
@@ -160,6 +180,25 @@ function SortableSection({ id, children }) {
  */
 export default function ProblemDetailLayout({ problem }) {
   const [order, setOrder] = useState(DEFAULT_ORDER);
+
+  // The shared problem instance (T35/#93), pre-filled from the problem's
+  // real declared `defaultInstance`.
+  const [instance, setInstance] = useState(problem.defaultInstance ?? "");
+
+  // Re-seed the box when the page switches to a different problem, so one
+  // problem's instance can never be left sitting in another's input. In
+  // practice pages/[problem].js unmounts this component while the next
+  // problem is loading, which would reset the state anyway, but that is a
+  // side effect of how the loading state happens to be rendered rather
+  // than something this component should depend on. React's documented
+  // "adjust state when a prop changes" pattern, not an effect: it settles
+  // during the same render instead of flashing the previous problem's
+  // instance for a frame first.
+  const [instanceProblemName, setInstanceProblemName] = useState(problem.name);
+  if (instanceProblemName !== problem.name) {
+    setInstanceProblemName(problem.name);
+    setInstance(problem.defaultInstance ?? "");
+  }
 
   // PointerSensor covers mouse; TouchSensor adds mobile/tablet support
   // (both ported from Redux_GUI). KeyboardSensor is new here — see file
@@ -242,10 +281,13 @@ export default function ProblemDetailLayout({ problem }) {
         <SortableContext items={order} strategy={verticalListSortingStrategy}>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
             {order.map((key) => {
-              const { Component } = SECTIONS_BY_KEY.get(key);
+              const { Component, usesInstance } = SECTIONS_BY_KEY.get(key);
+              const instanceProps = usesInstance
+                ? { instanceValue: instance, onInstanceChange: setInstance }
+                : null;
               return (
                 <SortableSection key={key} id={key}>
-                  <Component problem={problem} />
+                  <Component problem={problem} {...instanceProps} />
                 </SortableSection>
               );
             })}

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -10,16 +10,20 @@
 // 3-SAT's DPLL entry does), that result is shown statically next to the
 // disabled Run button, standing in for "the same canned result every time."
 //
-// Known gap, not fabricated: data/fixtures.js's FixtureProblem shape has no
-// instanceFormat/example/default-instance field for any problem — the
-// mockup's CNF-specific "PASTE AN INSTANCE" text was hand-drawn for 3-SAT
-// and was never added to the fixture data contract (T09). Inventing
-// plausible-looking format text here would fabricate data this component
-// has no real source for, and wouldn't even make sense for a non-SAT
-// problem like Knapsack. So this block degrades to a plain "not yet
-// available" message instead — same spirit as this project's documented
-// "Assignment Table" visualizationType gap. See this task's PR for the
-// decision writeup.
+// T35 (#93): the instance box is real and editable now. It pre-fills with
+// the problem's declared `defaultInstance` (a required backend field; all
+// 50 problems supply a runnable one) and its value is owned by
+// components/ProblemDetailLayout.js, not by this section, because the
+// Verifier section shows the same single value. See that file's header for
+// why. Run stays disabled regardless: turning it on is T37 (#95).
+//
+// The format block above the box shows the problem's `instanceFormat`,
+// prose with an embedded example. Only 18 of the 50 problems declare one
+// today, so the block says so plainly for the rest rather than inventing
+// format text. That never disables the box: the instance itself is always
+// available even when the prose describing it is not. (This replaces an
+// older note here claiming no instance field existed anywhere in the data
+// at all, which was wrong, see #92.)
 //
 // T28 (#37): the solver-list-plus-detail-pane split stacks below `md`
 // (900px), same breakpoint components/detail/VisualizationsSection.js's
@@ -84,10 +88,22 @@ const INSTANCE_TEXTAREA_ID = "solvers-instance-input";
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {string} [props.instanceValue] The shared problem instance, owned
+ *   by components/ProblemDetailLayout.js (T35/#93). Empty string when the
+ *   problem declares no instance.
+ * @param {(next: string) => void} [props.onInstanceChange] Called with the
+ *   new text whenever the visitor edits the box. The Verifier section's own
+ *   instance input is bound to the same value, so an edit here shows up
+ *   there too.
  * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
  *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function SolversSection({ problem, dragHandleProps }) {
+export default function SolversSection({
+  problem,
+  instanceValue = "",
+  onInstanceChange,
+  dragHandleProps,
+}) {
   const solvers = problem.solvers ?? [];
   const [selectedIndex, setSelectedIndex] = useState(0);
   const selected = solvers[selectedIndex];
@@ -105,11 +121,33 @@ export default function SolversSection({ problem, dragHandleProps }) {
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Typography variant="overline" sx={{ color: "text.secondary" }}>
-            Paste an instance — matches instanceFormat below
+            Paste an instance
           </Typography>
-          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
-            Instance format not yet available for this problem.
-          </Typography>
+          {problem.instanceFormat ? (
+            // Same presentation the Verifier section gives certificateFormat
+            // (a mono block in a padded panel), since these two fields are
+            // the same kind of thing: prose with an embedded example.
+            <Box
+              component="pre"
+              sx={{
+                mt: 1.5,
+                mb: 0,
+                p: 1.5,
+                borderRadius: 1,
+                backgroundColor: "background.default",
+                overflowX: "auto",
+              }}
+            >
+              <Typography variant="mono" component="code" sx={{ whiteSpace: "pre-wrap" }}>
+                {problem.instanceFormat}
+              </Typography>
+            </Box>
+          ) : (
+            <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+              Instance format not yet documented for this problem. The instance below is still the
+              problem&apos;s own declared example.
+            </Typography>
+          )}
           <Box component="label" htmlFor={INSTANCE_TEXTAREA_ID} sx={{ display: "block", mt: 1.5 }}>
             <Typography variant="body2" sx={{ color: "text.secondary", mb: 0.5 }}>
               Instance
@@ -119,7 +157,8 @@ export default function SolversSection({ problem, dragHandleProps }) {
             id={INSTANCE_TEXTAREA_ID}
             component="textarea"
             rows={2}
-            readOnly
+            value={instanceValue}
+            onChange={(event) => onInstanceChange?.(event.target.value)}
             placeholder="No default instance declared for this problem yet."
             sx={{
               width: "100%",

--- a/components/detail/VerifierSection.js
+++ b/components/detail/VerifierSection.js
@@ -14,6 +14,15 @@
 // Per the ratified naming convention this section's title is always the
 // generic "Verifier" — never problem-prefixed — so it's hardcoded by this
 // component's caller-facing contract, not derived from `problem.name`.
+//
+// T35 (#93): this section now also shows the problem instance the
+// certificate is being checked against. Verifying a certificate against a
+// different instance than the one that was solved is a silent, meaningless
+// error, so there is exactly one instance value on the page: it lives in
+// components/ProblemDetailLayout.js and both this section and the Solvers
+// section render their own input bound to it. Editing either updates both.
+// See that file's header for the full decision. Verify stays disabled:
+// turning it on is T37 (#95).
 
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
@@ -27,6 +36,10 @@ import SectionShell from "./SectionShell";
 
 const CERTIFICATE_INPUT_ID_PREFIX = "verifier-certificate-input";
 
+// Distinct from SolversSection's own "solvers-instance-input" (ground rule
+// 4): the two inputs share a value, never an id.
+const INSTANCE_INPUT_ID = "verifier-instance-input";
+
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
@@ -36,10 +49,22 @@ const CERTIFICATE_INPUT_ID_PREFIX = "verifier-certificate-input";
  *   optional field populated; most problems have just the two required
  *   fields, and Closest Pair of Points has `verifier: null` entirely and
  *   deliberately (the fixture's own "incomplete problem" example).
+ * @param {string} [props.instanceValue] The shared problem instance, owned
+ *   by components/ProblemDetailLayout.js (T35/#93). Empty string when the
+ *   problem declares no instance.
+ * @param {(next: string) => void} [props.onInstanceChange] Called with the
+ *   new text whenever the visitor edits the instance here. The Solvers
+ *   section's input is bound to the same value, so an edit here shows up
+ *   there too.
  * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
  *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function VerifierSection({ problem, dragHandleProps }) {
+export default function VerifierSection({
+  problem,
+  instanceValue = "",
+  onInstanceChange,
+  dragHandleProps,
+}) {
   const verifier = problem.verifier;
   const [certificateValue, setCertificateValue] = useState(verifier?.exampleCertificate ?? "");
   const inputId = `${CERTIFICATE_INPUT_ID_PREFIX}-${problem.slug}`;
@@ -83,7 +108,28 @@ export default function VerifierSection({ problem, dragHandleProps }) {
 
         <Paper variant="outlined" sx={{ p: 2 }}>
           <Typography variant="overline" sx={{ color: "text.secondary" }}>
-            Check a Certificate — matches the format above
+            Check a Certificate
+          </Typography>
+
+          <Box component="label" htmlFor={INSTANCE_INPUT_ID} sx={{ display: "block", mt: 1.5 }}>
+            <Typography variant="body2" sx={{ color: "text.secondary", mb: 0.5 }}>
+              Problem instance
+            </Typography>
+          </Box>
+          <TextField
+            id={INSTANCE_INPUT_ID}
+            fullWidth
+            multiline
+            minRows={2}
+            size="small"
+            value={instanceValue}
+            onChange={(event) => onInstanceChange?.(event.target.value)}
+            placeholder="No default instance declared for this problem yet."
+            slotProps={{ htmlInput: { sx: { fontFamily: monoFontFamily } } }}
+          />
+          <Typography variant="body2" sx={{ mt: 0.5, color: "text.secondary" }}>
+            This is the same instance the Solvers section shows. Editing it in either place changes
+            both, so a certificate is always checked against the instance that was solved.
           </Typography>
 
           <Box

--- a/hooks/useProblemDetail.js
+++ b/hooks/useProblemDetail.js
@@ -165,6 +165,18 @@ function buildProblem(problemCode, info, batches, codeToName) {
       source: problemInfo.source || undefined,
       contributedBy: contributors.length > 0 ? contributors.join(", ") : undefined,
     },
+    // T35 (#93): the instance the Solvers and Verifier sections show, and
+    // the prose format describing it, both straight off allInfo. Kept as
+    // their own top-level fields rather than folded into `overview`: the
+    // Overview mapping has its own instanceFormat-then-problemDefinition
+    // fallback chain for a different purpose (see this file's header), and
+    // the Solvers format block needs to be able to change without
+    // disturbing it. `defaultInstance` is a required IProblem member and
+    // all 50 problems supply one (verified against the live API
+    // 2026-09-02), but a missing one is still normalized to "" here rather
+    // than assumed away, so the input below it is always a string.
+    defaultInstance: problemInfo.defaultInstance || "",
+    instanceFormat: problemInfo.instanceFormat || "",
     solvers: buildSolvers(solversByProblem[problemCode], info),
     visualizations: buildVisualizations(visualizationsByProblem[problemCode], info),
     verifier: buildVerifier(verifiersByProblem[problemCode], info, problemInfo),

--- a/tests/e2e/detail.spec.js
+++ b/tests/e2e/detail.spec.js
@@ -4,6 +4,9 @@
 // reaches the detail page, sections collapse/expand, sections can be
 // reordered with the keyboard, and "Reset to default" restores the order.
 //
+// T35 (#93) added the last test: the Solvers and Verifier sections show one
+// shared, editable problem instance.
+//
 // Never names a specific problem -- every test opens whichever problem the
 // live catalog happens to put first (helpers.js's gotoFirstProblemDetail),
 // same "don't hardcode catalog contents" reasoning as home.spec.js.
@@ -68,4 +71,34 @@ test("Reset to default restores the canonical section order", async ({ page }) =
   await page.locator("#detail-layout-reset").click();
 
   await expect(status).toHaveText(DEFAULT_LAYOUT_STATUS);
+});
+
+// T35 (#93). Both sections render their own input bound to a single value
+// owned by components/ProblemDetailLayout.js, so a certificate can never be
+// checked against a different instance than the one that was solved. Reads
+// whatever instance the live backend declares for this problem rather than
+// asserting a literal, same reasoning as the rest of this file.
+test("Solvers and Verifier share one editable problem instance", async ({ page }) => {
+  await gotoFirstProblemDetail(page, { expect });
+
+  await page.locator("#section-solvers-toggle").click();
+  await page.locator("#section-verifier-toggle").click();
+
+  const solversInstance = page.locator("#solvers-instance-input");
+  const verifierInstance = page.locator("#verifier-instance-input");
+
+  // Pre-filled from the problem's declared defaultInstance, which every
+  // problem in the catalog supplies today.
+  const declaredInstance = await solversInstance.inputValue();
+  expect(declaredInstance).not.toBe("");
+  await expect(verifierInstance).toHaveValue(declaredInstance);
+
+  await solversInstance.fill(`${declaredInstance} edited-in-solvers`);
+  await expect(verifierInstance).toHaveValue(`${declaredInstance} edited-in-solvers`);
+
+  await verifierInstance.fill(`${declaredInstance} edited-in-verifier`);
+  await expect(solversInstance).toHaveValue(`${declaredInstance} edited-in-verifier`);
+
+  // Ground rule 5: this task leaves both actions inert.
+  await expect(page.locator("#solvers-run-button")).toBeDisabled();
 });


### PR DESCRIPTION
The Solvers section used to show a read-only box saying no default instance was declared for the problem. That was never true. The backend publishes a real, runnable instance for every problem in the catalog (all 50 of them, checked against the live API while doing this), and it arrives in the same allInfo response the detail page already downloads. This change reads it and puts it on screen, in both places that need it.

What changed:

- `hooks/useProblemDetail.js` now hands the page two more fields off that response: `defaultInstance` (the runnable instance itself) and `instanceFormat` (prose describing the format, with an example in it). They are their own fields rather than folded into the Overview block, because Overview has its own fallback rules for a different purpose and the two should be able to change independently.
- `components/ProblemDetailLayout.js` holds the instance. There is exactly one value for the whole page, pre-filled from the problem's declared instance, and it re-seeds when you navigate to a different problem.
- `components/detail/SolversSection.js` box is editable now instead of read-only, and it shows the problem's real instance format above it. For the 32 problems that do not declare a format yet, it says so in a sentence and leaves the box usable, since the instance is there whether or not the prose describing it is.
- `components/detail/VerifierSection.js` gained an instance field, which it never had. It is bound to the same single value as the Solvers box, so editing either one updates both. That is deliberate: checking a certificate against a different instance than the one that was solved is a silent, meaningless error, and one shared value makes it impossible. The two inputs have their own ids (`solvers-instance-input` and `verifier-instance-input`); only the value is shared.
- `tests/e2e/detail.spec.js` gained a test covering that: both boxes pre-fill with the same declared instance, and an edit in either one shows up in the other.

Run and Verify are still disabled and still out of the tab order. Turning them on is T37 (#95).

Done when, met:

- `defaultInstance` and `instanceFormat` are exposed as their own fields by `useProblemDetail.js`.
- The Solvers instance box is editable, holds state, and keeps its id and label.
- It pre-fills with the problem's real declared instance.
- `instanceFormat` renders for the problems that have one, and its absence is stated plainly without disabling the box.
- One shared instance owned by ProblemDetailLayout, with a bound editable input in both sections, each with its own id.
- A problem with no instance still renders intact with no console error (checked by intercepting the backend response and blanking the instance for one problem: the page renders, both boxes are empty and show the placeholder, and the browser console stays clean).
- No instance text is hardcoded in any component.
- Run and Verify are still disabled and out of the tab order.
- `npm run lint`, `npm run format` and `npm run build` are clean, and the Playwright detail tests pass against the live backend.

Done when, not met: none.

Decisions and assumptions:

- The Verifier's new instance field sits at the top of the "Check a Certificate" panel, above the certificate input, with a visible "Problem instance" label and a line saying the value is shared with the Solvers section. The panel heading lost its trailing "matches the format above" clause, which pointed at the certificate format and would have read as if it described the instance now that a second field sits under it.
- The instance box re-seeds when the page switches to a different problem. In practice the page unmounts this component while the next problem loads, so the value would reset anyway, but relying on that would make correctness depend on how an unrelated loading state happens to be rendered.
- A missing or empty instance is normalized to an empty string in the hook, so the input always has a string to show. Every problem supplies one today, but nothing here assumes that.
- Added the end-to-end test rather than leaving the behaviour uncovered until T39 (#97). T39 is about live Run and Verify; this test only covers the shared box, which is what this task actually adds.

Closes #93

Checks run before opening this PR: format-check: pass; lint: pass; build: pass; audit: clean; integration-test: skipped locally (runs in CI via rbs)