### PR TITLE
T37: Wire live Run and Verify

### DIFF
--- a/components/detail/ComputeStatus.js
+++ b/components/detail/ComputeStatus.js
@@ -1,0 +1,141 @@
+// components/detail/ComputeStatus.js
+//
+// T37 (#95): the bit of a live Run or a live Verify that looks the same in
+// both sections: the spinner, the Cancel button, the screen-reader
+// announcement, and the failure notice. Solvers and Verifier render their
+// own action button and their own idea of a result, but everything between
+// pressing the button and getting an answer is identical, so it lives here
+// once.
+//
+// --- Why the announcement and the failure box are separate elements ------
+// The live region is always mounted and never carries a role that
+// announces twice. A screen reader is told about a state change because the
+// text inside an existing `role="status"` region changed, which is the
+// reliable way to do it: a region that appears at the same moment as its
+// text is frequently missed entirely.
+//
+// The failure box below it is deliberately NOT a live region and has no
+// `role="alert"`. It is the same information at more length, and marking
+// both would announce every failure twice. The short version in the live
+// region is what gets spoken; the box is what gets read.
+//
+// These controls announced nothing at all before this task, because they
+// were inert, so this is the first feedback either section has ever given
+// a screen-reader user. A solve can run for up to the proxy's 60 second
+// compute limit, which is far too long to leave someone guessing.
+
+import Box from "@mui/material/Box";
+import CircularProgress from "@mui/material/CircularProgress";
+import Typography from "@mui/material/Typography";
+import { COMPUTE_CANCELLED, COMPUTE_FAILED, COMPUTE_RUNNING } from "../../hooks/useComputeRequest";
+
+/**
+ * Cancel does not stop the backend. Saying otherwise would be the easiest
+ * inaccuracy to ship here, so the wording is fixed in one place.
+ */
+export const CANCEL_EXPLANATION =
+  "Stopped waiting for an answer. Redux may still be finishing the computation on its end; only its own time limit stops that.";
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders
+ *   (ground rule 4: no literal ids inside a reusable component).
+ * @param {string} props.status One of the COMPUTE_* values from
+ *   hooks/useComputeRequest.js.
+ * @param {string} props.announcement One short sentence describing the
+ *   current state, spoken by the live region. Empty string while idle.
+ * @param {{headline: string, detail: string, expected?: string}|null}
+ *   [props.failure] Set when `status` is failed.
+ * @param {() => void} props.onCancel Called by the Cancel button.
+ * @param {string} props.busyLabel Visible text next to the spinner, e.g.
+ *   "Running Clique Brute Force Solver".
+ */
+export default function ComputeStatus({
+  idPrefix,
+  status,
+  announcement,
+  failure = null,
+  onCancel,
+  busyLabel,
+}) {
+  const isRunning = status === COMPUTE_RUNNING;
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+      <Box
+        id={`${idPrefix}-status`}
+        role="status"
+        aria-live="polite"
+        sx={{ color: "text.secondary" }}
+      >
+        <Typography variant="body2" sx={{ color: "inherit" }}>
+          {announcement}
+        </Typography>
+      </Box>
+
+      {isRunning && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, flexWrap: "wrap" }}>
+          <CircularProgress size={18} aria-hidden="true" />
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            {busyLabel}
+          </Typography>
+          <Box
+            id={`${idPrefix}-cancel-button`}
+            component="button"
+            type="button"
+            onClick={onCancel}
+            sx={{
+              border: "1px solid",
+              borderColor: "divider",
+              borderRadius: 999,
+              px: 1.5,
+              py: 0.5,
+              color: "text.primary",
+              backgroundColor: "transparent",
+              font: "inherit",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </Box>
+        </Box>
+      )}
+
+      {status === COMPUTE_CANCELLED && (
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          {CANCEL_EXPLANATION}
+        </Typography>
+      )}
+
+      {status === COMPUTE_FAILED && failure && (
+        <Box
+          id={`${idPrefix}-failure`}
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 0.5,
+            p: 1.5,
+            borderRadius: 1,
+            color: "error.light",
+            backgroundColor: "rgba(248, 113, 113, 0.12)",
+            border: "1px solid",
+            borderColor: "rgba(248, 113, 113, 0.4)",
+          }}
+        >
+          <Typography variant="body2" sx={{ color: "inherit", fontWeight: 700 }}>
+            {failure.headline}
+          </Typography>
+          <Typography variant="body2" sx={{ color: "inherit" }}>
+            {failure.detail}
+          </Typography>
+          {failure.expected && (
+            <Typography variant="body2" sx={{ color: "inherit" }}>
+              Redux expected: {failure.expected}
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -4,18 +4,33 @@
 // instance" block (format description + pre-filled input), a left rail of
 // declared solvers, and a right detail pane with a canned Run.
 //
-// v1 scope (ground rule 5): Run is present but `disabled` and produces no
-// live output — wiring `requestSolvedInstance()` live is explicitly out of
-// v1. Where the fixture already supplies a canned runtime/result (only
-// 3-SAT's DPLL entry does), that result is shown statically next to the
-// disabled Run button, standing in for "the same canned result every time."
+// T37 (#95): Run is live. It calls `requestSolvedInstance()` with the
+// selected solver's class name and the shared instance, and the answer
+// replaces the declared runtime/result rows underneath. Before this task it
+// was a real `disabled` button producing nothing, per ground rule 5, and
+// this is the task that lifts that for the Solvers section.
+//
+// Three things that took more care than the call itself:
+//
+//   - Staleness. A brute-force solver can run for the full 60 seconds the
+//     proxy allows, and the solver rail is right there to click during it.
+//     Selecting a different solver clears the run, and the result is also
+//     tagged with the solver and the instance it came from, so an answer
+//     can never be shown next to a solver that did not produce it.
+//   - The declared display path stays. A problem whose data carries a
+//     runtime and a result still shows them before anything has been run
+//     (#95: "do not remove the declared-data display path").
+//   - Runtime. The Redux API returns the solved instance and nothing else:
+//     no runtime figure at all. So a live result shows the round trip this
+//     browser measured, labelled as exactly that, rather than presenting a
+//     network-inclusive number as if it were the solver's own running time.
 //
 // T35 (#93): the instance box is real and editable now. It pre-fills with
 // the problem's declared `defaultInstance` (a required backend field; all
 // 50 problems supply a runnable one) and its value is owned by
 // components/ProblemDetailLayout.js, not by this section, because the
 // Verifier section shows the same single value. See that file's header for
-// why. Run stays disabled regardless: turning it on is T37 (#95).
+// why.
 //
 // The format block above the box shows the problem's `instanceFormat`,
 // prose with an embedded example. Only 18 of the 50 problems declare one
@@ -38,7 +53,16 @@ import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 import { TAXONOMY } from "../../data/taxonomy";
+import {
+  COMPUTE_CANCELLED,
+  COMPUTE_DONE,
+  COMPUTE_FAILED,
+  COMPUTE_RUNNING,
+  useComputeRequest,
+} from "../../hooks/useComputeRequest";
+import { REDUX_API_BASE_URL, requestSolvedInstance } from "../../lib/redux";
 import { getFacetAccentColor, thinScrollbarSx } from "../theme";
+import ComputeStatus from "./ComputeStatus";
 import SectionShell from "./SectionShell";
 
 // #71: fixed rail height so a problem with many declared solvers scrolls
@@ -85,6 +109,24 @@ function ComplexityBucketBadge({ bucketKey }) {
 
 const INSTANCE_TEXTAREA_ID = "solvers-instance-input";
 
+// One prefix for every id ComputeStatus renders inside this section, so the
+// Solvers status region and the Verifier's can never collide (ground rule
+// 4).
+const RUN_ID_PREFIX = "solvers-run";
+
+// The API returns the solved instance as a bare JSON string, but a future
+// solver returning something structured should still render rather than
+// print "[object Object]".
+function formatSolverOutput(value) {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value, null, 2);
+}
+
+function formatSeconds(milliseconds) {
+  return `${(milliseconds / 1000).toFixed(2)}s`;
+}
+
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
@@ -110,6 +152,62 @@ export default function SolversSection({
 
   const noun = solvers.length === 1 ? "solver" : "solvers";
   const summary = `${solvers.length} ${noun}`;
+
+  const run = useComputeRequest({ subject: "instance" });
+
+  const trimmedInstance = instanceValue.trim();
+  const canRun = Boolean(selected?.className) && trimmedInstance !== "";
+
+  // A result is only ever shown next to the solver that produced it. The
+  // selection handler below already clears the run, so this is the second
+  // of two guards rather than the only one -- worth having, because the
+  // rail is not the only thing that can change which solver `selected`
+  // points at (a problem whose solver list changes underneath this
+  // component would too).
+  const liveResult =
+    run.status === COMPUTE_DONE && run.result?.solverClassName === selected?.className
+      ? run.result
+      : null;
+  const instanceChangedSinceRun = Boolean(liveResult) && liveResult.instance !== instanceValue;
+
+  function handleSelectSolver(index) {
+    if (index === selectedIndex) return;
+    // Drops any in-flight request and clears the pane, so nothing from the
+    // previous solver survives the switch.
+    run.reset();
+    setSelectedIndex(index);
+  }
+
+  function handleRun() {
+    if (!canRun) return;
+    const solver = selected;
+    run.start(async (signal) => {
+      const output = await requestSolvedInstance(
+        REDUX_API_BASE_URL,
+        solver.className,
+        instanceValue,
+        signal,
+      );
+      return {
+        output,
+        solverClassName: solver.className,
+        solverName: solver.name,
+        instance: instanceValue,
+      };
+    });
+  }
+
+  const solverName = selected?.name ?? "this solver";
+  let announcement = "";
+  if (run.status === COMPUTE_RUNNING) {
+    announcement = `Running ${solverName}. This can take up to a minute.`;
+  } else if (run.status === COMPUTE_DONE) {
+    announcement = `${solverName} finished in ${formatSeconds(run.elapsedMs)}.`;
+  } else if (run.status === COMPUTE_FAILED) {
+    announcement = `${solverName} did not run. ${run.failure?.headline ?? ""}`;
+  } else if (run.status === COMPUTE_CANCELLED) {
+    announcement = `Run cancelled.`;
+  }
 
   return (
     <SectionShell
@@ -217,7 +315,7 @@ export default function SolversSection({
                       type="button"
                       role="option"
                       aria-selected={isSelected}
-                      onClick={() => setSelectedIndex(index)}
+                      onClick={() => handleSelectSolver(index)}
                       sx={(theme) => ({
                         display: "flex",
                         flexDirection: "column",
@@ -284,12 +382,69 @@ export default function SolversSection({
                 <Button
                   id="solvers-run-button"
                   variant="contained"
-                  disabled
+                  disabled={!canRun || run.isRunning}
+                  onClick={handleRun}
                   sx={{ alignSelf: "flex-start" }}
                 >
                   Run
                 </Button>
-                {selected.runtime || selected.result ? (
+                {!canRun && (
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                    {selected.className
+                      ? "Add a problem instance above to run this solver."
+                      : "This solver cannot be run: the catalog did not say which backend solver it is."}
+                  </Typography>
+                )}
+
+                <ComputeStatus
+                  idPrefix={RUN_ID_PREFIX}
+                  status={run.status}
+                  announcement={announcement}
+                  failure={run.failure}
+                  onCancel={run.cancel}
+                  busyLabel={`Running ${solverName}`}
+                />
+
+                {liveResult ? (
+                  <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                    <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                      Result from {liveResult.solverName}:
+                    </Typography>
+                    <Box
+                      id="solvers-run-output"
+                      component="pre"
+                      sx={{
+                        m: 0,
+                        p: 1.5,
+                        borderRadius: 1,
+                        backgroundColor: "background.default",
+                        overflowX: "auto",
+                      }}
+                    >
+                      <Typography variant="mono" component="code" sx={{ whiteSpace: "pre-wrap" }}>
+                        {formatSolverOutput(liveResult.output)}
+                      </Typography>
+                    </Box>
+                    {/* Not "Runtime": the Redux API reports no runtime for a
+                        solve, so this is the browser's own measurement of the
+                        whole round trip and is labelled as that rather than
+                        passed off as the solver's running time (#95: "leave
+                        it blank rather than fabricating a value"). */}
+                    <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                      Round trip: {formatSeconds(run.elapsedMs)}, network time included. Redux does
+                      not report the solver&apos;s own runtime.
+                    </Typography>
+                    {instanceChangedSinceRun && (
+                      <Typography variant="body2" sx={{ color: "warning.light" }}>
+                        The instance has been edited since this ran. Run again to solve the instance
+                        currently in the box.
+                      </Typography>
+                    )}
+                  </Box>
+                ) : selected.runtime || selected.result ? (
+                  // The declared-data path, untouched by T37 (#95): a problem
+                  // whose data carries a runtime and a result shows them
+                  // until a live run replaces them.
                   <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
                     {selected.runtime && (
                       <Typography variant="body2">
@@ -309,9 +464,15 @@ export default function SolversSection({
                     )}
                   </Box>
                 ) : (
-                  <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
-                    Not yet run.
-                  </Typography>
+                  run.status !== COMPUTE_RUNNING &&
+                  run.status !== COMPUTE_FAILED && (
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "text.secondary", fontStyle: "italic" }}
+                    >
+                      Not yet run.
+                    </Typography>
+                  )
                 )}
               </Box>
             )}

--- a/components/detail/VerifierSection.js
+++ b/components/detail/VerifierSection.js
@@ -3,13 +3,26 @@
 // T16d (#24) — the Verifier section of a Problem Detail page: the
 // certificate format a solution takes, plus a "check a certificate" demo.
 //
-// v1 scope (ground rule 5): certificate format is real declared data, but
-// Verify is inert — no live verification. The Verify button is `disabled`
-// (out of tab order automatically) rather than wired to a fake handler, so
-// it never looks functional when it isn't. The result banner below it is
-// simply the fixture's own canned outcome for its pre-filled example, shown
-// unconditionally rather than gated behind a click that wouldn't do
-// anything real anyway.
+// T37 (#95): Verify is live. It calls `requestVerifiedInstance()` with the
+// verifier's class name, the shared instance and whatever certificate is in
+// the box, and renders the real verdict in the result banner. Before this
+// task the button was genuinely `disabled` (and so out of the tab order)
+// per ground rule 5; this is the task that lifts that.
+//
+// Two things worth knowing about the verdict:
+//
+//   - The API answers with a bare "True" or "False" string. Anything else
+//     is shown as-is in a neutral banner rather than being forced into a
+//     pass or a fail, because guessing what an unrecognised answer meant is
+//     exactly the kind of quiet wrong claim this page must not make.
+//   - The pass/fail indication is never colour alone (T16d/#24). An icon
+//     and the wording carry it; colour sits on top of that, not instead.
+//
+// The local certificate validator that used to sit in front of this
+// request is gone. See lib/redux/index.js's `requestVerifiedInstance` for
+// the decision and the evidence behind it: the Redux API returns a far
+// better error for a malformed certificate than that regex ever produced,
+// and it does so for all 50 problems rather than two.
 //
 // Per the ratified naming convention this section's title is always the
 // generic "Verifier" — never problem-prefixed — so it's hardcoded by this
@@ -21,17 +34,32 @@
 // error, so there is exactly one instance value on the page: it lives in
 // components/ProblemDetailLayout.js and both this section and the Solvers
 // section render their own input bound to it. Editing either updates both.
-// See that file's header for the full decision. Verify stays disabled:
-// turning it on is T37 (#95).
+// See that file's header for the full decision.
+//
+// --- Decision: where the certificate box pre-fills from (T37/#95) --------
+// It keeps pre-filling from the problem's own declared example
+// (`verifierInfo.certificate`), and a live Run result never overwrites it.
+// Recorded on #95.
 
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
+import {
+  COMPUTE_CANCELLED,
+  COMPUTE_DONE,
+  COMPUTE_FAILED,
+  COMPUTE_RUNNING,
+  useComputeRequest,
+} from "../../hooks/useComputeRequest";
+import { REDUX_API_BASE_URL, requestVerifiedInstance } from "../../lib/redux";
+import ComputeStatus from "./ComputeStatus";
 import SectionShell from "./SectionShell";
 
 const CERTIFICATE_INPUT_ID_PREFIX = "verifier-certificate-input";
@@ -39,6 +67,19 @@ const CERTIFICATE_INPUT_ID_PREFIX = "verifier-certificate-input";
 // Distinct from SolversSection's own "solvers-instance-input" (ground rule
 // 4): the two inputs share a value, never an id.
 const INSTANCE_INPUT_ID = "verifier-instance-input";
+
+/**
+ * Reads the API's verdict. It answers `"True"` or `"False"` as a bare JSON
+ * string today (checked against the live API on 2026-09-02). Anything else
+ * comes back as `valid: null` so the banner can show it plainly instead of
+ * rounding an unrecognised answer to a pass or a fail.
+ */
+function readVerdict(raw) {
+  const text = typeof raw === "string" ? raw.trim() : JSON.stringify(raw);
+  if (/^true$/i.test(text)) return { valid: true, text };
+  if (/^false$/i.test(text)) return { valid: false, text };
+  return { valid: null, text };
+}
 
 /**
  * @param {Object} props
@@ -68,6 +109,47 @@ export default function VerifierSection({
   const verifier = problem.verifier;
   const [certificateValue, setCertificateValue] = useState(verifier?.exampleCertificate ?? "");
   const inputId = `${CERTIFICATE_INPUT_ID_PREFIX}-${problem.slug}`;
+  const verifyIdPrefix = `verifier-verify-${problem.slug}`;
+
+  const check = useComputeRequest({ subject: "certificate" });
+
+  // Both are needed for the request to mean anything, so Verify stays
+  // disabled (and out of the tab order) until both are present, rather than
+  // being enabled into a state where it cannot succeed.
+  const canVerify =
+    Boolean(verifier?.className) && instanceValue.trim() !== "" && certificateValue.trim() !== "";
+
+  const liveVerdict = check.status === COMPUTE_DONE ? readVerdict(check.result) : null;
+
+  function handleVerify() {
+    if (!canVerify) return;
+    check.start((signal) =>
+      requestVerifiedInstance(
+        REDUX_API_BASE_URL,
+        verifier.className,
+        instanceValue,
+        certificateValue,
+        signal,
+      ),
+    );
+  }
+
+  let announcement = "";
+  if (check.status === COMPUTE_RUNNING) {
+    announcement = "Checking this certificate.";
+  } else if (check.status === COMPUTE_DONE) {
+    if (liveVerdict?.valid === true) {
+      announcement = "Certificate accepted. It is valid for this instance.";
+    } else if (liveVerdict?.valid === false) {
+      announcement = "Certificate rejected. It is not valid for this instance.";
+    } else {
+      announcement = `Redux answered: ${liveVerdict?.text ?? ""}`;
+    }
+  } else if (check.status === COMPUTE_FAILED) {
+    announcement = `The certificate was not checked. ${check.failure?.headline ?? ""}`;
+  } else if (check.status === COMPUTE_CANCELLED) {
+    announcement = "Check cancelled.";
+  }
 
   if (!verifier) {
     return (
@@ -152,52 +234,76 @@ export default function VerifierSection({
               onChange={(event) => setCertificateValue(event.target.value)}
               slotProps={{ htmlInput: { sx: { fontFamily: monoFontFamily } } }}
             />
-            <Box
+            <Button
               id={`verifier-verify-button-${problem.slug}`}
-              component="button"
               type="button"
-              disabled
-              sx={disabledActionButtonSx}
+              variant="contained"
+              disabled={!canVerify || check.isRunning}
+              onClick={handleVerify}
+              sx={verifyButtonSx}
             >
               Verify
-            </Box>
+            </Button>
+          </Box>
+
+          {!canVerify && (
+            <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
+              {verifier.className
+                ? "Verify needs both a problem instance and a certificate. Fill in whichever box is empty."
+                : "This verifier cannot be run: the catalog did not say which backend verifier it is."}
+            </Typography>
+          )}
+
+          <Box sx={{ mt: 1.5 }}>
+            <ComputeStatus
+              idPrefix={verifyIdPrefix}
+              status={check.status}
+              announcement={announcement}
+              failure={check.failure}
+              onCancel={check.cancel}
+              busyLabel="Checking this certificate"
+            />
           </Box>
 
           {verifier.exampleCertificate && (
             <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
-              Pre-filled with the default solver&apos;s result above — replace it to check your own
-              certificate.
+              Pre-filled with the example certificate this problem declares. Replace it to check
+              your own, including one the Solvers section has just produced.
             </Typography>
           )}
 
-          {verifier.resultBanner && (
-            <Box
-              sx={{
-                mt: 2,
-                display: "flex",
-                alignItems: "flex-start",
-                gap: 1,
-                p: 1.5,
-                borderRadius: 1,
-                color: verifier.resultBanner.valid ? "success.light" : "error.light",
-                backgroundColor: verifier.resultBanner.valid
-                  ? "rgba(74, 222, 128, 0.12)"
-                  : "rgba(248, 113, 113, 0.12)",
-                border: "1px solid",
-                borderColor: verifier.resultBanner.valid
-                  ? "rgba(74, 222, 128, 0.4)"
-                  : "rgba(248, 113, 113, 0.4)",
-              }}
-            >
-              {verifier.resultBanner.valid ? (
-                <CheckCircleIcon fontSize="small" sx={{ mt: "2px" }} />
-              ) : (
-                <CancelIcon fontSize="small" sx={{ mt: "2px" }} />
-              )}
-              <Typography variant="body2" sx={{ color: "inherit" }}>
-                <strong>{verifier.resultBanner.headline}</strong> — {verifier.resultBanner.detail}
-              </Typography>
-            </Box>
+          {/* The live verdict when there is one, otherwise the problem's
+              own declared outcome for its pre-filled example. The declared
+              path is kept rather than replaced (#95: do not remove the
+              declared-data display path). */}
+          {liveVerdict ? (
+            <VerdictBanner
+              id={`verifier-verdict-${problem.slug}`}
+              valid={liveVerdict.valid}
+              headline={
+                liveVerdict.valid === true
+                  ? "Valid certificate"
+                  : liveVerdict.valid === false
+                    ? "Not a valid certificate"
+                    : "Redux answered something unexpected"
+              }
+              detail={
+                liveVerdict.valid === true
+                  ? "Redux checked this certificate against the instance above and accepted it."
+                  : liveVerdict.valid === false
+                    ? "Redux checked this certificate against the instance above and rejected it."
+                    : `The verifier returned "${liveVerdict.text}", which is neither True nor False, so this page will not guess which it meant.`
+              }
+            />
+          ) : (
+            verifier.resultBanner && (
+              <VerdictBanner
+                id={`verifier-declared-result-${problem.slug}`}
+                valid={verifier.resultBanner.valid}
+                headline={verifier.resultBanner.headline}
+                detail={verifier.resultBanner.detail}
+              />
+            )
           )}
 
           {verifier.properties && verifier.properties.length > 0 && (
@@ -215,19 +321,69 @@ export default function VerifierSection({
 
 const monoFontFamily = '"JetBrains Mono", "Fira Code", Consolas, "Courier New", monospace';
 
-const disabledActionButtonSx = {
+// Keeps the pill shape the section has always had, now on a real MUI
+// Button so a live control gets the focus ring, the hover state and the
+// disabled semantics for free. It used to be a plain Box styled to look
+// unavailable, which was right while it was inert and wrong now.
+const verifyButtonSx = {
   flexShrink: 0,
-  border: "1px solid",
-  borderColor: "divider",
   borderRadius: 999,
   px: 2,
   py: 1,
-  color: "text.disabled",
-  backgroundColor: "transparent",
-  font: "inherit",
   fontWeight: 600,
-  cursor: "not-allowed",
+  textTransform: "none",
 };
+
+/**
+ * Pass/fail (or "cannot tell") shown as an icon plus wording, never colour
+ * alone (T16d/#24). `valid` is `true`, `false`, or `null` for a verdict
+ * this page cannot read as either.
+ */
+function VerdictBanner({ id, valid, headline, detail }) {
+  const palette =
+    valid === true
+      ? {
+          color: "success.light",
+          background: "rgba(74, 222, 128, 0.12)",
+          border: "rgba(74, 222, 128, 0.4)",
+        }
+      : valid === false
+        ? {
+            color: "error.light",
+            background: "rgba(248, 113, 113, 0.12)",
+            border: "rgba(248, 113, 113, 0.4)",
+          }
+        : {
+            color: "text.primary",
+            background: "rgba(148, 163, 184, 0.12)",
+            border: "rgba(148, 163, 184, 0.4)",
+          };
+
+  const Icon = valid === true ? CheckCircleIcon : valid === false ? CancelIcon : InfoOutlinedIcon;
+
+  return (
+    <Box
+      id={id}
+      sx={{
+        mt: 2,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 1,
+        p: 1.5,
+        borderRadius: 1,
+        color: palette.color,
+        backgroundColor: palette.background,
+        border: "1px solid",
+        borderColor: palette.border,
+      }}
+    >
+      <Icon fontSize="small" aria-hidden="true" sx={{ mt: "2px" }} />
+      <Typography variant="body2" sx={{ color: "inherit" }}>
+        <strong>{headline}</strong> {detail}
+      </Typography>
+    </Box>
+  );
+}
 
 // Standard visually-hidden clip pattern (same as components/SearchBar.js) --
 // the label needs to exist for screen readers without displacing the

--- a/hooks/useComputeRequest.js
+++ b/hooks/useComputeRequest.js
@@ -1,0 +1,255 @@
+// hooks/useComputeRequest.js
+//
+// T37 (#95): the shared plumbing behind live Run (Solvers) and live Verify
+// (Verifier). One hook rather than two copies: #95 folded the two tasks
+// together precisely because the request handling, the loading state, the
+// aria-live announcement, the cancel behaviour and the error copy are the
+// same for both, and the only real difference is what each section does
+// with the answer.
+//
+// What it owns:
+//
+//   - The four states a request can be in, and only ever one at a time per
+//     section ("one run at a time", #95). Starting a new request aborts the
+//     one before it.
+//   - Staleness. Every request gets a sequence number, and a response whose
+//     number is no longer the current one is dropped instead of rendered.
+//     That is what stops a slow solve landing in the pane after the visitor
+//     has switched to a different solver.
+//   - Cancel, via AbortController. Be accurate about what that means: it
+//     stops this browser waiting, and it stops a stale answer arriving. It
+//     does NOT stop the backend computing. The proxy's 60s compute timeout
+//     (T36/#94, pages/api/redux/[...path].js) is the only thing that
+//     actually bounds the work, and the copy below says so.
+//   - Turning a failure into copy a person can act on. T36 made the failure
+//     cases distinguishable on purpose (502 unreachable, 504 timeout, 413
+//     too big, 429 rate-limited) and the Redux API distinguishes its own
+//     rejections further still, so collapsing all of it into one "something
+//     went wrong" would throw that away.
+
+import { useCallback, useRef, useState } from "react";
+import { ReduxRequestError } from "../lib/redux";
+
+/** Nothing has been run yet, or the last result was cleared. */
+export const COMPUTE_IDLE = "idle";
+/** A request is in flight. */
+export const COMPUTE_RUNNING = "running";
+/** A request came back and its value is in `result`. */
+export const COMPUTE_DONE = "done";
+/** A request failed and `failure` describes why. */
+export const COMPUTE_FAILED = "failed";
+/** The visitor pressed Cancel. */
+export const COMPUTE_CANCELLED = "cancelled";
+
+// The proxy's own limits, repeated here only so the copy can name real
+// numbers. Kept as named constants so the two places stay easy to compare
+// if pages/api/redux/[...path].js ever changes them.
+const PROXY_COMPUTE_TIMEOUT_SECONDS = 60;
+const PROXY_BODY_LIMIT_LABEL = "1 MB";
+const PROXY_RATE_LIMIT_PER_MINUTE = 10;
+
+function isAbort(error) {
+  return error?.name === "AbortError";
+}
+
+/**
+ * Turns a thrown request failure into a headline and an explanation.
+ *
+ * Every branch here corresponds to a case the layers underneath genuinely
+ * distinguish, so the copy can say something true and specific rather than
+ * hedging. `expected` is carried separately from `detail` because the Redux
+ * API supplies the format it wanted as its own field, and showing it next
+ * to the complaint is the single most useful thing on a rejected input.
+ *
+ * @param {Error} error
+ * @param {string} subject What was being sent, for the copy: "instance" or
+ *   "certificate".
+ * @returns {{headline: string, detail: string, expected?: string}}
+ */
+export function describeComputeFailure(error, subject = "instance") {
+  if (!(error instanceof ReduxRequestError)) {
+    // fetch itself rejected, so there was never a response: the browser
+    // could not reach this app's own server. Distinct from a 502, which
+    // means this app's server was reached and Redux behind it was not.
+    return {
+      headline: "The request could not be sent",
+      detail:
+        "Your browser could not reach this site's server, so nothing was asked of Redux. Check your connection and try again.",
+    };
+  }
+
+  const payload = error.payload ?? {};
+  const apiError = typeof payload.error === "string" ? payload.error : "";
+  const apiDetail = typeof payload.detail === "string" ? payload.detail : "";
+  const expected =
+    typeof payload.expected === "string" && payload.expected ? payload.expected : undefined;
+
+  switch (error.status) {
+    case 502:
+      return {
+        headline: "Couldn't reach the Redux backend",
+        detail:
+          "This site's server is running, but the Redux API behind it did not answer. It may be down or restarting. Try again in a moment.",
+      };
+    case 504:
+      return {
+        headline: "This took too long",
+        detail: `Redux did not finish within ${PROXY_COMPUTE_TIMEOUT_SECONDS} seconds, so the request was given up on. A smaller instance, or a faster solver if this problem declares one, will usually come back in time.`,
+      };
+    case 413:
+      return {
+        headline: "Too much text to send",
+        detail: `The request came to more than ${PROXY_BODY_LIMIT_LABEL}, which is the most this site will forward to Redux. Shorten the ${subject} and try again.`,
+      };
+    case 429: {
+      const wait = error.retryAfterSeconds > 0 ? `${error.retryAfterSeconds} seconds` : "a moment";
+      return {
+        headline: "Too many runs in a row",
+        detail: `This site accepts ${PROXY_RATE_LIMIT_PER_MINUTE} runs a minute so one visitor cannot tie up the backend. Wait ${wait} and try again.`,
+      };
+    }
+    default:
+      break;
+  }
+
+  if (apiError === "instance_parse_error") {
+    return {
+      headline: "Redux could not read this instance",
+      detail: apiDetail || "The instance is not in the format this problem expects.",
+      expected,
+    };
+  }
+
+  if (apiError === "certificate_parse_error") {
+    return {
+      headline: "Redux could not read this certificate",
+      detail: apiDetail || "The certificate is not in the format this problem expects.",
+      expected,
+    };
+  }
+
+  if (apiError === "unknown_solver" || apiError === "unknown_verifier") {
+    return {
+      headline: "Redux does not recognise that choice",
+      detail:
+        "The catalog offered something the backend no longer has. Reload the page to pick up the current list.",
+    };
+  }
+
+  if (error.status >= 400 && error.status < 500) {
+    return {
+      headline: `Redux rejected this ${subject}`,
+      detail:
+        apiDetail || apiError || `The backend answered ${error.status} without explaining why.`,
+      expected,
+    };
+  }
+
+  return {
+    headline: "Redux ran into a problem",
+    detail:
+      apiDetail ||
+      apiError ||
+      `The backend answered ${error.status}${error.statusText ? ` (${error.statusText})` : ""}.`,
+  };
+}
+
+/**
+ * @param {Object} [options]
+ * @param {string} [options.subject] "instance" or "certificate", used in the
+ *   failure copy. See `describeComputeFailure`.
+ * @returns {{
+ *   status: string,
+ *   result: unknown,
+ *   failure: {headline: string, detail: string, expected?: string}|null,
+ *   elapsedMs: number,
+ *   isRunning: boolean,
+ *   start: (perform: (signal: AbortSignal) => Promise<unknown>) => Promise<void>,
+ *   cancel: () => void,
+ *   reset: () => void,
+ * }}
+ */
+export function useComputeRequest({ subject = "instance" } = {}) {
+  const [status, setStatus] = useState(COMPUTE_IDLE);
+  const [result, setResult] = useState(null);
+  const [failure, setFailure] = useState(null);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  // Bumped on every start, cancel and reset. A settled request compares the
+  // number it was given against this one and stays quiet if they differ,
+  // which is what makes a stale response impossible to render.
+  const requestIdRef = useRef(0);
+  const controllerRef = useRef(null);
+
+  const abortInFlight = useCallback(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+  }, []);
+
+  const start = useCallback(
+    async (perform) => {
+      requestIdRef.current += 1;
+      const requestId = requestIdRef.current;
+
+      abortInFlight();
+      const controller = new AbortController();
+      controllerRef.current = controller;
+
+      setStatus(COMPUTE_RUNNING);
+      setResult(null);
+      setFailure(null);
+      setElapsedMs(0);
+
+      const startedAt = Date.now();
+      try {
+        const value = await perform(controller.signal);
+        if (requestIdRef.current !== requestId) return;
+        setElapsedMs(Date.now() - startedAt);
+        setResult(value);
+        setStatus(COMPUTE_DONE);
+      } catch (error) {
+        if (requestIdRef.current !== requestId) return;
+        // A cancelled request has already had its state set by `cancel`.
+        // Landing on COMPUTE_FAILED here would overwrite that with an error
+        // the visitor caused on purpose.
+        if (isAbort(error)) return;
+        setElapsedMs(Date.now() - startedAt);
+        setFailure(describeComputeFailure(error, subject));
+        setStatus(COMPUTE_FAILED);
+      } finally {
+        if (controllerRef.current === controller) {
+          controllerRef.current = null;
+        }
+      }
+    },
+    [abortInFlight, subject],
+  );
+
+  const cancel = useCallback(() => {
+    requestIdRef.current += 1;
+    abortInFlight();
+    setStatus(COMPUTE_CANCELLED);
+    setResult(null);
+    setFailure(null);
+  }, [abortInFlight]);
+
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    abortInFlight();
+    setStatus(COMPUTE_IDLE);
+    setResult(null);
+    setFailure(null);
+    setElapsedMs(0);
+  }, [abortInFlight]);
+
+  return {
+    status,
+    result,
+    failure,
+    elapsedMs,
+    isRunning: status === COMPUTE_RUNNING,
+    start,
+    cancel,
+    reset,
+  };
+}

--- a/hooks/useProblemDetail.js
+++ b/hooks/useProblemDetail.js
@@ -72,10 +72,15 @@ function slugify(name) {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
 }
 
+// `className` is carried alongside the display name because live Run
+// (T37/#95) needs it: ProblemProvider/solve is keyed by the solver's class
+// name ("CliqueBruteForce"), which is what allSolvers lists, not by the
+// human-readable solverName ("Clique Brute Force Solver") the UI shows.
 function buildSolvers(solverClassNames, info) {
   return (solverClassNames ?? []).map((className) => {
     const solverInfo = info[className] ?? {};
     return {
+      className,
       name: solverInfo.solverName ?? className,
       type: SOLVER_TYPE_MAP[solverInfo.solverType],
       complexityBucket: SOLVER_COMPLEXITY_MAP[solverInfo.complexityBucket],
@@ -104,6 +109,9 @@ function buildVerifier(verifierClassNames, info, problemInfo) {
 
   const verifierInfo = info[firstVerifierClassName] ?? {};
   return {
+    // Same reason as buildSolvers' className: ProblemProvider/verify is
+    // keyed by the verifier class name (T37/#95).
+    className: firstVerifierClassName,
     certificateDescription: verifierInfo.verifierDefinition ?? "",
     certificateFormat: problemInfo.certificateFormat || "",
     exampleCertificate: verifierInfo.certificate || undefined,

--- a/lib/redux/index.js
+++ b/lib/redux/index.js
@@ -14,7 +14,89 @@
  * (the data hooks built in T23/T24) can catch them and drive the "Couldn't reach the
  * Redux backend" banner. Do not reintroduce a try/catch that turns a failure into
  * `undefined` here.
+ *
+ * T37 (#95) added two things live Run and live Verify need and the read endpoints did
+ * not: failures now reject with a `ReduxRequestError` carrying the HTTP status and the
+ * parsed response body, so a caller can tell "the backend is down" (502) from "this took
+ * too long" (504) from "Redux rejected your instance" (400) instead of all three
+ * arriving as the same opaque message; and the two compute requests accept an
+ * `AbortSignal` so the browser can stop waiting on a long solve.
  */
+
+/**
+ * Base URL of the same-origin proxy every request in this app goes through
+ * (`pages/api/redux/[...path].js`). Exported so the detail-page sections that make live
+ * Run/Verify calls use the same value the data hooks' callers do, rather than each
+ * repeating the literal.
+ */
+export const REDUX_API_BASE_URL = "/api/redux/";
+
+/**
+ * A failed request, carrying enough of the response for a caller to write accurate copy.
+ *
+ * `status` is the HTTP status (0 when the request never got a response at all, e.g. the
+ * browser is offline). `payload` is the parsed JSON body when there was one, which for
+ * this app is either the proxy's own `{ error }` shape (T36/#94) or the Redux API's
+ * `{ error, problem, expected, received, detail }` shape for a rejected instance or
+ * certificate. `retryAfterSeconds` is filled in for a 429 from the proxy's `Retry-After`
+ * header.
+ */
+export class ReduxRequestError extends Error {
+  constructor(
+    message,
+    { status = 0, statusText = "", payload = null, retryAfterSeconds = 0 } = {},
+  ) {
+    super(message);
+    this.name = "ReduxRequestError";
+    this.status = status;
+    this.statusText = statusText;
+    this.payload = payload;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+/**
+ * Reads a failed response's body without letting the read itself throw: an error
+ * response is not guaranteed to be JSON (a proxy or load balancer in front of the app
+ * can return HTML), and losing the real status to a JSON parse error would be worse
+ * than losing the body.
+ *
+ * A body that is not JSON is deliberately returned as `null`. It is almost always an
+ * error page from something between this app and Redux, and putting raw HTML in front of
+ * a visitor is worse than saying nothing: the HTTP status on its own is more honest and
+ * more useful. Callers fall back to describing the status.
+ */
+async function readErrorPayload(resp) {
+  try {
+    const text = await resp.text();
+    if (!text) return null;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Turns a non-ok response into a `ReduxRequestError`. Shared by both request helpers so
+ * a read failure and a compute failure carry the same fields.
+ */
+async function requestError(resp, failMsg) {
+  const payload = await readErrorPayload(resp);
+  const headerRetryAfter = Number.parseInt(resp.headers.get("Retry-After") ?? "", 10);
+  const retryAfterSeconds = Number.isFinite(headerRetryAfter)
+    ? headerRetryAfter
+    : (payload?.retryAfterSeconds ?? 0);
+  return new ReduxRequestError(`${failMsg()}: ${resp.status} (${resp.statusText})`, {
+    status: resp.status,
+    statusText: resp.statusText,
+    payload,
+    retryAfterSeconds,
+  });
+}
 
 /**
  * @param url Full request URL.
@@ -25,7 +107,7 @@
 async function fetchJson(url, failMsg) {
   const resp = await fetch(url);
   if (!resp.ok) {
-    throw new Error(`${failMsg()}: ${resp.status} (${resp.statusText})`);
+    throw await requestError(resp, failMsg);
   }
   return await resp.json();
 }
@@ -34,19 +116,23 @@ async function fetchJson(url, failMsg) {
  * @param url Full request URL.
  * @param body Request payload, sent as JSON.
  * @param failMsg Lazily-evaluated description of the request, used in the thrown error.
+ * @param signal Optional `AbortSignal`. Aborting rejects with the browser's own
+ * `AbortError`, which callers check for by name rather than treating as a failure.
  * @returns the parsed JSON body of the response.
- * @throws if the request fails (network error) or the response is not `ok`.
+ * @throws {ReduxRequestError} if the response is not `ok`; whatever `fetch` throws if the
+ * request never got a response at all.
  */
-async function fetchPostJson(url, body, failMsg) {
+async function fetchPostJson(url, body, failMsg, signal) {
   const resp = await fetch(url, {
     method: "POST",
     body: JSON.stringify(body),
     headers: {
       "Content-Type": "application/json; charset=UTF-8",
     },
+    signal,
   });
   if (!resp.ok) {
-    throw new Error(`${failMsg()}: ${resp.status} (${resp.statusText})`);
+    throw await requestError(resp, failMsg);
   }
   return await resp.json();
 }
@@ -76,49 +162,6 @@ async function cachedRequest(cacheKey, requestFn) {
   } catch (error) {
     requestCache.delete(cacheKey);
     throw error;
-  }
-}
-
-/**
- * This function is a temporary solution for validating user input until it is ported to
- * the Redux API.
- * @returns `true` if the specified verifier certificate is valid.
- */
-function isCertificateValid(problem, certificate) {
-  var cleanInput = certificate.replace(new RegExp(/[( )]/g), ""); // Strips spaces and ()
-  cleanInput = cleanInput.replaceAll(":", "=");
-  var regexFormat = /[^-.,=:!{}\w;]/; // Checks for special characters not including -.,=:!{}
-  if (regexFormat.test(cleanInput) == true) {
-    // Invalid characters found, warn user.
-    return false;
-  } else {
-    var validUserInput = true;
-    if (problem == "SAT" || problem == "SAT3") {
-      var clauses = cleanInput.split(",");
-      const regex = /[^!\w]/; // Only allow alphanumber and !
-      const notBooleanRegex = /[^true$|^True$|^t$|^T$|^false$|^False$|^F$|^f$]/;
-      clauses.forEach((clause) => {
-        const singleClause = clause.split("=");
-
-        if (singleClause.length !== 2 || regex.test(singleClause[0] == true)) {
-          // No boolean assigned to variable.
-          validUserInput = false;
-          return false;
-        }
-
-        if (notBooleanRegex.test(singleClause[1] == true)) {
-          // boolean is not in the form True/true/T/F...
-          validUserInput = false;
-          return false;
-        } else {
-          // Replace True/true/t with T and False/false/f with F
-          singleClause[1] = singleClause[1].replace(new RegExp(/^false$|^False$|^f$/g), "F");
-          singleClause[1] = singleClause[1].replace(new RegExp(/^True$|^true$|^t$/g), "T");
-          validUserInput = true; // valid input
-        }
-      });
-    }
-    return validUserInput;
   }
 }
 
@@ -214,43 +257,75 @@ export function requestReductionGraph(url) {
 }
 
 /**
- * Not called anywhere in v1 — Solvers section shows canned Run output — but ported now
- * since it costs nothing extra and will be needed once Run goes live.
+ * Runs a solver over a problem instance.
+ *
+ * T37 (#95) turned this on: it was ported in T21 (#30) and called nowhere until now.
+ *
+ * The Redux API answers with the solved instance as a bare JSON string (verified against
+ * the live API on 2026-09-02: `CliqueBruteForce` over Clique's declared instance returns
+ * `"{2,3,4,5}"`). It reports no runtime, so there is nothing here for a caller to show as
+ * one.
+ *
  * @param url Base URL of the Redux API.
- * @param solver Solver identifier to run.
+ * @param solver Solver class name, e.g. `CliqueBruteForce`, the value
+ * `Navigation/Batch/allSolvers` lists, not the human-readable `solverName`.
  * @param instance The problem instance to solve.
+ * @param signal Optional `AbortSignal` so the caller can stop waiting. Aborting does not
+ * stop the backend computing; only the proxy's own 60s compute timeout does that.
  * @returns the solved `instance` from the specified `solver`.
- * @throws if the request fails.
+ * @throws {ReduxRequestError} if the request fails.
  */
-export async function requestSolvedInstance(url, solver, instance) {
+export async function requestSolvedInstance(url, solver, instance, signal) {
   return await fetchPostJson(
-    `${url}ProblemProvider/solve?solver=${solver}`,
+    `${url}ProblemProvider/solve?solver=${encodeURIComponent(solver)}`,
     instance,
     () => `${solver} SOLVED INSTANCE REQUEST FAILED`,
+    signal,
   );
 }
 
 /**
- * Not called anywhere in v1 — Verifier section shows canned Verify output — but ported
- * now since it costs nothing extra and will be needed once Verify goes live.
+ * Checks a certificate against a problem instance.
+ *
+ * --- Decision: the local `isCertificateValid` check is gone (T37/#95) ------------------
+ * This function used to run every certificate through a ported regex validator and
+ * return the literal string `"Invalid Input"` without ever calling the backend if it
+ * failed. That validator special-cased SAT and SAT3 and returned valid for all 48 other
+ * problems in the catalog, so what it actually enforced was "no unusual punctuation",
+ * not "this is a well-formed certificate". Its own comment said validation belonged in
+ * the API.
+ *
+ * It now does. Checked against the live API on 2026-09-02: posting a malformed
+ * certificate returns HTTP 400 with a body naming the problem, the format it expected,
+ * what it received, and why the parse failed, for example
+ * `{"error":"certificate_parse_error","problem":"Clique","expected":"Format: {K | K is
+ * set} Example: {1,2,4}","detail":"certificate did not parse to a non-empty list of node
+ * names"}`. That is better information than the regex could ever produce, it is correct
+ * for every problem rather than two, and it stays correct as the backend's parsers
+ * change. So the local gate is dropped and the backend is the single authority on
+ * whether a certificate is well formed. Recorded as a decision on #95.
+ *
+ * The `problem` argument went with it: it existed only to pick the SAT/SAT3 branch of
+ * that validator, and the backend already identifies the problem in its own error body.
+ *
+ * The API answers with a bare JSON string, `"True"` or `"False"` (verified against the
+ * live API on the same date).
+ *
  * @param url Base URL of the Redux API.
- * @param problem Problem identifier the certificate is being checked against.
- * @param verifier Verifier identifier to run.
+ * @param verifier Verifier class name, e.g. `CliqueVerifier`, the value
+ * `Navigation/Batch/allVerifiers` lists.
  * @param instance The problem instance being verified.
  * @param certificate The candidate certificate string.
- * @returns the verified `instance` results from the specified `verifier`, or the literal
- * string `"Invalid Input"` if `certificate` fails local format validation.
- * @throws if the request fails.
+ * @param signal Optional `AbortSignal`, same caveat as `requestSolvedInstance`.
+ * @returns the verifier's verdict.
+ * @throws {ReduxRequestError} if the request fails, including a 400 for a certificate or
+ * instance the backend could not parse.
  */
-export async function requestVerifiedInstance(url, problem, verifier, instance, certificate) {
-  // Temporary solution until certificate validation is moved to the Redux API.
-  if (!isCertificateValid(problem, certificate)) {
-    return "Invalid Input";
-  }
-
+export async function requestVerifiedInstance(url, verifier, instance, certificate, signal) {
   return await fetchPostJson(
-    `${url}ProblemProvider/verify?verifier=${verifier}`,
+    `${url}ProblemProvider/verify?verifier=${encodeURIComponent(verifier)}`,
     { problemInstance: instance, certificate: certificate },
     () => `${verifier} VERIFIED INSTANCE REQUEST FAILED`,
+    signal,
   );
 }

--- a/pages/[problem].js
+++ b/pages/[problem].js
@@ -53,9 +53,7 @@ import ProblemDetailLayout from "../components/ProblemDetailLayout";
 import { isProblemComplete } from "../components/StatusIcon";
 import { TAXONOMY } from "../data/taxonomy";
 import { useProblemDetail } from "../hooks/useProblemDetail";
-
-// Same same-origin proxy base lib/redux/index.js's own JSDoc documents.
-const API_BASE_URL = "/api/redux/";
+import { REDUX_API_BASE_URL } from "../lib/redux";
 
 // Badge row order per the mockup (NP-Complete, NP, Boolean Logic): complexity
 // badges first, then problem type. Chip variant is keyed straight off
@@ -152,7 +150,7 @@ export default function ProblemDetail() {
   const { problem: routeProblemName } = router.query;
 
   const { problem, loading, error } = useProblemDetail(
-    API_BASE_URL,
+    REDUX_API_BASE_URL,
     typeof routeProblemName === "string" ? routeProblemName : null,
   );
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -61,6 +61,7 @@ import { thinScrollbarSx } from "../components/theme";
 import { TAXONOMY } from "../data/taxonomy";
 import { useCatalogFilters } from "../hooks/useCatalogFilters";
 import { useCatalogIndex } from "../hooks/useCatalogIndex";
+import { REDUX_API_BASE_URL } from "../lib/redux";
 
 // #68: 280 was too narrow -- the longest option labels ("Algebra and Number
 // Theory", "Logical/Functional Models") wrapped to a second line against
@@ -88,10 +89,6 @@ const SIDEBAR_BREAKPOINT = "md";
 // open, and focus returns to the trigger button on close -- so none of that
 // is custom code here, just configuration.
 const FILTERS_DRAWER_ID = "home-filters-drawer";
-
-// Same-origin proxy base lib/redux/index.js's own JSDoc documents (keeps
-// the real backend origin server-side, pages/api/redux/[...path].js).
-const API_BASE_URL = "/api/redux/";
 
 function buildEmptySelection() {
   const selection = {};
@@ -196,7 +193,7 @@ export default function Home() {
   // rather than just CSS visibility.
   const isWideLayout = useMediaQuery(theme.breakpoints.up(SIDEBAR_BREAKPOINT));
 
-  const { index, completeness, loading, error } = useCatalogIndex(API_BASE_URL);
+  const { index, completeness, loading, error } = useCatalogIndex(REDUX_API_BASE_URL);
   const { results, facetOptions, matchedTags } = useCatalogFilters(index, {
     selected,
     searchValue,

--- a/tests/e2e/detail.spec.js
+++ b/tests/e2e/detail.spec.js
@@ -99,6 +99,13 @@ test("Solvers and Verifier share one editable problem instance", async ({ page }
   await verifierInstance.fill(`${declaredInstance} edited-in-verifier`);
   await expect(solversInstance).toHaveValue(`${declaredInstance} edited-in-verifier`);
 
-  // Ground rule 5: this task leaves both actions inert.
-  await expect(page.locator("#solvers-run-button")).toBeDisabled();
+  // T37 (#95) turned Run on, so it is enabled whenever there is an instance
+  // to run. Emptying the box has to disable it again: a Run with nothing to
+  // solve can only fail. Full coverage of the live Run and Verify paths is
+  // T39 (#97); this is the one assertion this test already owned, kept
+  // pointing at the current behaviour rather than the retired one.
+  const runButton = page.locator("#solvers-run-button");
+  await expect(runButton).toBeEnabled();
+  await solversInstance.fill("");
+  await expect(runButton).toBeDisabled();
 });


### PR DESCRIPTION
Turns on the Run button in the Solvers section and the Verify button in the Verifier section. Both had been deliberately inert since v1, and the request functions behind them have been sitting unused in `lib/redux/index.js` since T21. Because both buttons were genuinely disabled, they were also out of the keyboard tab order, so this is an accessibility change as much as a functional one.

## What changed

**The two buttons now do something.** Run sends the instance in the box to the selected solver and shows what comes back. Verify sends the instance and the certificate to the problem's verifier and shows whether it was accepted. Both stay disabled while there is nothing to send, so neither is ever clickable in a state where it can only fail.

**One shared piece of plumbing, not two copies** (`hooks/useComputeRequest.js`, new). Running and verifying need the same things: a loading state, a spoken announcement, a Cancel button, one request at a time, and error messages that say what actually went wrong. Writing that twice would have meant reviewing it twice and letting the two drift apart.

**Feedback for screen readers, for the first time in these sections** (`components/detail/ComputeStatus.js`, new). Both controls used to announce nothing at all, because they did nothing. A solve can run for up to a minute, which is far too long to leave someone with no idea whether anything is happening, so each section now has a live region that says when a run starts, when it finishes, and when it fails.

**Error messages that name the real problem.** T36 made the failure cases distinguishable on purpose, so a failed run now says which one it was: the backend is unreachable, the request took too long, the text was too large to send, too many runs in a minute, or the backend read the input and rejected it. In that last case the message repeats the backend's own explanation and the format it expected, which is usually enough to fix the input on the spot.

**Cancel is honest about what it does.** It stops this browser waiting and it guarantees a late answer never appears, but it does not stop Redux computing. The wording says so rather than implying otherwise.

**A slow run can no longer land in the wrong place.** Picking a different solver while one is running clears the pane, and every result is tagged with the solver that produced it, so an answer can never be shown next to a solver that did not produce it. If the instance is edited after a run, the result stays but gains a note saying the box has changed since.

## Two decisions this task had to make

Both are recorded in full as comments on #95 and cited in the code.

**The local certificate validator is gone.** `requestVerifiedInstance` used to run every certificate through a regex check ported from Redux_GUI and refuse to call the backend at all if it failed. That check only really validated SAT and 3-SAT and passed everything else through, and its own comment said validation belonged in the API. Testing the live API showed it now returns a genuinely useful 400 for a malformed certificate: the problem name, the format it expected, what it received, and why the parse failed. That is better than the regex could produce, correct for all 50 problems rather than two, and it stays correct as the backend changes. So the local check is dropped and the backend is the only authority.

**The certificate box still pre-fills from the problem's declared example**, and a Run result never overwrites it. The two sections collapse and reorder independently, so a Run result can arrive from a section that is closed or sitting below the Verifier, and silently replacing someone's typed text from somewhere they cannot see is worse than leaving it alone. The help text under the box now points out that a certificate the Solvers section just produced can be pasted in.

## Done when, met

- The `isCertificateValid` decision is made, implemented, recorded on the issue and cited in `lib/redux/index.js`.
- Run calls `requestSolvedInstance`, Verify calls `requestVerifiedInstance`, and both are disabled until there is something to send.
- Both have a spinner and an `aria-live` announcement on start and on completion.
- Real solver output replaces the canned Runtime and Result rows, and the real verdict renders in the Verifier banner.
- The Verifier still shows pass and fail with an icon and wording, never colour alone. A verdict that is neither True nor False gets a neutral banner showing what was actually returned, rather than being rounded to a pass or a fail.
- Unreachable (502), timeout (504), oversized (413), rate limited (429) and backend rejected each produce their own distinct message.
- Cancel works, and its wording does not claim to stop the backend.
- Switching solvers mid run cannot land a stale result.
- Both buttons are keyboard operable and in the tab order. Checked in a real browser: tabbing from the instance box reaches Run, and Enter runs it.
- The Verify pre-fill decision is recorded on the issue.
- A problem with no solvers, no verifier or no instance still renders intact.
- The section heading is still the generic "Verifier".
- `npm run lint`, `npm run format` and `npm run build` are clean, and the existing Playwright suite passes.

## Done when, worth a note

- **"Locally invalid certificate" has no distinct copy, because that case no longer exists.** The issue listed it as a sixth failure case needing its own wording, on the assumption the local validator survived. Dropping the validator removed the only thing that could produce it, so there is no longer a rejection that arrives as the bare string `"Invalid Input"` instead of an HTTP status. Every rejection is now a real status with a real explanation. Flagging it rather than quietly ticking the box, since the decision is what makes it true.

## Other things worth knowing

- **The Redux API reports no runtime for a solve**, only the solved instance. Rather than leave the Runtime row blank or invent a number, a live result shows the round trip this browser measured and says plainly that it includes network time and is not the solver's own runtime.
- **The solver and verifier class names are now carried through** `hooks/useProblemDetail.js`. The API is keyed by class name (`CliqueBruteForce`), not the display name the page shows (`Clique Brute Force Solver`), and the hook was previously dropping it.
- **The Verify button is now a real MUI button** rather than a plain element styled to look unavailable. It keeps the same pill shape and gains the focus ring and hover state a live control should have.
- **`/api/redux/` is now one exported constant** instead of the same literal written in three files.
- **One existing end-to-end assertion changed.** `tests/e2e/detail.spec.js` asserted that Run was disabled, which was correct until this task. It now checks that Run is enabled when there is an instance and goes back to disabled when the box is emptied. Full coverage of the live Run and Verify paths is T39 (#97).

Verified against the live backend at https://redux.isu.edu/api/redux/ in a real browser: a Clique solve returns `{2,3,4,5}` in about a tenth of a second, verifying that answer comes back valid, a nonsense certificate produces the backend's parse error with its expected format shown, and cancelling a slow run leaves nothing behind when the response finally arrives.

Closes #95

Checks run before opening this PR: format-check: pass; lint: pass; build: pass; audit: clean; integration-test: skipped locally (runs in CI via rbs)