### PR TITLE
Setup Graph Visualizations

### DIFF
--- a/components/ProblemDetailLayout.js
+++ b/components/ProblemDetailLayout.js
@@ -71,6 +71,19 @@
 // `order` is plain component-local useState. No localStorage, no URL
 // params — per the issue body and TASKLIST.md's T18 entry ("do not add
 // persistence ... unless the project owner asks").
+//
+// --- The shared Run action (T48/#111, INTERACTIVE_LAYER_DESIGN.md §2.1.1) --
+// Run is one shared action, lifted here because this is where the instance it
+// acts on already lives. It is not a fetch itself -- each section that
+// declares `usesRun` (Solvers, Visualizations; Reductions joins in T53) still
+// owns its own request (a `/solve` failure and a `/visualize` failure are
+// independent outcomes, shown in their own panels, never all-or-nothing).
+// What's shared is just the trigger: `runToken` is a counter bumped by
+// `triggerRun`, passed to every `usesRun` section alongside it, so pressing
+// Run in ANY of them re-runs every one of them against the same instant of
+// the shared instance -- Solvers keeps its own selected solver, Visualizations
+// its own selected visualization, and the token carries no data of its own,
+// just the "go" signal.
 
 import {
   closestCenter,
@@ -103,13 +116,29 @@ import VisualizationsSection from "./detail/VisualizationsSection";
 // (TASKLIST.md T18 entry) — Reductions goes last deliberately, not by
 // omission.
 //
-// `usesInstance` marks the two sections that take the shared problem
-// instance (T35/#93, see header) -- the other three are rendered with
-// `problem` alone, exactly as before.
+// `usesInstance` marks the sections that take the shared problem instance
+// (T35/#93, see header). `usesRun` marks the ones that also react to the
+// shared Run trigger (T48/#111, see header) -- Verifier deliberately does
+// not: Verify checks a user-supplied certificate against an instance, it
+// does not run a solver, and its certificate has no guaranteed relationship
+// to a fresh /visualize call (INTERACTIVE_LAYER_DESIGN.md §2.1). Reductions
+// joins `usesRun` in T53, once it has real data to refresh.
 const SECTIONS = [
   { key: "overview", title: "Overview", Component: OverviewSection },
-  { key: "visualizations", title: "Visualizations", Component: VisualizationsSection },
-  { key: "solvers", title: "Solvers", Component: SolversSection, usesInstance: true },
+  {
+    key: "visualizations",
+    title: "Visualizations",
+    Component: VisualizationsSection,
+    usesInstance: true,
+    usesRun: true,
+  },
+  {
+    key: "solvers",
+    title: "Solvers",
+    Component: SolversSection,
+    usesInstance: true,
+    usesRun: true,
+  },
   { key: "verifier", title: "Verifier", Component: VerifierSection, usesInstance: true },
   { key: "reductions", title: "Reductions", Component: ReductionsSection },
 ];
@@ -200,6 +229,14 @@ export default function ProblemDetailLayout({ problem }) {
     setInstance(problem.defaultInstance ?? "");
   }
 
+  // The shared Run trigger (T48/#111, see file header). A `usesRun` section
+  // reacts to this changing, not to its value -- it is a "go" signal, not a
+  // payload.
+  const [runToken, setRunToken] = useState(0);
+  function triggerRun() {
+    setRunToken((token) => token + 1);
+  }
+
   // PointerSensor covers mouse; TouchSensor adds mobile/tablet support
   // (both ported from Redux_GUI). KeyboardSensor is new here — see file
   // header.
@@ -281,13 +318,14 @@ export default function ProblemDetailLayout({ problem }) {
         <SortableContext items={order} strategy={verticalListSortingStrategy}>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
             {order.map((key) => {
-              const { Component, usesInstance } = SECTIONS_BY_KEY.get(key);
+              const { Component, usesInstance, usesRun } = SECTIONS_BY_KEY.get(key);
               const instanceProps = usesInstance
                 ? { instanceValue: instance, onInstanceChange: setInstance }
                 : null;
+              const runProps = usesRun ? { runToken, onRunRequest: triggerRun } : null;
               return (
                 <SortableSection key={key} id={key}>
-                  <Component problem={problem} {...instanceProps} />
+                  <Component problem={problem} {...instanceProps} {...runProps} />
                 </SortableSection>
               );
             })}

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -10,6 +10,15 @@
 // was a real `disabled` button producing nothing, per ground rule 5, and
 // this is the task that lifts that for the Solvers section.
 //
+// T48 (#111): the Run button no longer performs the solve directly. It
+// invokes the shared Run action (`onRunRequest`, owned by
+// ProblemDetailLayout.js -- see that file's header) instead, and an effect
+// here reacts to `runToken` changing by performing the same solve it always
+// did. The visible behavior of pressing this button is unchanged; what
+// changed is that Visualizations' own Run affordance now bumps the same
+// token, so a solve and a `/visualize` call happen together no matter which
+// section's button was pressed (INTERACTIVE_LAYER_DESIGN.md §2.1.1).
+//
 // Three things that took more care than the call itself:
 //
 //   - Staleness. A brute-force solver can run for the full 60 seconds the
@@ -51,7 +60,7 @@ import Chip from "@mui/material/Chip";
 import Paper from "@mui/material/Paper";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { TAXONOMY } from "../../data/taxonomy";
 import {
   COMPUTE_CANCELLED,
@@ -137,6 +146,11 @@ function formatSeconds(milliseconds) {
  *   new text whenever the visitor edits the box. The Verifier section's own
  *   instance input is bound to the same value, so an edit here shows up
  *   there too.
+ * @param {number} [props.runToken] The shared Run trigger (T48/#111), owned by
+ *   ProblemDetailLayout.js. A change in value (not the value itself) means
+ *   Run was pressed somewhere -- this section or another `usesRun` one.
+ * @param {() => void} [props.onRunRequest] Bumps `runToken`. Called by this
+ *   section's own Run button instead of solving directly.
  * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
  *   Forwarded straight through to SectionShell — see T18 (#27).
  */
@@ -144,6 +158,8 @@ export default function SolversSection({
   problem,
   instanceValue = "",
   onInstanceChange,
+  runToken,
+  onRunRequest,
   dragHandleProps,
 }) {
   const solvers = problem.solvers ?? [];
@@ -178,24 +194,40 @@ export default function SolversSection({
     setSelectedIndex(index);
   }
 
-  function handleRun() {
+  const { start: startRun } = run;
+  const handleRun = useCallback(() => {
     if (!canRun) return;
     const solver = selected;
-    run.start(async (signal) => {
+    const instanceAtRun = instanceValue;
+    startRun(async (signal) => {
       const output = await requestSolvedInstance(
         REDUX_API_BASE_URL,
         solver.className,
-        instanceValue,
+        instanceAtRun,
         signal,
       );
       return {
         output,
         solverClassName: solver.className,
         solverName: solver.name,
-        instance: instanceValue,
+        instance: instanceAtRun,
       };
     });
-  }
+  }, [canRun, selected, instanceValue, startRun]);
+
+  // Reacts to the shared Run trigger (T48/#111, see file header) rather than
+  // performing the solve inline in the button's onClick -- that way it fires
+  // the same way whether this section's own Run button was pressed or
+  // another `usesRun` section's was. `previousRunTokenRef` is what makes
+  // this "run on change", not "run on every render this effect happens to
+  // fire in": only a token that actually differs from the last one this
+  // effect acted on triggers a new solve.
+  const previousRunTokenRef = useRef(runToken);
+  useEffect(() => {
+    if (runToken === undefined || runToken === previousRunTokenRef.current) return;
+    previousRunTokenRef.current = runToken;
+    handleRun();
+  }, [runToken, handleRun]);
 
   const solverName = selected?.name ?? "this solver";
   let announcement = "";
@@ -383,7 +415,7 @@ export default function SolversSection({
                   id="solvers-run-button"
                   variant="contained"
                   disabled={!canRun || run.isRunning}
-                  onClick={handleRun}
+                  onClick={() => (onRunRequest ? onRunRequest() : handleRun())}
                   sx={{ alignSelf: "flex-start" }}
                 >
                   Run

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -2,46 +2,63 @@
 //
 // T16b (#22) — the Visualizations detail-page section: a left rail of the
 // problem's declared visualizations (name + type badge), and a right pane
-// with a static canvas, its caption, and step-scrubber chrome.
+// with a canvas, its caption, and step-scrubber chrome.
 //
-// v1 scope (ground rule 5, as narrowed by INTERACTIVE_LAYER_DESIGN.md's
-// staging plan): only the rail selection and the step-scrubber are live.
-// The canvas itself is still a static rendering (real diagram rendering is
-// T48-T50) and the "Drag nodes to reposition" / "Right-click to add" hint
-// text stays inert chrome — no live node editing, no right-click menu. The
-// scrubber row is real, though (T47/#110): play/pause/step/speed/scrub bar
-// all work, via the shared StepScrubber component. `selected.frames` isn't
-// populated by hooks/useProblemDetail.js yet (that's T48-T50's job), so the
-// scrubber currently degrades to a real, correctly-labelled single frame
-// ("Step 1 of 1") rather than faking a frame count that doesn't exist yet.
+// T48 (#111): the canvas is real now, for the `graph` universal type (24 of
+// 48 declared instances, the largest group -- ai_documentation/
+// VISUALIZATION_TYPE_CONTRACTS.md §3.1). Structural editing is still out of
+// scope (T51, gated on T46) -- rendering is read-only, and the earlier "Drag
+// nodes to reposition / Right-click to add" hint text is gone rather than
+// left pointing at an interaction that doesn't exist: it was harmless over
+// a static placeholder box, but would be actively misleading under a real,
+// rendered diagram nothing responds to.
 //
-// Only 3-SAT's fixture entries ever carried `stepLabel`/`stepNarration` —
-// every other problem's visualizations only have `{ name, type, caption }`,
-// so both are rendered conditionally rather than assumed present. Neither
-// field is populated by the real hook today (see hooks/useProblemDetail.js's
-// buildVisualizations) — kept here so this stays a no-op regression, not a
-// removal, if a future task adds narration data back.
+// Per INTERACTIVE_LAYER_DESIGN.md §0/§2.1/§2.1.1: this section shares
+// `instanceValue`/`onInstanceChange` with Solvers and Verifier (T35/#93) and
+// reacts to the shared Run trigger `runToken`/`onRunRequest` (owned by
+// components/ProblemDetailLayout.js) the same way Solvers does. Frames are
+// not refetched on every instance edit -- only on Run -- and a staleness
+// banner shows when the instance has changed since the frames currently
+// shown were fetched, the same `instanceChangedSinceRun` pattern
+// components/detail/SolversSection.js already established.
 //
-// T28 (#37): the rail-plus-pane split stacks below `md` (900px) -- same
-// breakpoint components/detail/OverviewSection.js already uses for its own
-// two-card split, and the width pages/index.js switches the Home sidebar
-// into a drawer at, kept consistent rather than picking a third number. The
-// rail's fixed width only applies at `md` and up; stacked, it's full width.
+// T47 (#110): step playback (play/pause/step/speed/scrub bar) is the shared
+// StepScrubber component, now driven by the real frame count a completed
+// run returns rather than a fallback of 1.
 
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { TAXONOMY, UNCLASSIFIED } from "../../data/taxonomy";
+import {
+  COMPUTE_CANCELLED,
+  COMPUTE_DONE,
+  COMPUTE_FAILED,
+  COMPUTE_RUNNING,
+  useComputeRequest,
+} from "../../hooks/useComputeRequest";
+import { REDUX_API_BASE_URL, requestVisualizedInstance } from "../../lib/redux";
 import { getFacetAccentColor, thinScrollbarSx } from "../theme";
+import ComputeStatus from "./ComputeStatus";
 import SectionShell from "./SectionShell";
 import StepScrubber from "./StepScrubber";
+import VisualizationCanvas from "./visualizations/VisualizationCanvas";
 
 const VISUALIZATION_TYPE_FACET = TAXONOMY.find((facet) => facet.key === "visualizationType");
 
 // #71: fixed rail height so a problem with many declared visualizations
 // scrolls inside the rail instead of stretching the section indefinitely.
 const RAIL_MAX_HEIGHT = 320;
+
+// One prefix for every id ComputeStatus renders inside this section, so it
+// can never collide with Solvers' own (ground rule 4).
+const RUN_ID_PREFIX = "visualizations-run";
+
+function formatSeconds(milliseconds) {
+  return `${(milliseconds / 1000).toFixed(2)}s`;
+}
 
 // Falls back to the raw key (or the UNCLASSIFIED sentinel itself, e.g.
 // 3-SAT's "Assignment Table" -- a real, documented taxonomy gap, see
@@ -79,27 +96,116 @@ function TypeBadge({ typeKey }) {
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {string} [props.instanceValue] The shared problem instance, owned by
+ *   components/ProblemDetailLayout.js (T35/#93).
+ * @param {(next: string) => void} [props.onInstanceChange] Called with the new
+ *   text whenever the visitor edits the instance elsewhere (Solvers' box) --
+ *   this section reads the value but does not render its own copy of the box.
+ * @param {number} [props.runToken] The shared Run trigger (T48/#111). A change
+ *   in value, not the value itself, means Run was pressed somewhere.
+ * @param {() => void} [props.onRunRequest] Bumps `runToken`. Called by this
+ *   section's own Run button instead of fetching directly.
  * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
  *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function VisualizationsSection({ problem, dragHandleProps }) {
+export default function VisualizationsSection({
+  problem,
+  instanceValue = "",
+  runToken,
+  onRunRequest,
+  dragHandleProps,
+}) {
   const visualizations = problem.visualizations ?? [];
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [currentStep, setCurrentStep] = useState(0);
   const selected = visualizations[selectedIndex];
   const noun = visualizations.length === 1 ? "visualization" : "visualizations";
 
-  // Selecting a different visualization starts its playback over rather
-  // than carrying over a step index that may be out of range for it. Done
-  // as a render-time state adjustment (React's documented pattern for this,
-  // not a useEffect) so it doesn't cost an extra committed render.
+  const visualize = useComputeRequest({ subject: "instance" });
+
+  const trimmedInstance = instanceValue.trim();
+  const canRun = Boolean(selected?.className) && trimmedInstance !== "";
+
+  // A rendered frame set is only ever shown next to the visualization that
+  // produced it -- same guard components/detail/SolversSection.js uses for
+  // its own liveResult, and for the same reason: the rail is not the only
+  // thing that can change which visualization `selected` points at.
+  const liveFrames =
+    visualize.status === COMPUTE_DONE &&
+    visualize.result?.visualizationClassName === selected?.className
+      ? visualize.result
+      : null;
+  const instanceChangedSinceRun = Boolean(liveFrames) && liveFrames.instance !== instanceValue;
+
+  function handleSelectVisualization(index) {
+    if (index === selectedIndex) return;
+    // Drops any in-flight request and clears the pane, so nothing from the
+    // previous visualization survives the switch.
+    visualize.reset();
+    setSelectedIndex(index);
+  }
+
+  const { start: startVisualize } = visualize;
+  const handleRun = useCallback(() => {
+    if (!canRun) return;
+    const visualization = selected;
+    const instanceAtRun = instanceValue;
+    startVisualize(async (signal) => {
+      const frames = await requestVisualizedInstance(
+        REDUX_API_BASE_URL,
+        visualization.className,
+        instanceAtRun,
+        signal,
+      );
+      return {
+        frames: Array.isArray(frames) ? frames : [],
+        visualizationClassName: visualization.className,
+        visualizationName: visualization.name,
+        instance: instanceAtRun,
+      };
+    });
+  }, [canRun, selected, instanceValue, startVisualize]);
+
+  // Reacts to the shared Run trigger (T48/#111) rather than fetching inline
+  // in the button's onClick -- see components/ProblemDetailLayout.js and
+  // components/detail/SolversSection.js, which does the identical thing.
+  const previousRunTokenRef = useRef(runToken);
+  useEffect(() => {
+    if (runToken === undefined || runToken === previousRunTokenRef.current) return;
+    previousRunTokenRef.current = runToken;
+    handleRun();
+  }, [runToken, handleRun]);
+
+  // Two independent render-time step resets (React's documented "adjust
+  // state" pattern, not a useEffect): selecting a different visualization
+  // starts its playback over, and so does a freshly-completed run replacing
+  // the frames currently shown -- both can leave a stale `currentStep`
+  // pointing past the end of a differently-sized frames[].
   const [stepResetKey, setStepResetKey] = useState(selectedIndex);
   if (stepResetKey !== selectedIndex) {
     setStepResetKey(selectedIndex);
     setCurrentStep(0);
   }
+  const [lastVisualizeResult, setLastVisualizeResult] = useState(visualize.result);
+  if (lastVisualizeResult !== visualize.result) {
+    setLastVisualizeResult(visualize.result);
+    setCurrentStep(0);
+  }
 
-  const frameCount = selected?.frames?.length ?? 1;
+  const frameCount = liveFrames?.frames?.length ?? 1;
+  const currentFrame = liveFrames?.frames?.[currentStep] ?? null;
+
+  const visualizationName = selected?.name ?? "this visualization";
+  let announcement = "";
+  if (visualize.status === COMPUTE_RUNNING) {
+    announcement = `Rendering ${visualizationName}. This can take up to a minute.`;
+  } else if (visualize.status === COMPUTE_DONE) {
+    announcement = `${visualizationName} rendered in ${formatSeconds(visualize.elapsedMs)}.`;
+  } else if (visualize.status === COMPUTE_FAILED) {
+    announcement = `${visualizationName} did not render. ${visualize.failure?.headline ?? ""}`;
+  } else if (visualize.status === COMPUTE_CANCELLED) {
+    announcement = "Run cancelled.";
+  }
 
   return (
     <SectionShell
@@ -143,7 +249,7 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
                     type="button"
                     role="option"
                     aria-selected={isSelected}
-                    onClick={() => setSelectedIndex(index)}
+                    onClick={() => handleSelectVisualization(index)}
                     sx={(theme) => ({
                       display: "flex",
                       flexDirection: "column",
@@ -184,7 +290,26 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
             })}
           </Box>
 
-          <Box sx={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 1 }}>
+          <Box sx={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 1.5 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+              <Button
+                id="visualizations-run-button"
+                variant="outlined"
+                size="small"
+                disabled={!canRun || visualize.isRunning}
+                onClick={() => (onRunRequest ? onRunRequest() : handleRun())}
+              >
+                Run
+              </Button>
+              {!canRun && (
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {selected.className
+                    ? "Add a problem instance above to render this visualization."
+                    : "This visualization cannot be run: the catalog did not say which backend visualization it is."}
+                </Typography>
+              )}
+            </Box>
+
             <StepScrubber
               idPrefix="visualizations-scrubber"
               frameCount={frameCount}
@@ -192,21 +317,60 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
               onStepChange={setCurrentStep}
             />
 
-            <Box
-              sx={{
-                flex: 1,
-                minHeight: 220,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                borderRadius: 2,
-                border: "1px solid",
-                borderColor: "divider",
-                color: "text.secondary",
-              }}
-            >
-              <Typography variant="body2">{selected.name}</Typography>
-            </Box>
+            <ComputeStatus
+              idPrefix={RUN_ID_PREFIX}
+              status={visualize.status}
+              announcement={announcement}
+              failure={visualize.failure}
+              onCancel={visualize.cancel}
+              busyLabel={`Rendering ${visualizationName}`}
+            />
+
+            {liveFrames ? (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                <Box
+                  sx={{
+                    minHeight: 260,
+                    borderRadius: 2,
+                    border: "1px solid",
+                    borderColor: "divider",
+                  }}
+                >
+                  <VisualizationCanvas
+                    idPrefix="visualizations-canvas"
+                    instanceName={selected.name}
+                    backendType={selected.backendType}
+                    frame={currentFrame}
+                  />
+                </Box>
+                {instanceChangedSinceRun && (
+                  <Typography variant="body2" sx={{ color: "warning.light" }}>
+                    The instance has been edited since this ran. Run again to visualize the instance
+                    currently in the box.
+                  </Typography>
+                )}
+              </Box>
+            ) : (
+              visualize.status !== COMPUTE_RUNNING &&
+              visualize.status !== COMPUTE_FAILED && (
+                <Box
+                  sx={{
+                    minHeight: 260,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderRadius: 2,
+                    border: "1px solid",
+                    borderColor: "divider",
+                    color: "text.secondary",
+                  }}
+                >
+                  <Typography variant="body2" sx={{ fontStyle: "italic" }}>
+                    Not yet run.
+                  </Typography>
+                </Box>
+              )
+            )}
 
             <Typography variant="body2" sx={{ color: "text.secondary" }}>
               {selected.caption}
@@ -217,10 +381,6 @@ export default function VisualizationsSection({ problem, dragHandleProps }) {
                 {selected.stepNarration}
               </Typography>
             )}
-
-            <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
-              Drag nodes to reposition &middot; Right-click to add
-            </Typography>
           </Box>
         </Box>
       )}

--- a/components/detail/visualizations/GraphRenderer.js
+++ b/components/detail/visualizations/GraphRenderer.js
@@ -1,0 +1,261 @@
+// components/detail/visualizations/GraphRenderer.js
+//
+// T48 (#111) -- the `graph` universal type's renderer
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.1), covering 24 of 48 declared
+// visualization instances, the largest single group. Ported from Redux_GUI's
+// StandardGraphSvgReact, with the bugs T40 found fixed rather than carried over:
+//
+//   - `weight` is always rendered as plain label text next to the link, never parsed as
+//     a number. DFA/NFA send transition symbols here ("a,b"), not numeric weights, and
+//     the old renderer fed it straight into `d3.scaleLinear()` -- exactly the defect
+//     §3.1's "malformed vs. valid" note calls out as a bug to fix in the port, not a
+//     contract violation to reject.
+//   - No `d3.selectAll`/`d3.select` against `document` or a hardcoded id (§4.1). This
+//     renderer only uses d3-force's simulation, a pure data computation with no DOM
+//     access at all -- layout math in, `{x, y}` positions out. Everything on screen is
+//     plain React-owned SVG, so nothing here can collide between two mounted instances
+//     of this component (the Reductions section's side-by-side panes, once T53 wires
+//     them to real data).
+//
+// The layout is a one-shot force simulation, ticked synchronously to convergence and
+// thrown away -- this is a *static* render (T48's own scope: "static (non-interactive)
+// rendering only"). No drag, no persistent simulation timer, no re-layout on a render
+// that didn't get a new frame.
+
+import { forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation } from "d3-force";
+import { useId, useMemo, useState } from "react";
+import { getVisualizationColor } from "../../theme";
+
+const NODE_RADIUS = 15;
+const LAYOUT_WIDTH = 640;
+const LAYOUT_HEIGHT = 380;
+const LAYOUT_PADDING = NODE_RADIUS * 2;
+const SIMULATION_TICKS = 300;
+const DEFAULT_STROKE = getVisualizationColor("");
+
+function isTruthyFlag(value) {
+  return value === "true" || value === true;
+}
+
+// d3-force mutates whatever objects it is given (adding x/y/vx/vy, and rewriting each
+// link's source/target from an id string to a node object reference) -- clone first so
+// the frame this component was handed (owned by the caller, and shared with the
+// contract-violation canary) is never mutated out from under it.
+function layoutGraph(nodes, links) {
+  const simNodes = nodes.map((node) => ({ ...node }));
+  const simLinks = links.map((link) => ({ ...link }));
+
+  const simulation = forceSimulation(simNodes)
+    .force(
+      "link",
+      forceLink(simLinks)
+        .id((node) => node.id)
+        .distance(90),
+    )
+    .force("charge", forceManyBody().strength(-220))
+    .force("center", forceCenter(LAYOUT_WIDTH / 2, LAYOUT_HEIGHT / 2))
+    .force("collide", forceCollide(NODE_RADIUS * 1.8))
+    .stop();
+
+  for (let i = 0; i < SIMULATION_TICKS; i += 1) {
+    simulation.tick();
+  }
+
+  return { simNodes, simLinks };
+}
+
+function computeViewBox(simNodes) {
+  if (simNodes.length === 0) {
+    return `0 0 ${LAYOUT_WIDTH} ${LAYOUT_HEIGHT}`;
+  }
+  const xs = simNodes.map((node) => node.x);
+  const ys = simNodes.map((node) => node.y);
+  const minX = Math.min(...xs) - LAYOUT_PADDING;
+  const maxX = Math.max(...xs) + LAYOUT_PADDING;
+  const minY = Math.min(...ys) - LAYOUT_PADDING;
+  const maxY = Math.max(...ys) + LAYOUT_PADDING;
+  return `${minX} ${minY} ${Math.max(maxX - minX, 1)} ${Math.max(maxY - minY, 1)}`;
+}
+
+function LinkMark({ link, idPrefix, highlighted }) {
+  const source = link.source;
+  const target = link.target;
+  if (!source || !target || source.x === undefined || target.x === undefined) {
+    return null;
+  }
+
+  const stroke = getVisualizationColor(link.color) || DEFAULT_STROKE;
+  const strokeWidth = highlighted ? 3 : 1.5;
+  const strokeDasharray = isTruthyFlag(link.dashed) ? "4 3" : undefined;
+  const markerEnd = link.directed ? `url(#${idPrefix}-arrow)` : undefined;
+  const isSelfLoop = source.id === target.id;
+
+  if (isSelfLoop) {
+    const loopPath = `M ${source.x - NODE_RADIUS * 0.6} ${source.y - NODE_RADIUS} C ${source.x - NODE_RADIUS * 3} ${source.y - NODE_RADIUS * 3}, ${source.x + NODE_RADIUS * 3} ${source.y - NODE_RADIUS * 3}, ${source.x + NODE_RADIUS * 0.6} ${source.y - NODE_RADIUS}`;
+    return (
+      <g>
+        <path
+          d={loopPath}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          strokeDasharray={strokeDasharray}
+          markerEnd={markerEnd}
+        />
+        {link.weight && (
+          <text
+            x={source.x}
+            y={source.y - NODE_RADIUS * 3.6}
+            textAnchor="middle"
+            fontSize={10}
+            fill={DEFAULT_STROKE}
+          >
+            {link.weight}
+          </text>
+        )}
+      </g>
+    );
+  }
+
+  const midX = (source.x + target.x) / 2;
+  const midY = (source.y + target.y) / 2;
+
+  return (
+    <g>
+      <line
+        x1={source.x}
+        y1={source.y}
+        x2={target.x}
+        y2={target.y}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeDasharray={strokeDasharray}
+        markerEnd={markerEnd}
+      />
+      {link.weight && (
+        <text x={midX} y={midY - 4} textAnchor="middle" fontSize={10} fill={DEFAULT_STROKE}>
+          {link.weight}
+        </text>
+      )}
+    </g>
+  );
+}
+
+function GraphNodeMark({ node, highlighted, onEnter, onLeave }) {
+  const fill = getVisualizationColor(node.color) || "#17140F";
+  const stroke = getVisualizationColor(node.outline) || "#F5F1EA";
+  const isAccept = isTruthyFlag(node.accept_state);
+  const isInitial = isTruthyFlag(node.initial);
+  const strokeDasharray = isTruthyFlag(node.dashed) ? "3 2" : undefined;
+
+  return (
+    <g
+      tabIndex={0}
+      role="img"
+      aria-label={node.name}
+      transform={`translate(${node.x}, ${node.y})`}
+      style={{ cursor: "default" }}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onFocus={onEnter}
+      onBlur={onLeave}
+    >
+      {isInitial && (
+        <path
+          d={`M ${-NODE_RADIUS - 14} 0 L ${-NODE_RADIUS - 2} -5 L ${-NODE_RADIUS - 2} 5 Z`}
+          fill={stroke}
+        />
+      )}
+      {isAccept && <circle r={NODE_RADIUS + 3} fill="none" stroke={stroke} strokeWidth={1.5} />}
+      <circle
+        r={NODE_RADIUS}
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={highlighted ? 3 : 1.5}
+        strokeDasharray={strokeDasharray}
+      />
+      <text
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={10}
+        fill="#F5F1EA"
+        style={{ pointerEvents: "none" }}
+      >
+        {node.name}
+      </text>
+    </g>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders, so two
+ *   mounted instances (Reductions' side-by-side panes) never collide (§4.1).
+ * @param {string} [props.instanceName] Human-readable visualization name, folded into
+ *   the accessible summary when given.
+ * @param {{nodes: Array, links: Array}} props.frame One already-validated `graph` frame.
+ */
+export default function GraphRenderer({ idPrefix, instanceName, frame }) {
+  const reactId = useId().replace(/:/g, "");
+  const scopeId = `${idPrefix}-${reactId}`;
+  const [hoveredNodeId, setHoveredNodeId] = useState(null);
+
+  const { simNodes, simLinks } = useMemo(() => layoutGraph(frame.nodes, frame.links), [frame]);
+  const viewBox = useMemo(() => computeViewBox(simNodes), [simNodes]);
+
+  const nodeCount = simNodes.length;
+  const linkCount = simLinks.length;
+  const summaryBody = `graph with ${nodeCount} node${nodeCount === 1 ? "" : "s"} and ${linkCount} link${linkCount === 1 ? "" : "s"}`;
+  const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
+
+  return (
+    <svg
+      id={scopeId}
+      role="img"
+      aria-label={summary}
+      viewBox={viewBox}
+      width="100%"
+      height="100%"
+      style={{ display: "block" }}
+    >
+      <title>{summary}</title>
+      <defs>
+        <marker
+          id={`${scopeId}-arrow`}
+          viewBox="0 0 10 10"
+          refX={NODE_RADIUS + 8}
+          refY={5}
+          markerWidth={6}
+          markerHeight={6}
+          orient="auto-start-reverse"
+        >
+          <path d="M 0 0 L 10 5 L 0 10 z" fill={DEFAULT_STROKE} />
+        </marker>
+      </defs>
+      <g>
+        {simLinks.map((link) => (
+          <LinkMark
+            key={link.id}
+            link={link}
+            idPrefix={scopeId}
+            highlighted={
+              hoveredNodeId != null &&
+              (link.source?.id === hoveredNodeId || link.target?.id === hoveredNodeId)
+            }
+          />
+        ))}
+      </g>
+      <g>
+        {simNodes.map((node) => (
+          <GraphNodeMark
+            key={node.id}
+            node={node}
+            highlighted={node.id === hoveredNodeId}
+            onEnter={() => setHoveredNodeId(node.id)}
+            onLeave={() => setHoveredNodeId((current) => (current === node.id ? null : current))}
+          />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/components/detail/visualizations/VisualizationCanvas.js
+++ b/components/detail/visualizations/VisualizationCanvas.js
@@ -1,0 +1,109 @@
+// components/detail/visualizations/VisualizationCanvas.js
+//
+// T48 (#111) -- resolves one frame's universal type
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §5) and either hands it to that
+// type's renderer, or renders one of the two outcomes §4.4 requires kept distinguishable:
+// no data / not yet supported (quiet, case b), versus a contract violation (a loud
+// `console.warn` plus a dev-only visible marker, case c).
+//
+// Only `graph` has a renderer today -- T49/T50 add the rest, one task per universal
+// type, the same "once per type, not once per instance" split the whole Track B design
+// is built around. Every other resolved type, and every payload this frontend doesn't
+// recognize at all, takes the quiet "not supported yet" path: that is honestly case (b),
+// not something to warn about.
+
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { useEffect } from "react";
+import { resolveVisualizationType, validateFrame } from "../../../data/visualizationTypes";
+import GraphRenderer from "./GraphRenderer";
+
+const RENDERERS = {
+  graph: GraphRenderer,
+};
+
+function CannotRender({ idPrefix, reason, violations }) {
+  return (
+    <Box
+      id={`${idPrefix}-cannot-render`}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 0.75,
+        alignItems: "center",
+        justifyContent: "center",
+        textAlign: "center",
+        height: "100%",
+        p: 2,
+      }}
+    >
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        {reason}
+      </Typography>
+      {process.env.NODE_ENV !== "production" && violations && violations.length > 0 && (
+        <Typography
+          variant="mono"
+          component="p"
+          sx={{ color: "error.light", fontSize: "0.75rem", m: 0 }}
+        >
+          Contract violation (dev only): {violations.join("; ")}
+        </Typography>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component (and whichever
+ *   renderer it dispatches to) renders (ground rule 4).
+ * @param {string} props.instanceName Human-readable visualization name, used in the
+ *   accessible summary and in the console.warn a contract violation emits.
+ * @param {string} [props.backendType] The raw `visualizationType` wire value (e.g.
+ *   "GraphD3") -- `Navigation/Batch/allVisualizationTypes`, falling back to `allInfo`.
+ * @param {Object|null} [props.frame] One frame (`frames[currentStep]`), or null/undefined
+ *   when there's nothing to show yet (not yet run, or an empty `frames[]`).
+ */
+export default function VisualizationCanvas({ idPrefix, instanceName, backendType, frame }) {
+  const universalType = resolveVisualizationType(backendType, frame);
+  const Renderer = universalType ? RENDERERS[universalType] : null;
+  const { valid, violations } =
+    Renderer && frame ? validateFrame(universalType, frame) : { valid: true, violations: [] };
+  const violationsSummary = violations.length > 0 ? violations.join("; ") : "";
+
+  useEffect(() => {
+    if (!Renderer || valid || !violationsSummary) return;
+    console.warn(
+      `[visualization] "${instanceName}" (${backendType ?? "unknown type"} -> ${universalType}) violates its contract: ${violationsSummary}`,
+    );
+  }, [Renderer, valid, violationsSummary, instanceName, backendType, universalType]);
+
+  if (!frame) {
+    return <CannotRender idPrefix={idPrefix} reason="No visualization data for this step." />;
+  }
+
+  if (!Renderer) {
+    return (
+      <CannotRender
+        idPrefix={idPrefix}
+        reason={
+          universalType
+            ? `No renderer built yet for "${universalType}" visualizations.`
+            : "This visualization type isn't supported yet."
+        }
+      />
+    );
+  }
+
+  if (!valid) {
+    return (
+      <CannotRender
+        idPrefix={idPrefix}
+        reason="Cannot render: this frame's data doesn't match what this visualization type expects."
+        violations={violations}
+      />
+    );
+  }
+
+  return <Renderer idPrefix={idPrefix} instanceName={instanceName} frame={frame} />;
+}

--- a/components/theme.js
+++ b/components/theme.js
@@ -149,6 +149,35 @@ export const thinScrollbarSx = {
   },
 };
 
+// --- T48 (#111): the shared visualization color-key vocabulary (§4.3) ------------------
+// `graph`, `quantumCircuit`, `booleanSatisfiability`, `recursiveSet` and `stepTable` all
+// send color fields as color-KEY NAMES ("Solution", "Background", "ElementHighlight",
+// ...), never hex, resolved through one lookup table -- Redux_GUI kept two
+// (`constants/VisColors.js`/`VisColorsArray.js`) for the same concept, which T40 flagged
+// as exactly the kind of drift this project doesn't want a second copy of. `pumpSchedule`
+// is exempt (§3.6): it hardcodes its own palette and sends no color-key field at all.
+//
+// Reconciled with this theme's own tokens rather than a separate palette: reusing
+// FACET_ACCENT_COLORS' hues keeps a visualization's "Solution"/"ElementHighlight" marks
+// visually related to this app's own accent vocabulary instead of introducing unrelated
+// colors. An unrecognized key (not in the table, and not "") is not malformed per the
+// contract -- it degrades to the same neutral BACKGROUND entry an empty string already
+// does, which is what the fallback below does.
+export const VISUALIZATION_COLOR_KEYS = {
+  Background: "#94A3B8",
+  Solution: FACET_ACCENT_COLORS.green,
+  ElementHighlight: FACET_ACCENT_COLORS.blue,
+  ClauseHighlight: FACET_ACCENT_COLORS.magenta,
+};
+
+const VISUALIZATION_COLOR_DEFAULT = VISUALIZATION_COLOR_KEYS.Background;
+
+/** Resolve a visualization payload's color-key string to a real color. */
+export function getVisualizationColor(colorKey) {
+  if (!colorKey) return VISUALIZATION_COLOR_DEFAULT;
+  return VISUALIZATION_COLOR_KEYS[colorKey] ?? VISUALIZATION_COLOR_DEFAULT;
+}
+
 const theme = createTheme({
   palette: {
     mode: "dark",

--- a/data/visualizationTypes.js
+++ b/data/visualizationTypes.js
@@ -1,0 +1,152 @@
+// data/visualizationTypes.js
+//
+// T48 (#111). Concrete home named by ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md
+// §5 (the resolver) and §4.4 (the runtime contract-violation canary), so an
+// implementation task didn't have to invent the location or guess whether one already
+// existed.
+//
+// This is a frontend-side reconstruction of a contract the backend does not yet
+// enforce (§0/§5 of that document) -- provisional, not a permanent authority. Once
+// ReduxISU/Redux#524 (a `kind` discriminator on the wire payload) and #525 (a typed
+// `IVisualization<U, TPayload>` interface) both ship, most of this file becomes dead
+// code to delete -- tracked on Redux_Frontend#107, not re-derived here.
+
+/**
+ * Backend `visualizationType` string (`Navigation/Batch/allVisualizationTypes`, or
+ * `allInfo`'s per-instance fallback) -> one of the 6 universal type keys, or `null` for
+ * a type this contract's v1 has no renderer for at all.
+ *
+ * Directly transcribed from VISUALIZATION_TYPE_CONTRACTS.md §1's table. `GraphD3` and
+ * `GraphLaTeX` share one renderer (§1.1: the LaTeX/TikZ path never ships here);
+ * `QuantumCircuitD3` and `QuantumCircuitQjs` share one renderer that only reads the
+ * `d3` arm of the payload (§3.2) -- a `QuantumCircuitQjs` instance with no `D3` sibling
+ * genuinely has nothing to render under this map, which is `resolveVisualizationType`'s
+ * job to surface as "no data", not a violation.
+ */
+export const VISUALIZATION_TYPE_MAP = {
+  GraphD3: "graph",
+  GraphLaTeX: "graph",
+  QuantumCircuitD3: "quantumCircuit",
+  QuantumCircuitQjs: "quantumCircuit",
+  BooleanSatisfiability: "booleanSatisfiability",
+  SetD3: "recursiveSet",
+  DynamicTable: "stepTable",
+  PumpSchedule: "pumpSchedule",
+  Unimplemented: null,
+};
+
+/**
+ * Resolves a frame to one of the 6 universal type keys (VISUALIZATION_TYPE_CONTRACTS.md
+ * §1), or `null` when nothing in this contract can render it.
+ *
+ * Prefers a payload-level `kind` field when present (the state once ReduxISU/Redux#524
+ * ships) and falls back to the static `backendType` -> universal type map otherwise.
+ * `quantumCircuit` at `format: 0` (QASM-only, no `d3` arm) is a real, in-vocabulary
+ * backend type that this contract's v1 still can't render (§3.2's decision) -- resolved
+ * to `null` here rather than `"quantumCircuit"`, so a caller doesn't have to separately
+ * remember that one universal type can still mean "no renderer for this particular
+ * frame."
+ *
+ * @param {string} [backendType] The raw `visualizationType` wire value, e.g. "GraphD3".
+ * @param {Object} [payload] One frame, if one is available yet.
+ * @returns {string|null}
+ */
+export function resolveVisualizationType(backendType, payload) {
+  if (payload && typeof payload.kind === "string" && payload.kind) {
+    return payload.kind;
+  }
+  const universalType = VISUALIZATION_TYPE_MAP[backendType] ?? null;
+  if (universalType === "quantumCircuit" && !(payload?.format === 1 && payload?.d3)) {
+    return null;
+  }
+  return universalType;
+}
+
+const GRAPH_REQUIRED_NODE_STRING_FIELDS = [
+  "id",
+  "name",
+  "color",
+  "outline",
+  "delay",
+  "dashed",
+  "additional",
+];
+const GRAPH_REQUIRED_LINK_STRING_FIELDS = [
+  "id",
+  "source",
+  "target",
+  "color",
+  "dashed",
+  "delay",
+  "weight",
+  "attribute1",
+  "attribute2",
+];
+const GRAPH_REQUIRED_LINK_BOOLEAN_FIELDS = ["weighted", "directed"];
+
+/**
+ * §3.1's contract, checked field by field. A `link.weight` that isn't numeric (DFA's
+ * transition symbols) is explicitly NOT a violation here -- the contract requires a
+ * string, not a number, precisely because T40 found the old renderer's opposite
+ * assumption was the bug.
+ */
+function validateGraphFrame(frame) {
+  const violations = [];
+  if (!Array.isArray(frame?.nodes)) {
+    violations.push("nodes: expected an array");
+  }
+  if (!Array.isArray(frame?.links)) {
+    violations.push("links: expected an array");
+  }
+  if (violations.length > 0) {
+    return { valid: false, violations };
+  }
+
+  frame.nodes.forEach((node, index) => {
+    for (const field of GRAPH_REQUIRED_NODE_STRING_FIELDS) {
+      if (typeof node?.[field] !== "string") {
+        violations.push(`nodes[${index}].${field}: expected a string`);
+      }
+    }
+  });
+
+  frame.links.forEach((link, index) => {
+    for (const field of GRAPH_REQUIRED_LINK_STRING_FIELDS) {
+      if (typeof link?.[field] !== "string") {
+        violations.push(`links[${index}].${field}: expected a string`);
+      }
+    }
+    for (const field of GRAPH_REQUIRED_LINK_BOOLEAN_FIELDS) {
+      if (typeof link?.[field] !== "boolean") {
+        violations.push(`links[${index}].${field}: expected a boolean`);
+      }
+    }
+  });
+
+  return { valid: violations.length === 0, violations };
+}
+
+const VALIDATORS = {
+  graph: validateGraphFrame,
+};
+
+/**
+ * §4.4's contract-violation canary: a field-presence/type/vocabulary check against §3's
+ * contracts, not a general JSON-schema validator. Only checks the failure classes §3
+ * already enumerates per type.
+ *
+ * A universal type with no validator yet (every type besides `graph`, until T49/T50
+ * add their own) always reports valid -- there is no renderer consuming it yet either,
+ * so there is nothing for a false-negative here to protect.
+ *
+ * @param {string|null} universalType
+ * @param {Object} frame
+ * @returns {{valid: boolean, violations: string[]}}
+ */
+export function validateFrame(universalType, frame) {
+  const validator = VALIDATORS[universalType];
+  if (!validator) {
+    return { valid: true, violations: [] };
+  }
+  return validator(frame);
+}

--- a/hooks/useProblemDetail.js
+++ b/hooks/useProblemDetail.js
@@ -62,6 +62,7 @@ import {
   requestAllSolvers,
   requestAllVerifiers,
   requestAllVisualizations,
+  requestAllVisualizationTypes,
   requestReductionGraph,
 } from "../lib/redux";
 
@@ -89,12 +90,24 @@ function buildSolvers(solverClassNames, info) {
   });
 }
 
-function buildVisualizations(visualizationClassNames, info) {
+// `className` and `backendType` are carried alongside the display name because T48
+// (#111) needs both: live rendering calls `ProblemProvider/visualize?visualization=
+// <className>` (keyed the same way solve/verify are, by class name rather than the
+// human-readable `visualizationName`), and resolving which universal render type a
+// frame is (data/visualizationTypes.js) needs the raw backend `visualizationType` wire
+// value. `visualizationTypesByInstance` is `Navigation/Batch/allVisualizationTypes`'s
+// answer when that endpoint exists; T40 found some deployments don't have it yet, so
+// this falls back to the same field read off `allInfo`, matching what Redux_GUI's own
+// hook already does for the same gap.
+function buildVisualizations(visualizationClassNames, info, visualizationTypesByInstance) {
   return (visualizationClassNames ?? []).map((className) => {
     const visualizationInfo = info[className] ?? {};
     return {
+      className,
       name: visualizationInfo.visualizationName ?? className,
       type: mergeVisualStyle(className, undefined),
+      backendType:
+        visualizationTypesByInstance[className] ?? visualizationInfo.visualizationType ?? "",
       caption: visualizationInfo.visualizationDefinition ?? "",
     };
   });
@@ -148,7 +161,13 @@ function buildReductions(problemCode, reductionGraph, codeToName) {
 
 function buildProblem(problemCode, info, batches, codeToName) {
   const problemInfo = info[problemCode] ?? {};
-  const { solversByProblem, verifiersByProblem, visualizationsByProblem, reductionGraph } = batches;
+  const {
+    solversByProblem,
+    verifiersByProblem,
+    visualizationsByProblem,
+    reductionGraph,
+    visualizationTypesByInstance,
+  } = batches;
 
   const contributors = Array.isArray(problemInfo.contributors) ? problemInfo.contributors : [];
 
@@ -186,7 +205,11 @@ function buildProblem(problemCode, info, batches, codeToName) {
     defaultInstance: problemInfo.defaultInstance || "",
     instanceFormat: problemInfo.instanceFormat || "",
     solvers: buildSolvers(solversByProblem[problemCode], info),
-    visualizations: buildVisualizations(visualizationsByProblem[problemCode], info),
+    visualizations: buildVisualizations(
+      visualizationsByProblem[problemCode],
+      info,
+      visualizationTypesByInstance,
+    ),
     verifier: buildVerifier(verifiersByProblem[problemCode], info, problemInfo),
     reductions: buildReductions(problemCode, reductionGraph, codeToName),
   };
@@ -235,6 +258,7 @@ export function useProblemDetail(url, problemName) {
           verifiersByProblem,
           visualizationsByProblem,
           reductionGraph,
+          visualizationTypesByInstance,
         ] = await Promise.all([
           requestAllProblems(url),
           requestAllInfo(url),
@@ -242,6 +266,11 @@ export function useProblemDetail(url, problemName) {
           requestAllVerifiers(url),
           requestAllVisualizations(url),
           requestReductionGraph(url),
+          // Falls back to allInfo per-instance (buildVisualizations) rather than
+          // failing the whole page load -- T40 found some deployments don't have this
+          // endpoint yet, which is exactly the case requestAllVisualizationTypes's own
+          // doc comment says a caller needs to handle.
+          requestAllVisualizationTypes(url).catch(() => null),
         ]);
 
         if (cancelled) return;
@@ -270,6 +299,7 @@ export function useProblemDetail(url, problemName) {
               verifiersByProblem: verifiersByProblem ?? {},
               visualizationsByProblem: visualizationsByProblem ?? {},
               reductionGraph: reductionGraph ?? {},
+              visualizationTypesByInstance: visualizationTypesByInstance ?? {},
             },
             codeToName,
           ),

--- a/lib/redux/index.js
+++ b/lib/redux/index.js
@@ -329,3 +329,34 @@ export async function requestVerifiedInstance(url, verifier, instance, certifica
     signal,
   );
 }
+
+/**
+ * Renders one visualization instance's frame array for a problem instance.
+ *
+ * T44 (#103) put this on the proxy allowlist ahead of any caller existing here, so
+ * Track B's design tasks could see real payloads through this app's own proxy. T48
+ * (#111) is the first caller.
+ *
+ * T40 verified this directly against the live API: the response is a bare JSON array
+ * of frames -- base state, then zero or more intermediate steps, then the solved state
+ * (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §2) -- never wrapped in an envelope
+ * object, the same shape `requestSolvedInstance` returns a bare string rather than
+ * `{ output: ... }`.
+ *
+ * @param {string} url Base URL of the Redux API.
+ * @param {string} visualization Visualization instance class name, e.g.
+ * "CliqueDefaultVisualization" -- the value `Navigation/Batch/allVisualizations` lists,
+ * not the human-readable `visualizationName`.
+ * @param {string} instance The problem instance to visualize.
+ * @param {AbortSignal} [signal] Optional, same caveat as `requestSolvedInstance`.
+ * @returns the ordered frame array.
+ * @throws {ReduxRequestError} if the request fails.
+ */
+export async function requestVisualizedInstance(url, visualization, instance, signal) {
+  return await fetchPostJson(
+    `${url}ProblemProvider/visualize?visualization=${encodeURIComponent(visualization)}`,
+    instance,
+    () => `${visualization} VISUALIZE REQUEST FAILED`,
+    signal,
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@mui/material": "^9.0.1",
         "@popperjs/core": "^2.11.8",
         "@swc/helpers": "^0.5.23",
+        "d3-force": "^3.0.0",
         "next": "^16.3.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.8"
@@ -3306,6 +3307,47 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mui/material": "^9.0.1",
     "@popperjs/core": "^2.11.8",
     "@swc/helpers": "^0.5.23",
+    "d3-force": "^3.0.0",
     "next": "^16.3.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.8"


### PR DESCRIPTION
Issue: #111 (T48: Static-but-real Visualizations rendering: graph type)
Branch: task/T48-graph-visualizations

Changed:
data/visualizationTypes.js                            (new)
components/detail/visualizations/GraphRenderer.js      (new)
components/detail/visualizations/VisualizationCanvas.js (new)
components/theme.js                     (added VISUALIZATION_COLOR_KEYS / getVisualizationColor)
lib/redux/index.js                      (added requestVisualizedInstance)
hooks/useProblemDetail.js               (visualizations now carry className/backendType; fetches allVisualizationTypes)
components/ProblemDetailLayout.js       (shared runToken/triggerRun; Visualizations joins usesInstance/usesRun)
components/detail/SolversSection.js     (Run button now goes through the shared runToken instead of fetching directly)
components/detail/VisualizationsSection.js  (real canvas, own Run button, staleness banner, live frame count)
package.json / package-lock.json        (added d3-force)

Done when, met:
- graph-type instances render the real payload from /visualize via the proxy — new GraphRenderer (d3-force for layout only, plain React SVG for rendering, no DOM selectors at all).
- Malformed/missing data shows the existing "cannot render" state; a contract violation additionally console.warns naming the instance, its type, and the failed field(s), plus a dev-only visible marker (data/visualizationTypes.js's validateFrame, wired through VisualizationCanvas).
- Renderer scoping uses refs/useId(), never global selectors — two mounted instances can't collide.
- Accessibility baseline met: <title>/aria-label summarizing the frame ("graph with N nodes and M links"), hover-highlight also reachable via keyboard focus on the same node element.
- Colors resolve through VISUALIZATION_COLOR_KEYS/getVisualizationColor in components/theme.js.
- T47's StepScrubber is wired in, now driven by the real frame count.
- The section reads the shared instance (instanceValue) rather than a local copy.
- This section has its own Run affordance, invoking the shared Run action (onRunRequest/runToken, lifted to ProblemDetailLayout.js) rather than fetching directly.
- Frames refresh only on Run, with a staleness banner (instanceChangedSinceRun) when the shown frames' instance no longer matches the current shared instance.

Decisions and assumptions:
- The "shared Run action" is implemented as a token bump (runToken/triggerRun in ProblemDetailLayout.js), not a single omniscient fetch — each section still owns its own request (solve vs. visualize), reacting independently to the same trigger. This is what let SolversSection keep its own request logic while gaining "any Run button refreshes every panel" behavior, matching INTERACTIVE_LAYER_DESIGN.md §2.1.1's "independent outcomes, shown in their own panels" requirement. SolversSection.js was refactored accordingly (its Run button now bumps the shared token instead of calling solve directly) since the design doc frames Run as shared infrastructure, not something T48 should build a second, disconnected copy of.
- Removed the old "Drag nodes to reposition · Right-click to add" hint text from VisualizationsSection.js: it was harmless over a static placeholder box, but would be actively misleading under a real, non-interactive rendered diagram (editing is T51, still not built).
- quantumCircuit, booleanSatisfiability, recursiveSet, stepTable, pumpSchedule all resolve to their universal type via resolveVisualizationType but have no renderer yet — VisualizationCanvas shows the honest "no renderer built yet" message (contract case b, no warning), for T49/T50 to fill in.
- validateFrame in data/visualizationTypes.js only implements the graph contract for now; other types return {valid: true} since there's no renderer yet to protect.
- Added d3-force (not the full d3 umbrella package) as a new dependency — only the force-simulation module is used, purely for layout math, no DOM access.

Closes #111