### PR TITLE
Establishing Some Universal Visualization Types

### DIFF
--- a/components/detail/visualizations/PumpScheduleRenderer.js
+++ b/components/detail/visualizations/PumpScheduleRenderer.js
@@ -1,0 +1,194 @@
+// components/detail/visualizations/PumpScheduleRenderer.js
+//
+// T50 (#113) -- the `pumpSchedule` universal type's renderer
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.6), covering the 2
+// PumpSchedulingCM/EM instances. Ported from Redux_GUI's
+// PumpSchedulingSvgReact (an hour's snapshot: pump on/off cards, a tank-fill
+// bar, metric tiles), rebuilt with MUI components matching this project's
+// own dark theme rather than the original's hardcoded light-mode hex values.
+//
+// §3.6's color-vocabulary exception: this is the one universal type exempt
+// from the shared VISUALIZATION_COLOR_KEYS table (§4.3) -- the payload
+// carries no color-key field at all, so the small palette below is local to
+// this file, not a second copy of anything in components/theme.js.
+//
+// §4.2 needs no separate alternative for this type: it already renders as
+// MUI cards and tiles with real text content, not a diagram standing in for
+// one.
+
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import LinearProgress from "@mui/material/LinearProgress";
+import Typography from "@mui/material/Typography";
+import { useId } from "react";
+
+const PUMP_ON_COLOR = "#2E7D32";
+const PUMP_OFF_COLOR = "#4B5563";
+const PEAK_COLOR = "#C0392B";
+const OFF_PEAK_COLOR = "#2E7D32";
+const TANK_LOW_COLOR = "#C0392B";
+const TANK_HIGH_COLOR = "#D96C1E";
+const TANK_NORMAL_COLOR = "#2F6FB3";
+
+function tankColor(fillRatio) {
+  if (fillRatio < 0.2) return TANK_LOW_COLOR;
+  if (fillRatio > 0.9) return TANK_HIGH_COLOR;
+  return TANK_NORMAL_COLOR;
+}
+
+function MetricTile({ id, label, value, accent }) {
+  return (
+    <Box
+      id={id}
+      sx={{
+        flex: "1 1 120px",
+        p: 1.25,
+        borderRadius: 1.5,
+        border: "1px solid",
+        borderColor: accent ? TANK_NORMAL_COLOR : "divider",
+      }}
+    >
+      <Typography variant="caption" sx={{ color: "text.secondary", display: "block" }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontWeight: 700 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders,
+ *   so two mounted instances (Reductions' side-by-side panes) never collide
+ *   (§4.1).
+ * @param {string} [props.instanceName] Unused here (see file header) -- kept
+ *   for signature parity with the other five renderers.
+ * @param {{action: string, metrics: Object, state: {pumps: Array}}} props.frame
+ *   One already-validated `pumpSchedule` frame.
+ */
+export default function PumpScheduleRenderer({ idPrefix, frame }) {
+  const reactId = useId().replace(/:/g, "");
+  const scopeId = `${idPrefix}-${reactId}`;
+
+  const { action, metrics, state } = frame;
+  const pumps = state.pumps;
+  const fillRatio = Math.min(1, Math.max(0, metrics.tankFillRatio));
+  const fillPct = Math.round(fillRatio * 100);
+
+  return (
+    <Box id={scopeId} sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 2 }}>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+        <Chip id={`${scopeId}-hour`} label={`Hour ${metrics.hour}`} sx={{ fontWeight: 700 }} />
+        <Chip
+          id={`${scopeId}-peak`}
+          label={metrics.isPeakHour ? "Peak" : "Off-Peak"}
+          sx={{
+            backgroundColor: metrics.isPeakHour ? PEAK_COLOR : OFF_PEAK_COLOR,
+            color: "#FFFFFF",
+            fontWeight: 700,
+          }}
+        />
+      </Box>
+
+      {action && (
+        <Typography
+          id={`${scopeId}-action`}
+          variant="body2"
+          sx={{
+            borderLeft: "4px solid",
+            borderLeftColor: TANK_NORMAL_COLOR,
+            pl: 1.5,
+            py: 0.5,
+            color: "text.secondary",
+          }}
+        >
+          {action}
+        </Typography>
+      )}
+
+      <Box>
+        <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 0.75 }}>
+          Pump States
+        </Typography>
+        <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+          {pumps.map((pump) => (
+            <Box
+              key={pump.name}
+              id={`${scopeId}-pump-${pump.name}`}
+              sx={{
+                minWidth: 110,
+                textAlign: "center",
+                borderRadius: 1.5,
+                p: 1,
+                backgroundColor: pump.isOn ? PUMP_ON_COLOR : PUMP_OFF_COLOR,
+                color: "#FFFFFF",
+              }}
+            >
+              <Typography variant="body2" sx={{ fontWeight: 700 }}>
+                {pump.name}
+              </Typography>
+              <Typography variant="caption" sx={{ display: "block" }}>
+                {pump.isOn ? "ON" : "OFF"}
+              </Typography>
+              {pump.isOn && (
+                <Typography variant="caption" sx={{ display: "block", opacity: 0.85 }}>
+                  {pump.flowGph.toLocaleString()} gph, {pump.powerKw.toFixed(1)} kW
+                </Typography>
+              )}
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      <Box>
+        <Typography id={`${scopeId}-tank-label`} variant="body2" sx={{ fontWeight: 700, mb: 0.5 }}>
+          Tank Level: {metrics.tankLevel.toLocaleString()} / {metrics.tankCapacity.toLocaleString()}{" "}
+          gal ({fillPct}%)
+        </Typography>
+        <LinearProgress
+          id={`${scopeId}-tank-bar`}
+          aria-labelledby={`${scopeId}-tank-label`}
+          variant="determinate"
+          value={fillPct}
+          sx={{
+            height: 10,
+            borderRadius: 5,
+            backgroundColor: "action.disabledBackground",
+            "& .MuiLinearProgress-bar": { backgroundColor: tankColor(fillRatio) },
+          }}
+        />
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+        <MetricTile
+          id={`${scopeId}-flow-in`}
+          label="Flow In"
+          value={`${metrics.flowIn.toLocaleString()} gph`}
+        />
+        <MetricTile
+          id={`${scopeId}-demand`}
+          label="Demand"
+          value={`${metrics.demand.toLocaleString()} gph`}
+        />
+        <MetricTile
+          id={`${scopeId}-net`}
+          label="Net"
+          value={`${(metrics.flowIn - metrics.demand).toFixed(1)} gph`}
+        />
+        <MetricTile
+          id={`${scopeId}-hour-cost`}
+          label="Hour Cost"
+          value={`$${metrics.stepCost.toFixed(4)}`}
+        />
+        <MetricTile
+          id={`${scopeId}-cumulative-cost`}
+          label="Cumulative Cost"
+          value={`$${metrics.cumulativeCost.toFixed(4)}`}
+          accent
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/components/detail/visualizations/QuantumCircuitRenderer.js
+++ b/components/detail/visualizations/QuantumCircuitRenderer.js
@@ -1,0 +1,295 @@
+// components/detail/visualizations/QuantumCircuitRenderer.js
+//
+// T50 (#113) -- the `quantumCircuit` universal type's renderer
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.2), covering the 3
+// D3-arm instances (Bernstein-Vazirani, Deutsch, Deutsch-Jozsa) this
+// contract's v1 can render. Ported from Redux_GUI's StandardCircuitSvgReact,
+// generalized rather than special-cased per gate-type string ("h", "cx",
+// "m", ...): the contract names no fixed gate-type vocabulary, so this
+// renderer treats every gate the same way structurally -- a labeled box on
+// its last target wire, a connecting line plus dots on any other targets,
+// and an optional dashed link down to the classical bus for a gate that also
+// carries `classical` targets (the shape a measurement gate uses).
+//
+// No `d3.selectAll`/`d3.select` against `document` or a hardcoded id (§4.1):
+// layout is a pure data computation (`buildLayout`), everything on screen is
+// plain React-owned SVG.
+//
+// Solution/oracle/iteration metadata (the panel StandardCircuitSvgReact drew
+// below the diagram) is out of scope here -- §3.2's contract covers `d3`'s
+// wires/gates/overlays, not `metadata`'s free-form contents, and T50's own
+// scope is rendering the frame, not a metadata inspector.
+
+import Box from "@mui/material/Box";
+import { useId, useMemo, useState } from "react";
+import { getVisualizationColor } from "../../theme";
+
+const GATE_WIDTH = 44;
+const GATE_HEIGHT = 26;
+const ROW_SPACING = 60;
+const COLUMN_SPACING = 80;
+const MARGIN = { top: 24, right: 40, bottom: 24, left: 60 };
+const CLASSICAL_GAP = 40;
+const LABEL_COLOR = "#F5F1EA";
+const WIRE_COLOR = getVisualizationColor("");
+const GATE_FILL = getVisualizationColor("ElementHighlight");
+const OVERLAY_COLOR = getVisualizationColor("ClauseHighlight");
+
+// Assigns one x column per distinct `time` value across every gate and
+// overlay boundary, and one y row per qubit (plus one shared classical bus
+// row, the same "one bus line with per-measurement tick marks" the ported
+// original used rather than one row per classical bit).
+function buildLayout(d3) {
+  const qubits = d3.qubits;
+  const classical = d3.classical ?? [];
+  const gates = d3.gates ?? [];
+  const overlays = d3.overlays ?? [];
+
+  const times = new Set();
+  gates.forEach((gate) => times.add(gate.time));
+  overlays.forEach((overlay) => {
+    times.add(overlay.timeStart);
+    times.add(overlay.timeEnd);
+  });
+  const sortedTimes = Array.from(times).sort((a, b) => a - b);
+  const columnIndex = new Map(sortedTimes.map((time, index) => [time, index]));
+  const xForTime = (time) => MARGIN.left + (columnIndex.get(time) ?? 0) * COLUMN_SPACING;
+
+  const qubitRowY = new Map(qubits.map((id, index) => [id, MARGIN.top + index * ROW_SPACING]));
+  const lastQubitY =
+    qubits.length > 0 ? MARGIN.top + (qubits.length - 1) * ROW_SPACING : MARGIN.top;
+  const classicalRowY = classical.length > 0 ? lastQubitY + CLASSICAL_GAP : null;
+
+  const maxColumn = Math.max(sortedTimes.length - 1, 0);
+  const width = MARGIN.left + MARGIN.right + Math.max(maxColumn, 1) * COLUMN_SPACING + GATE_WIDTH;
+  const height = (classicalRowY ?? lastQubitY) + MARGIN.bottom;
+
+  return { qubits, classical, gates, overlays, xForTime, qubitRowY, classicalRowY, width, height };
+}
+
+function GateMark({ idPrefix, gate, x, targetYs, classicalY, highlighted, onEnter, onLeave }) {
+  if (targetYs.length === 0) return null;
+
+  const label = gate.label ?? gate.type ?? "?";
+  const sortedYs = [...targetYs].sort((a, b) => a - b);
+  const boxY = sortedYs[sortedYs.length - 1];
+  const dotYs = sortedYs.slice(0, -1);
+  const hasClassicalLink =
+    classicalY != null && Array.isArray(gate.classical) && gate.classical.length > 0;
+  const stroke = highlighted ? GATE_FILL : WIRE_COLOR;
+
+  return (
+    <g
+      id={`${idPrefix}-gate-${gate.id}`}
+      tabIndex={0}
+      role="img"
+      aria-label={`${label} on ${gate.targets.join(", ")}`}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onFocus={onEnter}
+      onBlur={onLeave}
+      style={{ cursor: "default" }}
+    >
+      {sortedYs.length > 1 && (
+        <line
+          x1={x}
+          x2={x}
+          y1={sortedYs[0]}
+          y2={sortedYs[sortedYs.length - 1]}
+          stroke={stroke}
+          strokeWidth={highlighted ? 2.5 : 1.5}
+        />
+      )}
+      {dotYs.map((y) => (
+        <circle key={y} cx={x} cy={y} r={5} fill={stroke} />
+      ))}
+      {hasClassicalLink && (
+        <>
+          <line
+            x1={x}
+            x2={x}
+            y1={boxY}
+            y2={classicalY}
+            stroke={WIRE_COLOR}
+            strokeWidth={1.5}
+            strokeDasharray="3 2"
+          />
+          <circle cx={x} cy={classicalY} r={4} fill={WIRE_COLOR} />
+        </>
+      )}
+      <rect
+        x={x - GATE_WIDTH / 2}
+        y={boxY - GATE_HEIGHT / 2}
+        width={GATE_WIDTH}
+        height={GATE_HEIGHT}
+        rx={5}
+        ry={5}
+        fill={GATE_FILL}
+        stroke={highlighted ? "#FFFFFF" : WIRE_COLOR}
+        strokeWidth={highlighted ? 2 : 1.5}
+      />
+      <text
+        x={x}
+        y={boxY + 4}
+        textAnchor="middle"
+        fontSize={11}
+        fontWeight={700}
+        fill={LABEL_COLOR}
+        style={{ pointerEvents: "none" }}
+      >
+        {String(label).toUpperCase()}
+      </text>
+    </g>
+  );
+}
+
+function OverlayBand({ idPrefix, overlay, overlayIndex, x0, x1, yMin, yMax }) {
+  const top = yMin - GATE_HEIGHT - 10;
+  const bottom = yMax + GATE_HEIGHT / 2 + 6;
+  return (
+    <g id={`${idPrefix}-overlay-${overlay.id || overlayIndex}`}>
+      <rect
+        x={x0}
+        y={top}
+        width={Math.max(x1 - x0, 1)}
+        height={bottom - top}
+        rx={10}
+        ry={10}
+        fill={OVERLAY_COLOR}
+        fillOpacity={0.14}
+        stroke={OVERLAY_COLOR}
+        strokeDasharray="4 3"
+        strokeWidth={1.5}
+      />
+      <text
+        x={(x0 + x1) / 2}
+        y={top + 14}
+        textAnchor="middle"
+        fontSize={11}
+        fontWeight={700}
+        fill={OVERLAY_COLOR}
+      >
+        {overlay.label || overlay.type}
+      </text>
+    </g>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders,
+ *   so two mounted instances (Reductions' side-by-side panes) never collide
+ *   (§4.1).
+ * @param {string} [props.instanceName] Human-readable visualization name,
+ *   folded into the accessible summary when given.
+ * @param {{d3: Object}} props.frame One already-validated `quantumCircuit`
+ *   frame (the `d3` arm -- resolveVisualizationType only reaches this
+ *   renderer when `format === 1` and `d3` is present, per §3.2).
+ */
+export default function QuantumCircuitRenderer({ idPrefix, instanceName, frame }) {
+  const reactId = useId().replace(/:/g, "");
+  const scopeId = `${idPrefix}-${reactId}`;
+  const [hoveredGateId, setHoveredGateId] = useState(null);
+
+  const layout = useMemo(() => buildLayout(frame.d3), [frame]);
+  const { qubits, classical, gates, overlays, xForTime, qubitRowY, classicalRowY, width, height } =
+    layout;
+
+  const summaryBody = `quantum circuit with ${qubits.length} qubit${qubits.length === 1 ? "" : "s"} and ${gates.length} gate${gates.length === 1 ? "" : "s"}`;
+  const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
+
+  return (
+    <Box sx={{ width: "100%", height: "100%", overflow: "auto" }}>
+      <svg
+        id={scopeId}
+        role="img"
+        aria-label={summary}
+        viewBox={`0 0 ${width} ${height}`}
+        width={width}
+        height={height}
+        style={{ display: "block" }}
+      >
+        <title>{summary}</title>
+
+        {qubits.map((qubitId) => {
+          const y = qubitRowY.get(qubitId);
+          return (
+            <g key={qubitId}>
+              <text x={MARGIN.left - 10} y={y + 4} textAnchor="end" fontSize={11} fill={WIRE_COLOR}>
+                {qubitId}
+              </text>
+              <line x1={MARGIN.left} x2={width - MARGIN.right} y1={y} y2={y} stroke={WIRE_COLOR} />
+            </g>
+          );
+        })}
+
+        {classicalRowY != null && (
+          <g>
+            <text
+              x={MARGIN.left - 10}
+              y={classicalRowY - 8}
+              textAnchor="end"
+              fontSize={11}
+              fill={WIRE_COLOR}
+            >
+              {classical.length === 1 ? classical[0] : `c (${classical.length})`}
+            </text>
+            <line
+              x1={MARGIN.left}
+              x2={width - MARGIN.right}
+              y1={classicalRowY}
+              y2={classicalRowY}
+              stroke={WIRE_COLOR}
+              strokeWidth={2}
+            />
+          </g>
+        )}
+
+        {overlays.map((overlay, overlayIndex) => {
+          const targetYs = (overlay.targets ?? [])
+            .map((targetId) => qubitRowY.get(targetId))
+            .filter((y) => y != null);
+          if (targetYs.length === 0) return null;
+          const x0 = xForTime(overlay.timeStart) - COLUMN_SPACING / 2 + GATE_WIDTH / 2;
+          const x1 = xForTime(overlay.timeEnd) + COLUMN_SPACING / 2 - GATE_WIDTH / 2;
+          // §3.2 only requires `id` be a string -- live data sends "" on every
+          // overlay of at least one instance (Bernstein-Vazirani), so the
+          // index is the fallback that keeps both the React key and the DOM
+          // id (§4.1) unique when `id` alone can't.
+          return (
+            <OverlayBand
+              key={overlay.id || overlayIndex}
+              idPrefix={scopeId}
+              overlay={overlay}
+              overlayIndex={overlayIndex}
+              x0={x0}
+              x1={x1}
+              yMin={Math.min(...targetYs)}
+              yMax={Math.max(...targetYs)}
+            />
+          );
+        })}
+
+        {gates.map((gate) => {
+          const x = xForTime(gate.time);
+          const targetYs = (gate.targets ?? [])
+            .map((targetId) => qubitRowY.get(targetId))
+            .filter((y) => y != null);
+          return (
+            <GateMark
+              key={gate.id}
+              idPrefix={scopeId}
+              gate={gate}
+              x={x}
+              targetYs={targetYs}
+              classicalY={classicalRowY}
+              highlighted={hoveredGateId === gate.id}
+              onEnter={() => setHoveredGateId(gate.id)}
+              onLeave={() => setHoveredGateId((current) => (current === gate.id ? null : current))}
+            />
+          );
+        })}
+      </svg>
+    </Box>
+  );
+}

--- a/components/detail/visualizations/RecursiveSetRenderer.js
+++ b/components/detail/visualizations/RecursiveSetRenderer.js
@@ -1,0 +1,145 @@
+// components/detail/visualizations/RecursiveSetRenderer.js
+//
+// T50 (#113) -- the `recursiveSet` universal type's renderer
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.4), covering the 4
+// ExactCover/HittingSet/Partition/SetCover instances. Ported from
+// Redux_GUI's StandardSetSvgReact (nested sets drawn as bracketed,
+// comma-separated runs of colored elements), rebuilt as plain React-owned
+// markup rather than d3 DOM manipulation against `document` (§4.1) -- there
+// is nothing here d3 did that isn't already what React's own tree diffing
+// does for a static, non-editable render.
+//
+// §3.4's "malformed at that node, not the whole tree" clause is handled
+// entirely inside SetNode below: `validateRecursiveSetFrame`
+// (data/visualizationTypes.js) only checks that `frame.data` itself exists,
+// not that every node in the tree is internally consistent -- a node with
+// `isValue: true` and no `value`, or `isValue: false` and no `list`,
+// degrades to a `PlaceholderMark` at that node instead of failing the whole
+// render, exactly what the contract asks for.
+
+import Box from "@mui/material/Box";
+import { Fragment, useId } from "react";
+import { getVisualizationColor } from "../../theme";
+
+function leafCount(node) {
+  if (!node || typeof node !== "object") return 0;
+  if (node.isValue) return typeof node.value === "string" ? 1 : 0;
+  if (!Array.isArray(node.list)) return 0;
+  return node.list.reduce((total, child) => total + leafCount(child), 0);
+}
+
+function PlaceholderMark({ id }) {
+  return (
+    <Box id={id} component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+      ?
+    </Box>
+  );
+}
+
+function Bracket({ children }) {
+  return (
+    <Box component="span" aria-hidden="true" sx={{ color: "text.secondary" }}>
+      {children}
+    </Box>
+  );
+}
+
+function Comma() {
+  return (
+    <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mr: 0.5 }}>
+      ,
+    </Box>
+  );
+}
+
+function SetNode({ id, node }) {
+  if (!node || typeof node !== "object") {
+    return <PlaceholderMark id={id} />;
+  }
+
+  if (node.isValue) {
+    if (typeof node.value !== "string") {
+      return <PlaceholderMark id={id} />;
+    }
+    return (
+      <Box
+        id={id}
+        component="span"
+        sx={{
+          fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
+          fontSize: "0.9375rem",
+          fontWeight: 600,
+          color: getVisualizationColor(node.color),
+        }}
+      >
+        {node.value}
+      </Box>
+    );
+  }
+
+  const open = node.isOrdered ? "(" : "{";
+  const close = node.isOrdered ? ")" : "}";
+  if (!Array.isArray(node.list)) {
+    return (
+      <Box id={id} component="span">
+        <Bracket>{open}</Bracket>
+        <Bracket>{close}</Bracket>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      id={id}
+      component="span"
+      sx={{ display: "inline-flex", alignItems: "center", flexWrap: "wrap" }}
+    >
+      <Bracket>{open}</Bracket>
+      {node.list.map((child, index) => (
+        <Fragment key={child?.id ?? index}>
+          {index > 0 && <Comma />}
+          <SetNode id={`${id}-${index}`} node={child} />
+        </Fragment>
+      ))}
+      <Bracket>{close}</Bracket>
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders,
+ *   so two mounted instances (Reductions' side-by-side panes) never collide
+ *   (§4.1).
+ * @param {string} [props.instanceName] Human-readable visualization name,
+ *   folded into the accessible summary when given.
+ * @param {{data: Object}} props.frame One already-validated `recursiveSet`
+ *   frame.
+ */
+export default function RecursiveSetRenderer({ idPrefix, instanceName, frame }) {
+  const reactId = useId().replace(/:/g, "");
+  const scopeId = `${idPrefix}-${reactId}`;
+
+  const count = leafCount(frame.data);
+  const summaryBody = `set structure with ${count} element${count === 1 ? "" : "s"}`;
+  const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
+
+  return (
+    <Box
+      id={scopeId}
+      role="img"
+      aria-label={summary}
+      sx={{
+        display: "flex",
+        flexWrap: "wrap",
+        alignItems: "center",
+        gap: 0.5,
+        p: 2,
+        minHeight: "100%",
+        boxSizing: "border-box",
+      }}
+    >
+      <SetNode id={`${scopeId}-root`} node={frame.data} />
+    </Box>
+  );
+}

--- a/components/detail/visualizations/StepTableRenderer.js
+++ b/components/detail/visualizations/StepTableRenderer.js
@@ -1,0 +1,131 @@
+// components/detail/visualizations/StepTableRenderer.js
+//
+// T50 (#113) -- the `stepTable` universal type's renderer
+// (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.5), covering the 4
+// DFATable/NFATable/SPSPTable/SSSPTable instances. Ported from Redux_GUI's
+// DynamicTableSvgReact, which already rendered a real HTML `<table>` --
+// §4.2's accessibility ask for this type is smaller than the other five as
+// a result: a `<caption>`, `scope` on header cells, and a focusable scroll
+// region, added here rather than a `<title>`/`role="img"` alternative.
+//
+// Cell text (including status glyphs like U+2705/U+274C/U+221E, T40's
+// finding) is rendered exactly as the backend sends it -- no substituting or
+// stripping characters, per §3.5's decision. A `cells` entry missing a
+// column's key renders "-", the documented degenerate case, not a
+// violation.
+
+import Box from "@mui/material/Box";
+import { alpha } from "@mui/material/styles";
+import { useId } from "react";
+import { getVisualizationColor } from "../../theme";
+
+/**
+ * @param {Object} props
+ * @param {string} props.idPrefix Prefixes every id this component renders,
+ *   so two mounted instances (Reductions' side-by-side panes) never collide
+ *   (§4.1).
+ * @param {string} [props.instanceName] Human-readable visualization name,
+ *   used to build the table's caption when the frame itself has no `title`.
+ * @param {{title: string|null, columns: Array, rows: Array}} props.frame One
+ *   already-validated `stepTable` frame.
+ */
+export default function StepTableRenderer({ idPrefix, instanceName, frame }) {
+  const reactId = useId().replace(/:/g, "");
+  const scopeId = `${idPrefix}-${reactId}`;
+
+  const columns = frame.columns;
+  const rows = frame.rows;
+  const rowCount = rows.length;
+  const captionText =
+    frame.title || `${instanceName ?? "Step table"}: ${rowCount} row${rowCount === 1 ? "" : "s"}`;
+
+  return (
+    <Box
+      id={scopeId}
+      tabIndex={0}
+      role="group"
+      aria-label={captionText}
+      sx={{
+        maxHeight: 400,
+        overflow: "auto",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: 1,
+      }}
+    >
+      <Box
+        component="table"
+        sx={{
+          borderCollapse: "collapse",
+          width: "100%",
+          fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
+          fontSize: "0.8125rem",
+        }}
+      >
+        <Box
+          component="caption"
+          sx={{ captionSide: "top", textAlign: "left", p: 1, fontWeight: 700 }}
+        >
+          {captionText}
+        </Box>
+        <Box component="thead">
+          <Box component="tr">
+            {columns.map((column) => (
+              <Box
+                component="th"
+                key={column.key}
+                id={`${scopeId}-col-${column.key}`}
+                scope="col"
+                sx={{
+                  position: "sticky",
+                  top: 0,
+                  border: "1px solid",
+                  borderColor: "divider",
+                  backgroundColor: "background.paper",
+                  p: 1,
+                  textAlign: "center",
+                  fontWeight: 700,
+                }}
+              >
+                {column.label}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+        <Box component="tbody">
+          {rows.map((row, rowIndex) => {
+            const rowColor = row.color ? getVisualizationColor(row.color) : null;
+            return (
+              <Box
+                component="tr"
+                key={row.id ?? rowIndex}
+                sx={{ color: rowColor ?? "inherit", fontWeight: rowColor ? 700 : 400 }}
+              >
+                {columns.map((column) => {
+                  const cellColorKey = row.cellColors?.[column.key];
+                  const cellColor = cellColorKey ? getVisualizationColor(cellColorKey) : null;
+                  return (
+                    <Box
+                      component="td"
+                      key={column.key}
+                      headers={`${scopeId}-col-${column.key}`}
+                      sx={{
+                        border: "1px solid",
+                        borderColor: "divider",
+                        p: 1,
+                        textAlign: "center",
+                        backgroundColor: cellColor ? alpha(cellColor, 0.22) : "transparent",
+                      }}
+                    >
+                      {row.cells?.[column.key] ?? "-"}
+                    </Box>
+                  );
+                })}
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/components/detail/visualizations/VisualizationCanvas.js
+++ b/components/detail/visualizations/VisualizationCanvas.js
@@ -6,22 +6,35 @@
 // no data / not yet supported (quiet, case b), versus a contract violation (a loud
 // `console.warn` plus a dev-only visible marker, case c).
 //
-// `graph` (T48) and `booleanSatisfiability` (T49) have renderers today -- T50 adds the
-// rest, one task per universal type, the same "once per type, not once per instance"
-// split the whole Track B design is built around. Every other resolved type, and every
-// payload this frontend doesn't recognize at all, takes the quiet "not supported yet"
-// path: that is honestly case (b), not something to warn about.
+// All 6 universal types have renderers as of T50 (`quantumCircuit`,
+// `recursiveSet`, `stepTable`, `pumpSchedule` joining `graph`/T48 and
+// `booleanSatisfiability`/T49), the "once per type, not once per instance"
+// split the whole Track B design is built around. Every payload this
+// frontend doesn't recognize at all still takes the quiet "not supported
+// yet" path: that is honestly case (b), not something to warn about.
 
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useEffect } from "react";
-import { resolveVisualizationType, validateFrame } from "../../../data/visualizationTypes";
+import {
+  describeUnrenderableReason,
+  resolveVisualizationType,
+  validateFrame,
+} from "../../../data/visualizationTypes";
 import BooleanSatisfiabilityRenderer from "./BooleanSatisfiabilityRenderer";
 import GraphRenderer from "./GraphRenderer";
+import PumpScheduleRenderer from "./PumpScheduleRenderer";
+import QuantumCircuitRenderer from "./QuantumCircuitRenderer";
+import RecursiveSetRenderer from "./RecursiveSetRenderer";
+import StepTableRenderer from "./StepTableRenderer";
 
 const RENDERERS = {
   graph: GraphRenderer,
   booleanSatisfiability: BooleanSatisfiabilityRenderer,
+  quantumCircuit: QuantumCircuitRenderer,
+  recursiveSet: RecursiveSetRenderer,
+  stepTable: StepTableRenderer,
+  pumpSchedule: PumpScheduleRenderer,
 };
 
 function CannotRender({ idPrefix, reason, violations }) {
@@ -85,13 +98,15 @@ export default function VisualizationCanvas({ idPrefix, instanceName, backendTyp
   }
 
   if (!Renderer) {
+    const specificReason = describeUnrenderableReason(backendType, frame);
     return (
       <CannotRender
         idPrefix={idPrefix}
         reason={
-          universalType
+          specificReason ??
+          (universalType
             ? `No renderer built yet for "${universalType}" visualizations.`
-            : "This visualization type isn't supported yet."
+            : "This visualization type isn't supported yet.")
         }
       />
     );

--- a/data/visualizationTypes.js
+++ b/data/visualizationTypes.js
@@ -62,6 +62,30 @@ export function resolveVisualizationType(backendType, payload) {
   return universalType;
 }
 
+/**
+ * T50 (#113): a more specific "cannot render" reason for the one case that's
+ * genuinely in-contract but out of v1's coverage (§3.2's decision) -- a
+ * `quantumCircuit` frame at `format: 0` (QASM-only, no `d3` arm).
+ * `resolveVisualizationType` already folds this into `null` like any other
+ * unresolvable type; this export exists only so the UI can tell that
+ * specific case apart from a genuinely unsupported backend type, per the
+ * issue's own Done-when list ("show 'cannot render' with a distinct
+ * reason, not a fake empty circuit").
+ *
+ * @param {string} [backendType]
+ * @param {Object} [payload]
+ * @returns {string|null}
+ */
+export function describeUnrenderableReason(backendType, payload) {
+  if (
+    VISUALIZATION_TYPE_MAP[backendType] === "quantumCircuit" &&
+    !(payload?.format === 1 && payload?.d3)
+  ) {
+    return "No structured circuit data for this visualization.";
+  }
+  return null;
+}
+
 const GRAPH_REQUIRED_NODE_STRING_FIELDS = [
   "id",
   "name",
@@ -166,9 +190,167 @@ function validateBooleanSatisfiabilityFrame(frame) {
   return { valid: violations.length === 0, violations };
 }
 
+/**
+ * §3.2's contract, checked field by field. By the time a frame reaches this
+ * validator, resolveVisualizationType has already guaranteed `format === 1`
+ * and `frame.d3` is truthy (that's what makes it resolve to
+ * "quantumCircuit" instead of null in the first place) -- this only checks
+ * the required shape *inside* `d3`, which resolveVisualizationType does not.
+ */
+function validateQuantumCircuitFrame(frame) {
+  const violations = [];
+  const d3 = frame?.d3;
+  if (!d3 || typeof d3 !== "object") {
+    violations.push("d3: expected an object");
+    return { valid: false, violations };
+  }
+  if (!Array.isArray(d3.qubits)) violations.push("d3.qubits: expected an array");
+  if (!Array.isArray(d3.classical)) violations.push("d3.classical: expected an array");
+  if (!Array.isArray(d3.gates)) violations.push("d3.gates: expected an array");
+  if (d3.overlays !== undefined && d3.overlays !== null && !Array.isArray(d3.overlays)) {
+    violations.push("d3.overlays: expected an array");
+  }
+  if (violations.length > 0) {
+    return { valid: false, violations };
+  }
+
+  d3.gates.forEach((gate, index) => {
+    if (typeof gate?.id !== "string") violations.push(`d3.gates[${index}].id: expected a string`);
+    if (typeof gate?.type !== "string")
+      violations.push(`d3.gates[${index}].type: expected a string`);
+    if (!Array.isArray(gate?.targets)) {
+      violations.push(`d3.gates[${index}].targets: expected an array`);
+    }
+    if (typeof gate?.time !== "number")
+      violations.push(`d3.gates[${index}].time: expected a number`);
+  });
+
+  (d3.overlays ?? []).forEach((overlay, index) => {
+    if (typeof overlay?.id !== "string") {
+      violations.push(`d3.overlays[${index}].id: expected a string`);
+    }
+    if (!Array.isArray(overlay?.targets)) {
+      violations.push(`d3.overlays[${index}].targets: expected an array`);
+    }
+    if (typeof overlay?.timeStart !== "number") {
+      violations.push(`d3.overlays[${index}].timeStart: expected a number`);
+    }
+    if (typeof overlay?.timeEnd !== "number") {
+      violations.push(`d3.overlays[${index}].timeEnd: expected a number`);
+    }
+  });
+
+  return { valid: violations.length === 0, violations };
+}
+
+/**
+ * §3.4's contract. Only checks that `data` itself is present -- per-node
+ * consistency (`isValue: true` with no `value`, `isValue: false` with no
+ * `list`) is deliberately NOT checked here. §3.4 is explicit that this kind
+ * of defect is "malformed at that node", not a reason to fail the whole
+ * frame; RecursiveSetRenderer.js's SetNode degrades a bad node to a
+ * placeholder mark instead, so there is nothing for the canary to gate on
+ * beyond the one field that really does make the whole frame unrenderable.
+ */
+function validateRecursiveSetFrame(frame) {
+  const violations = [];
+  if (!frame?.data || typeof frame.data !== "object") {
+    violations.push("data: expected an object");
+  }
+  return { valid: violations.length === 0, violations };
+}
+
+/**
+ * §3.5's contract. A `cells` entry missing a column's key is the documented
+ * "-" case, not a violation, so only `columns`/`rows` shape is checked here.
+ */
+function validateStepTableFrame(frame) {
+  const violations = [];
+  if (!Array.isArray(frame?.columns)) violations.push("columns: expected an array");
+  if (!Array.isArray(frame?.rows)) violations.push("rows: expected an array");
+  if (violations.length > 0) {
+    return { valid: false, violations };
+  }
+
+  frame.columns.forEach((column, index) => {
+    if (typeof column?.key !== "string")
+      violations.push(`columns[${index}].key: expected a string`);
+    if (typeof column?.label !== "string") {
+      violations.push(`columns[${index}].label: expected a string`);
+    }
+  });
+  frame.rows.forEach((row, index) => {
+    if (typeof row?.id !== "string") violations.push(`rows[${index}].id: expected a string`);
+    if (!row?.cells || typeof row.cells !== "object") {
+      violations.push(`rows[${index}].cells: expected an object`);
+    }
+  });
+
+  return { valid: violations.length === 0, violations };
+}
+
+const PUMP_SCHEDULE_METRIC_NUMBER_FIELDS = [
+  "hour",
+  "stepCost",
+  "cumulativeCost",
+  "tankLevel",
+  "tankCapacity",
+  "tankFillRatio",
+  "flowIn",
+  "demand",
+];
+
+/**
+ * §3.6's contract. `pumpSchedule` is the one type whose numeric fields are
+ * real JSON numbers rather than strings (per §3.6), so this checks `number`/
+ * `boolean`, not `string`, unlike every other validator in this file.
+ */
+function validatePumpScheduleFrame(frame) {
+  const violations = [];
+  if (typeof frame?.action !== "string") violations.push("action: expected a string");
+
+  if (!frame?.metrics || typeof frame.metrics !== "object") {
+    violations.push("metrics: expected an object");
+  } else {
+    for (const field of PUMP_SCHEDULE_METRIC_NUMBER_FIELDS) {
+      if (typeof frame.metrics[field] !== "number") {
+        violations.push(`metrics.${field}: expected a number`);
+      }
+    }
+    if (typeof frame.metrics.isPeakHour !== "boolean") {
+      violations.push("metrics.isPeakHour: expected a boolean");
+    }
+  }
+
+  if (!Array.isArray(frame?.state?.pumps)) {
+    violations.push("state.pumps: expected an array");
+  } else {
+    frame.state.pumps.forEach((pump, index) => {
+      if (typeof pump?.name !== "string") {
+        violations.push(`state.pumps[${index}].name: expected a string`);
+      }
+      if (typeof pump?.isOn !== "boolean") {
+        violations.push(`state.pumps[${index}].isOn: expected a boolean`);
+      }
+      if (typeof pump?.flowGph !== "number") {
+        violations.push(`state.pumps[${index}].flowGph: expected a number`);
+      }
+      if (typeof pump?.powerKw !== "number") {
+        violations.push(`state.pumps[${index}].powerKw: expected a number`);
+      }
+    });
+  }
+
+  return { valid: violations.length === 0, violations };
+}
+
 const VALIDATORS = {
   graph: validateGraphFrame,
   booleanSatisfiability: validateBooleanSatisfiabilityFrame,
+  quantumCircuit: validateQuantumCircuitFrame,
+  recursiveSet: validateRecursiveSetFrame,
+  stepTable: validateStepTableFrame,
+  pumpSchedule: validatePumpScheduleFrame,
 };
 
 /**
@@ -176,10 +358,10 @@ const VALIDATORS = {
  * contracts, not a general JSON-schema validator. Only checks the failure classes §3
  * already enumerates per type.
  *
- * A universal type with no validator yet (every type besides `graph` and
- * `booleanSatisfiability`, until T50 adds the rest) always reports valid -- there is no
- * renderer consuming it yet either, so there is nothing for a false-negative here to
- * protect.
+ * All 6 universal types have a validator as of T50. A universal type this map doesn't
+ * recognize at all (`null`, or a payload-level `kind` this frontend has never heard of)
+ * always reports valid -- there is no renderer consuming it either, so there is nothing
+ * for a false-negative here to protect.
  *
  * @param {string|null} universalType
  * @param {Object} frame


### PR DESCRIPTION
Issue:  #113 (T50: Static-but-real Visualizations rendering: quantumCircuit, recursiveSet, stepTable, pumpSchedule)
Branch: task/T50-universal-visualization-types

Changed:
  components/detail/visualizations/QuantumCircuitRenderer.js  (new)
  components/detail/visualizations/RecursiveSetRenderer.js    (new)
  components/detail/visualizations/StepTableRenderer.js       (new)
  components/detail/visualizations/PumpScheduleRenderer.js    (new)
  data/visualizationTypes.js         (added the four types' §4.4 validators, plus
                                       describeUnrenderableReason for the QASM-only case)
  components/detail/visualizations/VisualizationCanvas.js
                                      (wired the four new renderers into RENDERERS,
                                       used describeUnrenderableReason for a distinct
                                       "cannot render" message)

Done when, met:
  - All four types render real payloads from /visualize instead of the static placeholder
    (verified against the live local backend for Set Cover/recursiveSet, DFA Acceptance/
    stepTable, Bernstein-Vazirani/quantumCircuit, Pump Scheduling Cost Minimization/
    pumpSchedule -- screenshots confirmed correct rendering, no console warnings).
  - quantumCircuit frames with format: 0 (QASM-only) show "cannot render" with the
    distinct reason "No structured circuit data for this visualization." -- verified
    against Bernstein-Vazirani's QuantumCircuitQjs-only sibling instance.
  - stepTable renders backend cell text (including the U+2705/U+274C status glyphs)
    unmodified -- confirmed against real DFA table data.
  - pumpSchedule uses its own local palette, not the shared color-key table.
  - Malformed/missing data and contract violations are distinguished per §4.4 for all
    four (validators added to data/visualizationTypes.js's VALIDATORS map).
  - T47's scrubber and the shared-instance wiring both already worked generically
    across every universal type via VisualizationsSection.js/VisualizationCanvas.js,
    so no changes were needed there.

Decisions and assumptions:
  - recursiveSet's validator only checks that `frame.data` exists, not that every node
    in the tree is internally consistent, per §3.4's explicit "malformed at that node,
    not the whole tree" clause -- RecursiveSetRenderer.js degrades a bad node to a "?"
    placeholder instead.
  - quantumCircuit gates are rendered generically (a labeled box on the last target
    wire, connecting line/dots on other targets) rather than special-cased per
    gate-type string, since the contract names no fixed vocabulary. Verified against
    live H/X/oracle/measurement gates and it reads correctly.
  - Found and fixed a real-data quirk while testing live: overlay.id can be an empty
    string shared across multiple overlays on the same frame (Bernstein-Vazirani) --
    QuantumCircuitRenderer falls back to the array index for the React key and DOM id
    in that case.
  - Solution/oracle/iteration metadata (a panel the ported Redux_GUI renderer drew) is
    left out of QuantumCircuitRenderer -- out of §3.2's frame contract, and out of
    T50's "rendering only" scope.

  Closes #113