### PR TITLE
Setup Proxy Visualize Endpoint

### DIFF
--- a/pages/api/redux/[...path].js
+++ b/pages/api/redux/[...path].js
@@ -66,11 +66,17 @@ const rateLimitBuckets = new Map();
  * Endpoints this frontend actually uses, and the methods each accepts. Anything else on
  * the backend origin is refused.
  *
- * The surface is small and fully known (`lib/redux/index.js` is the only caller), so an
- * allowlist costs almost nothing here and means a stray path cannot reach an endpoint
- * nobody meant to expose. Adding a backend call means adding it to this map too. Track
- * B (T41, #99) is expected to need at least one more entry once the visualization data
- * contract is settled.
+ * The surface is small and known (`lib/redux/index.js` is the only current caller for
+ * everything except `ProblemProvider/visualize`), so an allowlist costs almost nothing
+ * here and means a stray path cannot reach an endpoint nobody meant to expose. Adding a
+ * backend call means adding it to this map too.
+ *
+ * `ProblemProvider/visualize` (T44, #103) is allowed ahead of any caller existing in
+ * `lib/redux/index.js`. That is a deliberate exception to "the list holds what the site
+ * actually uses": Track B's design tasks (T41, #99; T42, #100) need to see real
+ * visualization payloads through this app's own proxy, and nothing can render one while
+ * the proxy 404s the request first. `ProblemProvider/visualizeReduction` has the same
+ * compute profile and is deliberately NOT added yet -- see the comment below.
  *
  * Keys are paths relative to `REDUX_BASE_URL`, matched exactly and case-sensitively.
  * Query strings are not part of the match.
@@ -85,10 +91,20 @@ const ALLOWED_ENDPOINTS = new Map([
   ["Navigation/Reductions", ["GET", "HEAD"]],
   ["ProblemProvider/solve", ["POST"]],
   ["ProblemProvider/verify", ["POST"]],
+  ["ProblemProvider/visualize", ["POST"]],
+  // ProblemProvider/visualizeReduction is NOT here. It has the same compute profile as
+  // `visualize` above, but nothing calls it yet. Add it, and its COMPUTE_ENDPOINTS entry
+  // below, in whichever task first wires the Reductions section against live data --
+  // not before, per this allowlist's own principle that it holds what the site actually
+  // uses. (T44, #103)
 ]);
 
 /** Endpoints that run an algorithm rather than returning a stored lookup. */
-const COMPUTE_ENDPOINTS = new Set(["ProblemProvider/solve", "ProblemProvider/verify"]);
+const COMPUTE_ENDPOINTS = new Set([
+  "ProblemProvider/solve",
+  "ProblemProvider/verify",
+  "ProblemProvider/visualize",
+]);
 
 export const config = {
   api: { bodyParser: false },


### PR DESCRIPTION
Issue:  #103 (T44: Add ProblemProvider/visualize to the proxy allowlist as a compute endpoint)
Branch: task/T44-proxy-visualize-endpoint

Changed:
  pages/api/redux/[...path].js   (ProblemProvider/visualize added to ALLOWED_ENDPOINTS and
                                   COMPUTE_ENDPOINTS; comments updated to explain both the
                                   deliberate ahead-of-caller addition and visualizeReduction's
                                   deliberate absence)

Done when, met:
  - ProblemProvider/visualize is in ALLOWED_ENDPOINTS, POST only
  - It is also in COMPUTE_ENDPOINTS (60s timeout, not 15s)
  - Verified live: POST through the proxy to the production backend (temporarily pointed
    .env.local at https://redux.isu.edu/api/redux/, reverted after) returned a real
    {nodes, links} visualization payload for CliqueDefaultVisualization
  - GET to ProblemProvider/visualize returns 405 with Allow: POST
  - An endpoint not on the list (ProblemProvider/visualizeReduction) still returns 404,
    both GET and POST
  - visualizeReduction is still absent from the allowlist, with a code comment naming
    the reason and pointing at whichever task wires the Reductions section to live data
  - Rate limiting, body cap, host/SSRF check, redirect handling and content-encoding
    stripping are untouched — same code path, only the allowlist/compute-set entries changed
  - npm run lint, npm run format, npm run build are all clean

Decisions and assumptions:
  - Verified against the live production backend rather than a local one, since .env.local
    is configured for a local backend at :27000 that wasn't running. Confirmed the response
    shape matches T40's documented GraphD3 payload exactly.
  - Updated the ALLOWED_ENDPOINTS doc comment to note visualize is allowed ahead of any
    caller existing in lib/redux/index.js yet (deliberate, per the issue's own reasoning
    that Track B's design tasks need real payloads through this app's own proxy) — flagging
    this since it's a small deviation from the comment's previous "the surface is small and
    fully known" framing, not because it changes any actual behavior.

  Closes #103