### PR TITLE
Adding Playback Step Scrubber

### DIFF
--- a/components/detail/ReductionsSection.js
+++ b/components/detail/ReductionsSection.js
@@ -3,18 +3,18 @@
 // T16e (#25) — the most complex-looking panel in the mockup, and deliberately
 // the most scoped-down. Reduces-to/reduces-from lists and cost badges are
 // real declared data (data/fixtures.js's `reductions` shape aligns well with
-// the backend); the source/target instance diagrams are static placeholders
-// only — no live step-scrubber, no draggable/editable nodes (v1 scope).
+// the backend); the source/target instance diagrams are still static
+// placeholders (real diagram rendering is T53, once T48-T50 land) — no
+// draggable/editable nodes (v1 scope).
 //
-// Gap, deliberately not papered over: unlike VisualizationsSection's
-// per-instance `stepLabel`/`stepNarration`, data/fixtures.js's `reductions`
-// shape (`{ to: [{target, cost, type}], from: [{source, cost, type}] }`) has
-// no step/narration field at all, for any problem. The mockup's "step 2/5"
-// counter and "Step 2: clause C2 (...) becomes cover-edge (...)" narration
-// were hand-drawn for 3-SAT specifically and were never added to the T09
-// fixture contract. Rather than fabricate problem-specific narration text
-// that has no backing data, the scrubber below renders as inert chrome with
-// a plain, honest "not available yet" note instead of a real step count.
+// The step-scrubber row is real now (T47/#110), via the shared StepScrubber
+// component. A reduction is structurally a 2-frame case, not a UI limitation
+// to work around: `POST /ProblemProvider/visualizeReduction` always returns
+// an empty steps list (`AdditionalControllers/ProblemProvider.cs:312`), so
+// there is only ever a source-shape base frame and a reduced/solved frame,
+// never intermediate steps (INTERACTIVE_LAYER_DESIGN.md §1.3) — so this
+// section always passes `frameCount={2}` rather than deriving a count from
+// data that will never carry more than that.
 //
 // The source/target canvas cards are likewise static placeholders (no real
 // diagram-rendering exists yet) rather than an attempt to actually draw a
@@ -23,11 +23,7 @@
 // interactive behavior the issue's done-when asks for.
 
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
-import SkipNextIcon from "@mui/icons-material/SkipNext";
-import SkipPreviousIcon from "@mui/icons-material/SkipPrevious";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
 import Paper from "@mui/material/Paper";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
@@ -35,6 +31,7 @@ import { useState } from "react";
 import { TAXONOMY } from "../../data/taxonomy";
 import { getFacetAccentColor, thinScrollbarSx } from "../theme";
 import SectionShell from "./SectionShell";
+import StepScrubber from "./StepScrubber";
 
 // #71: fixed list height so a problem with many declared reduction targets
 // scrolls inside the list instead of stretching the section indefinitely.
@@ -113,12 +110,23 @@ function CanvasCard({ title }) {
 export default function ReductionsSection({ problem, dragHandleProps }) {
   const { to, from } = problem.reductions;
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [currentStep, setCurrentStep] = useState(0);
   const [fromExpanded, setFromExpanded] = useState(true);
 
   const hasTo = to.length > 0;
   const hasFrom = from.length > 0;
   const hasAny = hasTo || hasFrom;
   const selected = hasTo ? to[Math.min(selectedIndex, to.length - 1)] : null;
+
+  // Selecting a different reduction target starts its base/reduced toggle
+  // over rather than carrying a step index across to an unrelated pair.
+  // Render-time state adjustment (React's documented pattern for this, not
+  // a useEffect) so it doesn't cost an extra committed render.
+  const [stepResetKey, setStepResetKey] = useState(selectedIndex);
+  if (stepResetKey !== selectedIndex) {
+    setStepResetKey(selectedIndex);
+    setCurrentStep(0);
+  }
 
   const total = to.length + from.length;
   const summary = `${total} reduction${total === 1 ? "" : "s"}`;
@@ -139,24 +147,20 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
         </Typography>
       )}
 
-      {hasAny && (
-        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}>
-          <IconButton size="small" disabled aria-label="Previous step">
-            <SkipPreviousIcon fontSize="small" />
-          </IconButton>
-          <IconButton size="small" disabled aria-label="Play">
-            <PlayArrowIcon fontSize="small" />
-          </IconButton>
-          <IconButton size="small" disabled aria-label="Next step">
-            <SkipNextIcon fontSize="small" />
-          </IconButton>
-          <Box sx={{ flex: 1, height: 4, borderRadius: 999, backgroundColor: "divider" }} />
+      {hasTo && (
+        <Box sx={{ mb: 2 }}>
+          <StepScrubber
+            idPrefix="reductions-scrubber"
+            frameCount={2}
+            currentStep={currentStep}
+            onStepChange={setCurrentStep}
+            frameNoun="Frame"
+          />
+          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1, fontStyle: "italic" }}>
+            A reduction is a single mapping, not a stepped process — this toggles between the source
+            instance and the reduced instance, with no intermediate steps.
+          </Typography>
         </Box>
-      )}
-      {hasAny && (
-        <Typography variant="body2" sx={{ color: "text.secondary", mb: 2, fontStyle: "italic" }}>
-          Step-by-step reduction narration isn&apos;t available yet for this problem.
-        </Typography>
       )}
 
       {hasTo && (

--- a/components/detail/StepScrubber.js
+++ b/components/detail/StepScrubber.js
@@ -1,0 +1,219 @@
+// components/detail/StepScrubber.js
+//
+// T47 (#110) — the shared step-playback scrubber used by both
+// VisualizationsSection.js and ReductionsSection.js. Purely a rendering/
+// navigation concern (INTERACTIVE_LAYER_DESIGN.md §1): walks whatever
+// frames[] array the caller owns, emitting `onStepChange` as the user
+// plays, steps, or drags the scrub bar. No assumptions baked in about
+// which section renders it or how many frames it has -- Visualizations'
+// up-to-24-frame case (§1.2, pumpSchedule, the largest of the 48 observed
+// instances) and Reductions' structurally-fixed 2-frame case (§1.3, base
+// then reduced/solved, since visualizeReduction never returns intermediate
+// steps) are the same `frameCount` prop, just a different number.
+//
+// Play/pause/step buttons are real, focusable, aria-labelled controls; the
+// scrub bar is a real MUI Slider (a native range input under the hood, so
+// arrow keys move it without extra wiring); frame changes announce through
+// an aria-live region, matching ComputeStatus.js's existing live-Run/Verify
+// pattern -- a persistent role="status" region whose *text* changes, rather
+// than one that mounts at the same moment as its content (that combination
+// is often missed entirely by a screen reader).
+//
+// Playback and speed are owned internally rather than lifted to the
+// caller: the caller only needs to know the current frame (to render it)
+// and how to change it, not whether a timer is currently ticking. That
+// keeps both call sites down to frameCount/currentStep/onStepChange, per
+// the issue's genericity requirement.
+
+import PauseIcon from "@mui/icons-material/Pause";
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+import SkipNextIcon from "@mui/icons-material/SkipNext";
+import SkipPreviousIcon from "@mui/icons-material/SkipPrevious";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Slider from "@mui/material/Slider";
+import Typography from "@mui/material/Typography";
+import { useEffect, useState } from "react";
+
+// Milliseconds between frames while playing at 1x. SPEED_OPTIONS' `factor`
+// multiplies this, so 2x plays twice as fast (half the delay) and 0.5x half
+// as fast (double the delay).
+const BASE_STEP_MS = 900;
+const SPEED_OPTIONS = [
+  { value: "0.5", factor: 2, label: "0.5x" },
+  { value: "1", factor: 1, label: "1x" },
+  { value: "2", factor: 0.5, label: "2x" },
+];
+const DEFAULT_SPEED_VALUE = "1";
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders
+ *   (ground rule 4: no literal ids inside a reusable component).
+ * @param {number} props.frameCount Total number of frames to scrub across.
+ *   Reductions passes 2 (source, reduced); Visualizations passes however
+ *   many frames the selected visualization declares.
+ * @param {number} props.currentStep The index of the frame currently shown,
+ *   0-based, owned by the caller.
+ * @param {(next: number) => void} props.onStepChange Called with the new
+ *   step index on every step/scrub/play tick.
+ * @param {string} [props.frameNoun] What one frame is called in the
+ *   position text and the aria-live announcement. Defaults to "Step".
+ */
+export default function StepScrubber({
+  idPrefix,
+  frameCount,
+  currentStep,
+  onStepChange,
+  frameNoun = "Step",
+}) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speedValue, setSpeedValue] = useState(DEFAULT_SPEED_VALUE);
+
+  const hasFrames = frameCount > 0;
+  const lastIndex = Math.max(frameCount - 1, 0);
+  const canScrub = frameCount > 1;
+  const atStart = currentStep <= 0;
+  const atEnd = currentStep >= lastIndex;
+  // `isPlaying` only ever records the user's own play/pause intent; whether
+  // playback is actually ticking right now also depends on atEnd, which the
+  // effect below can't set (it would be a setState-during-effect call for a
+  // value already derivable from props+state). Deriving it here instead
+  // means reaching the last frame while playing stops the timer for free
+  // (the effect's own condition goes false) without an extra render to
+  // flip a redundant "stopped" flag.
+  const isPlayingEffective = isPlaying && canScrub && !atEnd;
+
+  // Advances one frame after a speed-scaled delay while playing, and stops
+  // itself once the last frame is reached rather than looping -- a scrubber
+  // that silently jumps back to frame 0 on its own would be confusing next
+  // to a position indicator that just read "Step 7 of 7".
+  useEffect(() => {
+    if (!isPlayingEffective) {
+      return undefined;
+    }
+    const speed = SPEED_OPTIONS.find((option) => option.value === speedValue) ?? SPEED_OPTIONS[1];
+    const timeoutId = setTimeout(() => {
+      onStepChange(Math.min(currentStep + 1, lastIndex));
+    }, BASE_STEP_MS * speed.factor);
+    return () => clearTimeout(timeoutId);
+  }, [isPlayingEffective, speedValue, currentStep, lastIndex, onStepChange]);
+
+  function handlePlayPause() {
+    if (isPlayingEffective) {
+      setIsPlaying(false);
+      return;
+    }
+    // Replaying after reaching the end restarts from the beginning instead
+    // of doing nothing, which is what a press of Play would otherwise do
+    // while already sitting on the last frame.
+    if (atEnd) {
+      onStepChange(0);
+    }
+    setIsPlaying(true);
+  }
+
+  function handleStepBack() {
+    setIsPlaying(false);
+    onStepChange(Math.max(currentStep - 1, 0));
+  }
+
+  function handleStepForward() {
+    setIsPlaying(false);
+    onStepChange(Math.min(currentStep + 1, lastIndex));
+  }
+
+  function handleScrub(_event, value) {
+    setIsPlaying(false);
+    onStepChange(Array.isArray(value) ? value[0] : value);
+  }
+
+  const positionText = hasFrames
+    ? `${frameNoun} ${currentStep + 1} of ${frameCount}`
+    : "No frames available";
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        px: 1.5,
+        py: 1,
+        borderRadius: 2,
+        border: "1px solid",
+        borderColor: "divider",
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        <IconButton
+          id={`${idPrefix}-previous`}
+          size="small"
+          disabled={!canScrub || atStart}
+          onClick={handleStepBack}
+          aria-label="Previous step"
+        >
+          <SkipPreviousIcon fontSize="small" />
+        </IconButton>
+        <IconButton
+          id={`${idPrefix}-play-pause`}
+          size="small"
+          disabled={!canScrub}
+          onClick={handlePlayPause}
+          aria-label={isPlayingEffective ? "Pause" : "Play"}
+        >
+          {isPlayingEffective ? <PauseIcon fontSize="small" /> : <PlayArrowIcon fontSize="small" />}
+        </IconButton>
+        <IconButton
+          id={`${idPrefix}-next`}
+          size="small"
+          disabled={!canScrub || atEnd}
+          onClick={handleStepForward}
+          aria-label="Next step"
+        >
+          <SkipNextIcon fontSize="small" />
+        </IconButton>
+
+        <Slider
+          id={`${idPrefix}-slider`}
+          aria-label="Scrub to step"
+          getAriaValueText={(value) => `${frameNoun} ${value + 1} of ${frameCount}`}
+          valueLabelDisplay="auto"
+          valueLabelFormat={(value) => `${value + 1}`}
+          size="small"
+          min={0}
+          max={lastIndex}
+          step={1}
+          value={currentStep}
+          onChange={handleScrub}
+          disabled={!canScrub}
+          sx={{ flex: 1, mx: 1 }}
+        />
+
+        <Select
+          id={`${idPrefix}-speed`}
+          aria-label="Playback speed"
+          size="small"
+          value={speedValue}
+          disabled={!canScrub}
+          onChange={(event) => setSpeedValue(event.target.value)}
+          sx={{ flexShrink: 0, minWidth: 76 }}
+        >
+          {SPEED_OPTIONS.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </Box>
+
+      <Box id={`${idPrefix}-position`} role="status" aria-live="polite">
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          {positionText}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -4,17 +4,23 @@
 // problem's declared visualizations (name + type badge), and a right pane
 // with a static canvas, its caption, and step-scrubber chrome.
 //
-// v1 scope (ground rule 5): only the rail selection is live. The canvas
-// itself is a static rendering, and the step-scrubber controls (prev/play/
-// next, progress bar, step counter) plus the "Drag nodes to reposition" /
-// "Right-click to add" hint text are rendered as visibly inert chrome —
-// real MUI `disabled` buttons (which also removes them from tab order),
-// not just dimmed-looking active ones. No live node editing, no
-// right-click menu, no working scrubber.
+// v1 scope (ground rule 5, as narrowed by INTERACTIVE_LAYER_DESIGN.md's
+// staging plan): only the rail selection and the step-scrubber are live.
+// The canvas itself is still a static rendering (real diagram rendering is
+// T48-T50) and the "Drag nodes to reposition" / "Right-click to add" hint
+// text stays inert chrome — no live node editing, no right-click menu. The
+// scrubber row is real, though (T47/#110): play/pause/step/speed/scrub bar
+// all work, via the shared StepScrubber component. `selected.frames` isn't
+// populated by hooks/useProblemDetail.js yet (that's T48-T50's job), so the
+// scrubber currently degrades to a real, correctly-labelled single frame
+// ("Step 1 of 1") rather than faking a frame count that doesn't exist yet.
 //
-// Only 3-SAT's fixture entries carry `stepLabel`/`stepNarration` — every
-// other problem's visualizations only have `{ name, type, caption }`, so
-// both are rendered conditionally rather than assumed present.
+// Only 3-SAT's fixture entries ever carried `stepLabel`/`stepNarration` —
+// every other problem's visualizations only have `{ name, type, caption }`,
+// so both are rendered conditionally rather than assumed present. Neither
+// field is populated by the real hook today (see hooks/useProblemDetail.js's
+// buildVisualizations) — kept here so this stays a no-op regression, not a
+// removal, if a future task adds narration data back.
 //
 // T28 (#37): the rail-plus-pane split stacks below `md` (900px) -- same
 // breakpoint components/detail/OverviewSection.js already uses for its own
@@ -22,17 +28,14 @@
 // into a drawer at, kept consistent rather than picking a third number. The
 // rail's fixed width only applies at `md` and up; stacked, it's full width.
 
-import PlayArrowIcon from "@mui/icons-material/PlayArrow";
-import SkipNextIcon from "@mui/icons-material/SkipNext";
-import SkipPreviousIcon from "@mui/icons-material/SkipPrevious";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useState } from "react";
 import { TAXONOMY, UNCLASSIFIED } from "../../data/taxonomy";
 import { getFacetAccentColor, thinScrollbarSx } from "../theme";
 import SectionShell from "./SectionShell";
+import StepScrubber from "./StepScrubber";
 
 const VISUALIZATION_TYPE_FACET = TAXONOMY.find((facet) => facet.key === "visualizationType");
 
@@ -82,8 +85,21 @@ function TypeBadge({ typeKey }) {
 export default function VisualizationsSection({ problem, dragHandleProps }) {
   const visualizations = problem.visualizations ?? [];
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [currentStep, setCurrentStep] = useState(0);
   const selected = visualizations[selectedIndex];
   const noun = visualizations.length === 1 ? "visualization" : "visualizations";
+
+  // Selecting a different visualization starts its playback over rather
+  // than carrying over a step index that may be out of range for it. Done
+  // as a render-time state adjustment (React's documented pattern for this,
+  // not a useEffect) so it doesn't cost an extra committed render.
+  const [stepResetKey, setStepResetKey] = useState(selectedIndex);
+  if (stepResetKey !== selectedIndex) {
+    setStepResetKey(selectedIndex);
+    setCurrentStep(0);
+  }
+
+  const frameCount = selected?.frames?.length ?? 1;
 
   return (
     <SectionShell
@@ -169,47 +185,12 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
           </Box>
 
           <Box sx={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 1 }}>
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 1,
-                px: 1.5,
-                py: 1,
-                borderRadius: 2,
-                border: "1px solid",
-                borderColor: "divider",
-              }}
-            >
-              <IconButton
-                id="visualizations-scrubber-previous"
-                size="small"
-                disabled
-                aria-label="Previous step"
-              >
-                <SkipPreviousIcon fontSize="small" />
-              </IconButton>
-              <IconButton id="visualizations-scrubber-play" size="small" disabled aria-label="Play">
-                <PlayArrowIcon fontSize="small" />
-              </IconButton>
-              <IconButton
-                id="visualizations-scrubber-next"
-                size="small"
-                disabled
-                aria-label="Next step"
-              >
-                <SkipNextIcon fontSize="small" />
-              </IconButton>
-              <Box
-                aria-hidden="true"
-                sx={{ flex: 1, height: 4, borderRadius: 999, backgroundColor: "divider", mx: 1 }}
-              />
-              {selected.stepLabel && (
-                <Typography variant="body2" sx={{ color: "text.secondary", flexShrink: 0 }}>
-                  {selected.stepLabel}
-                </Typography>
-              )}
-            </Box>
+            <StepScrubber
+              idPrefix="visualizations-scrubber"
+              frameCount={frameCount}
+              currentStep={currentStep}
+              onStepChange={setCurrentStep}
+            />
 
             <Box
               sx={{


### PR DESCRIPTION
Issue: #110 (T47: Shared step-playback scrubber component)
Branch: task/T47-step-playback-scrubber

Changed:
components/detail/StepScrubber.js       (new — the shared component)
components/detail/VisualizationsSection.js   (wired in, replacing the disabled icon row)
components/detail/ReductionsSection.js       (wired in, replacing the disabled icon row)

Done when, met:
- Play, pause, step forward/back, speed control (0.5x/1x/2x), and scrub bar all work and are keyboard-operable (real IconButtons and a real MUI Slider, which is a native range input under the hood).
- Frame position is shown as text ("Step 3 of 7") and announced via a persistent role="status" aria-live="polite" region whose text changes, matching ComputeStatus.js's existing pattern for live Run/Verify.
- The component is generic: its only props are frameCount/currentStep/onStepChange (plus optional idPrefix/frameNoun). Play/pause/speed state lives inside the component itself rather than being pushed onto the caller.
- Wired into VisualizationsSection.js.
- Wired into ReductionsSection.js, which now always passes frameCount={2} (source, reduced) since visualizeReduction never returns intermediate steps, and only renders the scrubber when there's a selected "reduces to" target to scrub (it was previously gated on hasAny, which could show a scrubber with no canvas underneath it in the reduces-from-only case — fixed as part of this wiring).

Decisions and assumptions:
- problem.visualizations[i] doesn't carry a frames field yet (that's T48-T50's job); VisualizationsSection defensively falls back to frameCount = selected?.frames?.length ?? 1, so today it correctly shows a real, non-fake "Step 1 of 1" rather than fabricating a frame count. No behavior change needed here once T48-T50 lands a real frames array.
- Reductions' scrubber uses frameNoun="Frame" instead of the default "Step", since nothing is being computed step-by-step there, just a source/reduced toggle — matches the design doc's own "frame" language in §1.3. Added a short caption explaining that structural reasoning in place of the old "not available yet" note, which is no longer true.
- The two sections' "reset step index when the selection changes" logic uses React's documented render-time state-adjustment pattern rather than useEffect, because eslint-plugin-react-hooks's set-state-in-effect rule (already enabled in this repo) flags a direct setState call inside an effect body. Same reasoning applied inside StepScrubber itself: whether playback is actually still ticking is derived (isPlayingEffective = isPlaying && canScrub && !atEnd) rather than written back into state by the timer effect.
- npm run lint, npm run format, and npm run build are all clean.

Closes #110