### PR TITLE
Adding Boolean Satisfactory Visualization

### DIFF
--- a/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
+++ b/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
@@ -1,0 +1,157 @@
+// components/detail/visualizations/BooleanSatisfiabilityRenderer.js
+//
+// T49 (#112) -- the `booleanSatisfiability` universal type's renderer
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.3), covering SAT and SAT3 (2 of
+// 48 declared instances). Ported from Redux_GUI's StandardSATSvgReact: each clause in
+// parentheses, literals joined with U+2227, clauses joined with U+2228 -- T40's
+// documented reading of what the original renderer actually draws, kept as-is rather
+// than "corrected" against standard CNF notation, since this is a port of an observed
+// renderer, not a re-derivation from first principles.
+//
+// No `d3.selectAll`/`d3.select` against `document` or a hardcoded id (§4.1): this is
+// plain React-owned markup, nothing to scope beyond the one root id `useId()` already
+// makes collision-proof between two mounted instances (Reductions' side-by-side panes,
+// once T53 wires them to real data).
+//
+// Literal text (`"x1"`, `"!x2"`) is rendered exactly as the backend sends it -- no
+// substituting `!` for a proper negation glyph -- the same "display exactly what the
+// backend returned" call §3.5 already made for stepTable's cell text, extended here on
+// the same reasoning: this is the backend's own data, not this project's UI copy.
+//
+// This is deliberately structured to grow editing affordances in T52 (`clauses`/
+// `literals` map straight onto per-clause/per-literal React elements already) --
+// T49 itself is static rendering only, per the issue's own scope note.
+
+import Box from "@mui/material/Box";
+import { useId, useState } from "react";
+import { getVisualizationColor } from "../../theme";
+
+const CONJUNCTION = "∧"; // AND, between literals within a clause (T40's finding, see header)
+const DISJUNCTION = "∨"; // OR, between clauses
+
+function literalVariable(literalText) {
+  return typeof literalText === "string" ? literalText.replace(/^!/, "") : literalText;
+}
+
+function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
+  const color = getVisualizationColor(literal.color);
+  return (
+    <Box
+      id={id}
+      component="span"
+      tabIndex={0}
+      aria-label={literal.literal}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onFocus={onEnter}
+      onBlur={onLeave}
+      sx={{
+        fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
+        fontSize: "0.9375rem",
+        color,
+        fontWeight: highlighted ? 700 : 500,
+        textDecoration: highlighted ? "underline" : "none",
+        borderRadius: 0.5,
+        cursor: "default",
+      }}
+    >
+      {literal.literal}
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders, so two
+ *   mounted instances (Reductions' side-by-side panes) never collide (§4.1).
+ * @param {string} [props.instanceName] Human-readable visualization name, folded into
+ *   the accessible summary when given.
+ * @param {{clauses: Array}} props.frame One already-validated `booleanSatisfiability`
+ *   frame.
+ */
+export default function BooleanSatisfiabilityRenderer({ idPrefix, instanceName, frame }) {
+  const reactId = useId().replace(/:/g, "");
+  const scopeId = `${idPrefix}-${reactId}`;
+  // Hovering or focusing one literal highlights every literal for the same variable
+  // (ignoring negation) across the whole formula -- the hover-triggered highlight §4.2
+  // requires stay keyboard-reachable, via the identical onFocus/onBlur pair LiteralMark
+  // already wires to the same mouse handlers.
+  const [hoveredVariable, setHoveredVariable] = useState(null);
+
+  const clauses = frame.clauses;
+  const clauseCount = clauses.length;
+  const summaryBody = `boolean formula with ${clauseCount} clause${clauseCount === 1 ? "" : "s"}`;
+  const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
+
+  return (
+    <Box
+      id={scopeId}
+      role="img"
+      aria-label={summary}
+      sx={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: 1,
+        p: 2,
+        minHeight: "100%",
+        boxSizing: "border-box",
+      }}
+    >
+      {clauseCount === 0 ? (
+        <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+          No clauses.
+        </Box>
+      ) : (
+        clauses.map((clause, clauseIndex) => (
+          <Box
+            key={clause.id}
+            component="span"
+            sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+          >
+            {clauseIndex > 0 && (
+              <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mx: 0.5 }}>
+                {DISJUNCTION}
+              </Box>
+            )}
+            <Box component="span" sx={{ color: "text.secondary" }}>
+              (
+            </Box>
+            {clause.literals.map((literal, literalIndex) => {
+              const variable = literalVariable(literal.literal);
+              return (
+                <Box
+                  key={literal.id}
+                  component="span"
+                  sx={{ display: "inline-flex", alignItems: "center" }}
+                >
+                  {literalIndex > 0 && (
+                    <Box
+                      component="span"
+                      aria-hidden="true"
+                      sx={{ color: "text.secondary", mx: 0.5 }}
+                    >
+                      {CONJUNCTION}
+                    </Box>
+                  )}
+                  <LiteralMark
+                    id={`${scopeId}-literal-${literal.id}`}
+                    literal={literal}
+                    highlighted={hoveredVariable != null && variable === hoveredVariable}
+                    onEnter={() => setHoveredVariable(variable)}
+                    onLeave={() =>
+                      setHoveredVariable((current) => (current === variable ? null : current))
+                    }
+                  />
+                </Box>
+              );
+            })}
+            <Box component="span" sx={{ color: "text.secondary" }}>
+              )
+            </Box>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/components/detail/visualizations/VisualizationCanvas.js
+++ b/components/detail/visualizations/VisualizationCanvas.js
@@ -6,20 +6,22 @@
 // no data / not yet supported (quiet, case b), versus a contract violation (a loud
 // `console.warn` plus a dev-only visible marker, case c).
 //
-// Only `graph` has a renderer today -- T49/T50 add the rest, one task per universal
-// type, the same "once per type, not once per instance" split the whole Track B design
-// is built around. Every other resolved type, and every payload this frontend doesn't
-// recognize at all, takes the quiet "not supported yet" path: that is honestly case (b),
-// not something to warn about.
+// `graph` (T48) and `booleanSatisfiability` (T49) have renderers today -- T50 adds the
+// rest, one task per universal type, the same "once per type, not once per instance"
+// split the whole Track B design is built around. Every other resolved type, and every
+// payload this frontend doesn't recognize at all, takes the quiet "not supported yet"
+// path: that is honestly case (b), not something to warn about.
 
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useEffect } from "react";
 import { resolveVisualizationType, validateFrame } from "../../../data/visualizationTypes";
+import BooleanSatisfiabilityRenderer from "./BooleanSatisfiabilityRenderer";
 import GraphRenderer from "./GraphRenderer";
 
 const RENDERERS = {
   graph: GraphRenderer,
+  booleanSatisfiability: BooleanSatisfiabilityRenderer,
 };
 
 function CannotRender({ idPrefix, reason, violations }) {

--- a/data/visualizationTypes.js
+++ b/data/visualizationTypes.js
@@ -126,8 +126,49 @@ function validateGraphFrame(frame) {
   return { valid: violations.length === 0, violations };
 }
 
+/**
+ * §3.3's contract, checked field by field. An empty `clauses` array is a valid
+ * degenerate case (0 clauses), not malformed -- only a missing/non-array `clauses`, or
+ * a clause with no `literals` array, is.
+ */
+function validateBooleanSatisfiabilityFrame(frame) {
+  const violations = [];
+  if (!Array.isArray(frame?.clauses)) {
+    violations.push("clauses: expected an array");
+    return { valid: false, violations };
+  }
+
+  frame.clauses.forEach((clause, clauseIndex) => {
+    if (typeof clause?.id !== "string") {
+      violations.push(`clauses[${clauseIndex}].id: expected a string`);
+    }
+    if (!Array.isArray(clause?.literals)) {
+      violations.push(`clauses[${clauseIndex}].literals: expected an array`);
+      return;
+    }
+    clause.literals.forEach((literal, literalIndex) => {
+      if (typeof literal?.id !== "string") {
+        violations.push(`clauses[${clauseIndex}].literals[${literalIndex}].id: expected a string`);
+      }
+      if (typeof literal?.literal !== "string") {
+        violations.push(
+          `clauses[${clauseIndex}].literals[${literalIndex}].literal: expected a string`,
+        );
+      }
+      if (typeof literal?.color !== "string") {
+        violations.push(
+          `clauses[${clauseIndex}].literals[${literalIndex}].color: expected a string`,
+        );
+      }
+    });
+  });
+
+  return { valid: violations.length === 0, violations };
+}
+
 const VALIDATORS = {
   graph: validateGraphFrame,
+  booleanSatisfiability: validateBooleanSatisfiabilityFrame,
 };
 
 /**
@@ -135,9 +176,10 @@ const VALIDATORS = {
  * contracts, not a general JSON-schema validator. Only checks the failure classes §3
  * already enumerates per type.
  *
- * A universal type with no validator yet (every type besides `graph`, until T49/T50
- * add their own) always reports valid -- there is no renderer consuming it yet either,
- * so there is nothing for a false-negative here to protect.
+ * A universal type with no validator yet (every type besides `graph` and
+ * `booleanSatisfiability`, until T50 adds the rest) always reports valid -- there is no
+ * renderer consuming it yet either, so there is nothing for a false-negative here to
+ * protect.
  *
  * @param {string|null} universalType
  * @param {Object} frame


### PR DESCRIPTION
Issue: #112 (T49: Static-but-real Visualizations rendering: booleanSatisfiability type)
Branch: task/T49-boolean-satisfiability-visualization

Changed:
components/detail/visualizations/BooleanSatisfiabilityRenderer.js  (new)
components/detail/visualizations/VisualizationCanvas.js  (registered the new renderer)
data/visualizationTypes.js               (added validateBooleanSatisfiabilityFrame)

Done when, met:
- booleanSatisfiability instances (SAT, SAT3) render the real payload from /visualize — no changes needed to VisualizationsSection.js or the Run/instance wiring, since T48 already built that generically; this task only had to add the renderer and register it.
- Malformed/missing data and contract violations are distinguished per §4.4, via validateBooleanSatisfiabilityFrame (missing clauses array or a clause missing literals → violation; empty clauses → valid, 0-clause case).
- Renderer scoping uses useId() for a collision-proof root id (§4.1); accessibility baseline met via role="img"/aria-label summarizing the frame ("boolean formula with N clauses"), with a hover-highlight (same variable across the formula) reachable identically by keyboard focus (§4.2); colors resolve through the existing getVisualizationColor (§4.3).
- T47's scrubber and the shared instance/Run wiring are already in place from T48 and needed no changes.

Decisions and assumptions:
- Literal text ("x1", "!x2") is rendered exactly as the backend sends it, no substituting ! for a negation glyph — same reasoning §3.5 already established for stepTable cell text (it's the backend's data, not this project's UI copy).
- Clauses are joined with ∨ and literals within a clause with ∧, matching T40's literal documented reading of what the original Redux_GUI renderer draws — kept as-is rather than "corrected" against standard CNF notation, since this is a port of an observed renderer.
- Added a hover/focus-driven "highlight same variable across the formula" interaction, matching the effort level of T48's graph-renderer hover highlight; not required by the contract but consistent with it (same mouse/keyboard parity).

Closes #112