### PR TITLE
Diagram Editing Added

### DIFF
--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -25,13 +25,35 @@
 // T47 (#110): step playback (play/pause/step/speed/scrub bar) is the shared
 // StepScrubber component, now driven by the real frame count a completed
 // run returns rather than a fallback of 1.
+//
+// T51 (#114): structural editing for the `graph`, `recursiveSet` and
+// `quantumCircuit` universal types (wave 2). Per INTERACTIVE_LAYER_DESIGN.md
+// §2.3, editing only ever applies to the base frame (frames[0]) -- the
+// `editedGraph`/`editedRecursiveData`/`editedCircuit` state below is
+// local-preview-only, seeded from the fetched base frame as soon as it's
+// available (so an edit panel's rows have stable identity from the start,
+// not just after the first edit) and cleared whenever the selected
+// visualization changes or a fresh Run replaces the frames (§2.1.2:
+// "editing previews locally; Run reconciles through the real backend round
+// trip"). Pressing Run serializes any pending edit into the shared instance
+// text (only `graph` node edits and `recursiveSet` are actually sendable --
+// see data/instanceSerializers.js's header for `quantumCircuit`'s open gap,
+// and this file's own handleRunClick for why `graph` edge edits stay
+// preview-only) via `onInstanceChange` *before* triggering the shared Run
+// action, exactly the same sequencing T52 (#115) established for
+// `booleanSatisfiability` on its own branch.
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  serializeGraphInstance,
+  serializeRecursiveSetInstance,
+} from "../../data/instanceSerializers";
 import { TAXONOMY, UNCLASSIFIED } from "../../data/taxonomy";
+import { VISUALIZATION_TYPE_MAP } from "../../data/visualizationTypes";
 import {
   COMPUTE_CANCELLED,
   COMPUTE_DONE,
@@ -47,6 +69,169 @@ import StepScrubber from "./StepScrubber";
 import VisualizationCanvas from "./visualizations/VisualizationCanvas";
 
 const VISUALIZATION_TYPE_FACET = TAXONOMY.find((facet) => facet.key === "visualizationType");
+
+// Ids assigned to a newly-added edge/gate within one editing session only need to be
+// unique within that session (React keys, DOM ids) -- a module-level counter is enough.
+let editIdCounter = 0;
+function nextEditId(prefix) {
+  editIdCounter += 1;
+  return `${prefix}-${editIdCounter}`;
+}
+
+function cloneGraphForEdit(frame) {
+  return {
+    nodes: frame.nodes.map((node) => ({ ...node, _key: node.id })),
+    links: frame.links.map((link) => ({ ...link, _key: link.id })),
+  };
+}
+
+// Applies one GraphRenderer edit descriptor to a cloned {nodes, links} structure.
+// Referential integrity for node removal/rename (an edge can't be left dangling, per
+// T46's finding that SPADE itself won't catch this) is handled locally here the same way
+// data/spadeInstanceText.js's `removeLeafEverywhere`/`renameLeafEverywhere` handle it in
+// the text -- the two are independent implementations of the same rule, one over the
+// in-memory structure for the local preview, one over the parsed text for Run.
+function applyGraphOp(current, op) {
+  switch (op.type) {
+    case "addNode": {
+      if (current.nodes.some((node) => node.id === op.id)) return current;
+      return {
+        ...current,
+        nodes: [
+          ...current.nodes,
+          {
+            id: op.id,
+            name: op.id,
+            color: "",
+            outline: "",
+            delay: "",
+            dashed: "",
+            additional: "",
+            _key: op.id,
+          },
+        ],
+      };
+    }
+    case "removeNode":
+      return {
+        nodes: current.nodes.filter((node) => node.id !== op.id),
+        links: current.links.filter((link) => link.source !== op.id && link.target !== op.id),
+      };
+    case "renameNode": {
+      if (op.from === op.to || current.nodes.some((node) => node.id === op.to)) return current;
+      return {
+        nodes: current.nodes.map((node) =>
+          node.id === op.from ? { ...node, id: op.to, name: op.to } : node,
+        ),
+        links: current.links.map((link) => ({
+          ...link,
+          source: link.source === op.from ? op.to : link.source,
+          target: link.target === op.from ? op.to : link.target,
+        })),
+      };
+    }
+    case "addEdge": {
+      if (op.source === op.target) return current;
+      const alreadyExists = current.links.some(
+        (link) =>
+          (link.source === op.source && link.target === op.target) ||
+          (link.source === op.target && link.target === op.source),
+      );
+      if (alreadyExists) return current;
+      return {
+        ...current,
+        links: [
+          ...current.links,
+          {
+            id: nextEditId("edge"),
+            _key: nextEditId("edge-key"),
+            source: op.source,
+            target: op.target,
+            color: "",
+            dashed: "",
+            delay: "",
+            weight: "",
+            weighted: false,
+            directed: false,
+            attribute1: "",
+            attribute2: "",
+          },
+        ],
+      };
+    }
+    case "removeEdge":
+      return { ...current, links: current.links.filter((link) => link.id !== op.id) };
+    default:
+      return current;
+  }
+}
+
+function cloneCircuitForEdit(d3) {
+  return {
+    qubits: [...d3.qubits],
+    classical: [...(d3.classical ?? [])],
+    gates: (d3.gates ?? []).map((gate) => ({ ...gate, targets: [...gate.targets] })),
+    overlays: d3.overlays ?? [],
+    metadata: d3.metadata ?? null,
+  };
+}
+
+// Local-preview-only (data/instanceSerializers.js has no `quantumCircuit` serializer --
+// see that file's header) -- so unlike `applyGraphOp`, nothing here needs to track a
+// separate op log for Run.
+function applyCircuitOp(current, op) {
+  switch (op.type) {
+    case "addQubit":
+      if (current.qubits.includes(op.id)) return current;
+      return { ...current, qubits: [...current.qubits, op.id] };
+    case "removeQubit":
+      return {
+        ...current,
+        qubits: current.qubits.filter((qubit) => qubit !== op.id),
+        gates: current.gates.filter((gate) => !gate.targets.includes(op.id)),
+      };
+    case "renameQubit": {
+      if (op.from === op.to || current.qubits.includes(op.to)) return current;
+      return {
+        ...current,
+        qubits: current.qubits.map((qubit) => (qubit === op.from ? op.to : qubit)),
+        gates: current.gates.map((gate) => ({
+          ...gate,
+          targets: gate.targets.map((target) => (target === op.from ? op.to : target)),
+        })),
+      };
+    }
+    case "addGate": {
+      const maxTime = current.gates.reduce((max, gate) => Math.max(max, gate.time ?? 0), -1);
+      return {
+        ...current,
+        gates: [
+          ...current.gates,
+          {
+            id: nextEditId("gate"),
+            type: op.gateType,
+            targets: [op.target],
+            classical: null,
+            params: null,
+            label: null,
+            time: maxTime + 1,
+          },
+        ],
+      };
+    }
+    case "removeGate":
+      return { ...current, gates: current.gates.filter((gate) => gate.id !== op.id) };
+    case "relabelGate":
+      return {
+        ...current,
+        gates: current.gates.map((gate) =>
+          gate.id === op.id ? { ...gate, type: op.gateType } : gate,
+        ),
+      };
+    default:
+      return current;
+  }
+}
 
 // #71: fixed rail height so a problem with many declared visualizations
 // scrolls inside the rail instead of stretching the section indefinitely.
@@ -99,8 +284,9 @@ function TypeBadge({ typeKey }) {
  * @param {string} [props.instanceValue] The shared problem instance, owned by
  *   components/ProblemDetailLayout.js (T35/#93).
  * @param {(next: string) => void} [props.onInstanceChange] Called with the new
- *   text whenever the visitor edits the instance elsewhere (Solvers' box) --
- *   this section reads the value but does not render its own copy of the box.
+ *   text whenever the visitor edits the instance elsewhere (Solvers' box), and
+ *   (T51/#114) called by this section itself, just before Run, to write a
+ *   pending diagram edit's serialized text into the shared instance.
  * @param {number} [props.runToken] The shared Run trigger (T48/#111). A change
  *   in value, not the value itself, means Run was pressed somewhere.
  * @param {() => void} [props.onRunRequest] Bumps `runToken`. Called by this
@@ -111,6 +297,7 @@ function TypeBadge({ typeKey }) {
 export default function VisualizationsSection({
   problem,
   instanceValue = "",
+  onInstanceChange,
   runToken,
   onRunRequest,
   dragHandleProps,
@@ -137,12 +324,68 @@ export default function VisualizationsSection({
       : null;
   const instanceChangedSinceRun = Boolean(liveFrames) && liveFrames.instance !== instanceValue;
 
+  // T51 (#114): which universal type the selected visualization renders as, and whether
+  // it's one of the three wave-2 editable types. Derived from the static backend-type map
+  // alone (not `resolveVisualizationType`, which also needs a live frame) since this is
+  // needed before a frame exists, to decide whether edit affordances can ever apply.
+  const universalType = VISUALIZATION_TYPE_MAP[selected?.backendType] ?? null;
+  const isGraph = universalType === "graph";
+  const isRecursiveSet = universalType === "recursiveSet";
+  const isQuantumCircuit = universalType === "quantumCircuit";
+  const isEditableType = isGraph || isRecursiveSet || isQuantumCircuit;
+
+  // Local-preview-only edit state (INTERACTIVE_LAYER_DESIGN.md §2.1.2/§2.3), one slot per
+  // wave-2 type -- only the slot matching the selected visualization's type is ever
+  // non-null. `graphNodeOps` is the ordered node-edit log `serializeGraphInstance` replays
+  // at Run time (see that function's own doc comment for why edge edits aren't logged the
+  // same way).
+  const [editedGraph, setEditedGraph] = useState(null);
+  const [graphNodeOps, setGraphNodeOps] = useState([]);
+  const [graphHasEdgeEdits, setGraphHasEdgeEdits] = useState(false);
+  const [editedRecursiveData, setEditedRecursiveData] = useState(null);
+  const [editedCircuit, setEditedCircuit] = useState(null);
+  const [serializeError, setSerializeError] = useState(null);
+
+  const baseFrame = liveFrames?.frames?.[0] ?? null;
+
+  // Seeds `editedGraph` as soon as a base `graph` frame exists, rather than waiting for
+  // the first edit -- GraphRenderer's edit panel needs every row's stable `_key` from its
+  // very first render, not just after something has already been changed (React's
+  // documented "adjust state during render" pattern, the same one `stepResetKey`/
+  // `lastVisualizeResult` below already use in this file).
+  if (isGraph && currentStep === 0 && baseFrame && editedGraph === null) {
+    setEditedGraph(cloneGraphForEdit(baseFrame));
+  }
+
+  function applyGraphEdit(op) {
+    setEditedGraph((current) => applyGraphOp(current ?? cloneGraphForEdit(baseFrame), op));
+    if (op.type === "addNode" || op.type === "removeNode" || op.type === "renameNode") {
+      setGraphNodeOps((ops) => [...ops, op]);
+    } else {
+      setGraphHasEdgeEdits(true);
+    }
+  }
+
+  function applyCircuitEdit(op) {
+    setEditedCircuit((current) => applyCircuitOp(current ?? cloneCircuitForEdit(baseFrame.d3), op));
+  }
+
+  function handleDataChange(updater) {
+    setEditedRecursiveData((current) => updater(current ?? baseFrame.data));
+  }
+
   function handleSelectVisualization(index) {
     if (index === selectedIndex) return;
     // Drops any in-flight request and clears the pane, so nothing from the
     // previous visualization survives the switch.
     visualize.reset();
     setSelectedIndex(index);
+    setEditedGraph(null);
+    setGraphNodeOps([]);
+    setGraphHasEdgeEdits(false);
+    setEditedRecursiveData(null);
+    setEditedCircuit(null);
+    setSerializeError(null);
   }
 
   const { start: startVisualize } = visualize;
@@ -166,6 +409,34 @@ export default function VisualizationsSection({
     });
   }, [canRun, selected, instanceValue, startVisualize]);
 
+  // T51 (#114): the Run affordance's onClick, not `handleRun`/`onRunRequest` directly --
+  // a pending `graph` node edit or `recursiveSet` edit must be serialized into the shared
+  // instance *before* Run fires (`onInstanceChange` and `onRunRequest` are both setters on
+  // the same parent, ProblemDetailLayout.js, batched into one re-render, so the runToken
+  // effect below sees the updated `instanceValue` by the time it fires -- the same
+  // ordering T52/#115 relies on for `booleanSatisfiability`, on its own branch). A
+  // `quantumCircuit` edit, or a `graph` edit that's edge-only, has nothing to serialize --
+  // Run still fires, it just won't reflect that particular pending edit.
+  function handleRunClick() {
+    setSerializeError(null);
+    if (isGraph && graphNodeOps.length > 0 && liveFrames) {
+      const baseNodeIds = liveFrames.frames[0].nodes.map((node) => node.id);
+      const result = serializeGraphInstance(liveFrames.instance, baseNodeIds, graphNodeOps);
+      if ("error" in result) {
+        setSerializeError(result.error);
+        return;
+      }
+      onInstanceChange?.(result.instanceText);
+    } else if (isRecursiveSet && editedRecursiveData !== null) {
+      onInstanceChange?.(serializeRecursiveSetInstance(editedRecursiveData));
+    }
+    if (onRunRequest) {
+      onRunRequest();
+    } else {
+      handleRun();
+    }
+  }
+
   // Reacts to the shared Run trigger (T48/#111) rather than fetching inline
   // in the button's onClick -- see components/ProblemDetailLayout.js and
   // components/detail/SolversSection.js, which does the identical thing.
@@ -176,11 +447,13 @@ export default function VisualizationsSection({
     handleRun();
   }, [runToken, handleRun]);
 
-  // Two independent render-time step resets (React's documented "adjust
-  // state" pattern, not a useEffect): selecting a different visualization
-  // starts its playback over, and so does a freshly-completed run replacing
-  // the frames currently shown -- both can leave a stale `currentStep`
-  // pointing past the end of a differently-sized frames[].
+  // Independent render-time resets (React's documented "adjust state" pattern, not a
+  // useEffect): selecting a different visualization starts its playback over (handled in
+  // handleSelectVisualization above, alongside its edit-state reset); a freshly-completed
+  // run replaces the frames currently shown, which both resets the step position and
+  // drops any pending edit -- §2.1.2 requires Run to replace the local preview with what
+  // the backend actually parsed back, not leave the pre-Run edit displayed on top of new
+  // data.
   const [stepResetKey, setStepResetKey] = useState(selectedIndex);
   if (stepResetKey !== selectedIndex) {
     setStepResetKey(selectedIndex);
@@ -190,10 +463,34 @@ export default function VisualizationsSection({
   if (lastVisualizeResult !== visualize.result) {
     setLastVisualizeResult(visualize.result);
     setCurrentStep(0);
+    if (editedGraph !== null) setEditedGraph(null);
+    if (graphNodeOps.length > 0) setGraphNodeOps([]);
+    if (graphHasEdgeEdits) setGraphHasEdgeEdits(false);
+    if (editedRecursiveData !== null) setEditedRecursiveData(null);
+    if (editedCircuit !== null) setEditedCircuit(null);
   }
 
   const frameCount = liveFrames?.frames?.length ?? 1;
-  const currentFrame = liveFrames?.frames?.[currentStep] ?? null;
+  const fetchedFrame = liveFrames?.frames?.[currentStep] ?? null;
+  // T51 (#114): on the base frame (frames[0]) only, a pending local edit shows instead of
+  // the fetched frame -- the diagram's own preview of an edit that hasn't been sent to the
+  // backend yet (§2.1.2). Any other step is always playback-only, never edited (§2.3).
+  const isEditingStep0 = currentStep === 0 && isEditableType;
+  let currentFrame = fetchedFrame;
+  if (isEditingStep0 && fetchedFrame) {
+    if (isGraph && editedGraph) {
+      currentFrame = { nodes: editedGraph.nodes, links: editedGraph.links };
+    } else if (isRecursiveSet && editedRecursiveData !== null) {
+      currentFrame = { data: editedRecursiveData };
+    } else if (isQuantumCircuit && editedCircuit) {
+      currentFrame = { ...fetchedFrame, d3: { ...fetchedFrame.d3, ...editedCircuit } };
+    }
+  }
+
+  const hasPendingEdit =
+    (isGraph && (graphNodeOps.length > 0 || graphHasEdgeEdits)) ||
+    (isRecursiveSet && editedRecursiveData !== null) ||
+    (isQuantumCircuit && editedCircuit !== null);
 
   const visualizationName = selected?.name ?? "this visualization";
   let announcement = "";
@@ -297,7 +594,7 @@ export default function VisualizationsSection({
                 variant="outlined"
                 size="small"
                 disabled={!canRun || visualize.isRunning}
-                onClick={() => (onRunRequest ? onRunRequest() : handleRun())}
+                onClick={handleRunClick}
               >
                 Run
               </Button>
@@ -341,8 +638,24 @@ export default function VisualizationsSection({
                     instanceName={selected.name}
                     backendType={selected.backendType}
                     frame={currentFrame}
+                    editable={isEditingStep0}
+                    onGraphEdit={isEditingStep0 ? applyGraphEdit : undefined}
+                    onDataChange={isEditingStep0 ? handleDataChange : undefined}
+                    onCircuitEdit={isEditingStep0 ? applyCircuitEdit : undefined}
                   />
                 </Box>
+                {serializeError && (
+                  <Typography variant="body2" sx={{ color: "error.light" }}>
+                    {serializeError}
+                  </Typography>
+                )}
+                {hasPendingEdit && (
+                  <Typography variant="body2" sx={{ color: "warning.light" }}>
+                    {isQuantumCircuit
+                      ? "This diagram has unsaved edits. They preview here but can't be sent to Run yet for this visualization type."
+                      : "This diagram has unsaved edits. Press Run to send them to the backend."}
+                  </Typography>
+                )}
                 {instanceChangedSinceRun && (
                   <Typography variant="body2" sx={{ color: "warning.light" }}>
                     The instance has been edited since this ran. Run again to visualize the instance

--- a/components/detail/visualizations/GraphRenderer.js
+++ b/components/detail/visualizations/GraphRenderer.js
@@ -21,7 +21,36 @@
 // thrown away -- this is a *static* render (T48's own scope: "static (non-interactive)
 // rendering only"). No drag, no persistent simulation timer, no re-layout on a render
 // that didn't get a new frame.
+//
+// T51 (#114): structural editing (add/remove/relabel a node; add/remove an edge -- see
+// this component's own scope note below) is gated behind the `editable` prop. Rather than
+// embedding forms inside the SVG (no natural text-flow to hang a labelled input off, and
+// every hover target here is already a small circle), edit controls render in a separate
+// panel below the diagram -- a real, focusable, aria-labelled list of node/edge rows plus
+// add forms, the same keyboard-reachable pattern T52 established for
+// BooleanSatisfiabilityRenderer. The SVG itself stays exactly as before when not editable.
+//
+// Node/gate position dragging is out of scope everywhere in this contract
+// (INTERACTIVE_LAYER_DESIGN.md §2.3: no position field exists on any type this project's
+// force-directed layout is computed fresh, not read from data) -- nothing here changes
+// that.
+//
+// **Edge edits preview locally but are not sent to Run.** See
+// data/instanceSerializers.js's `serializeGraphInstance` doc comment for the full
+// reasoning: a node id is a simple literal token this project can locate in instance text
+// with confidence; an edge is not, across all 24 `graph` instances (DFA/NFA's weighted
+// transition symbols are the concrete counterexample). VisualizationsSection.js's own
+// summary to the user says this plainly when an edge edit is pending, rather than sending
+// a guess to the backend.
 
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import { forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation } from "d3-force";
 import { useId, useMemo, useState } from "react";
 import { getVisualizationColor } from "../../theme";
@@ -187,6 +216,199 @@ function GraphNodeMark({ node, highlighted, onEnter, onLeave }) {
   );
 }
 
+// Node/edge rows are keyed by `_key`, a stable identifier VisualizationsSection.js
+// assigns once when local edit state is created (see that file's header) and never
+// changes even when the node's own `id` is renamed -- keying by `node.id` directly would
+// remount (and drop focus from) the very text field the user is typing a rename into,
+// since React treats a changed `key` as a different element. `id` is still what's shown,
+// edited, and referenced by edges; `_key` only exists for this reason.
+function GraphEditPanel({ idPrefix, nodes, links, onGraphEdit }) {
+  const [newNodeId, setNewNodeId] = useState("");
+  const [newEdgeSource, setNewEdgeSource] = useState(nodes[0]?.id ?? "");
+  const [newEdgeTarget, setNewEdgeTarget] = useState(nodes[1]?.id ?? nodes[0]?.id ?? "");
+
+  const sourceValue = nodes.some((node) => node.id === newEdgeSource)
+    ? newEdgeSource
+    : (nodes[0]?.id ?? "");
+  const targetValue = nodes.some((node) => node.id === newEdgeTarget)
+    ? newEdgeTarget
+    : (nodes[1]?.id ?? nodes[0]?.id ?? "");
+
+  function handleAddNode(event) {
+    event.preventDefault();
+    const trimmed = newNodeId.trim();
+    if (!trimmed || nodes.some((node) => node.id === trimmed)) return;
+    onGraphEdit({ type: "addNode", id: trimmed });
+    setNewNodeId("");
+  }
+
+  function handleAddEdge(event) {
+    event.preventDefault();
+    if (!sourceValue || !targetValue) return;
+    onGraphEdit({ type: "addEdge", source: sourceValue, target: targetValue });
+  }
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        mt: 1,
+        p: 1.5,
+        border: "1px dashed",
+        borderColor: "divider",
+        borderRadius: 1,
+      }}
+    >
+      <Typography variant="overline" sx={{ color: "text.secondary" }}>
+        Edit nodes
+      </Typography>
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+        {nodes.map((node) => (
+          <Box key={node._key} sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
+            <Box
+              component="label"
+              htmlFor={`${idPrefix}-node-${node._key}`}
+              sx={{ display: "none" }}
+            >
+              Rename node {node.id}
+            </Box>
+            <TextField
+              id={`${idPrefix}-node-${node._key}`}
+              size="small"
+              variant="standard"
+              value={node.id}
+              onChange={(event) =>
+                onGraphEdit({ type: "renameNode", from: node.id, to: event.target.value })
+              }
+              sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
+              inputProps={{ "aria-label": `Rename node ${node.id}` }}
+            />
+            <IconButton
+              id={`${idPrefix}-node-${node._key}-remove`}
+              size="small"
+              aria-label={`Remove node ${node.id}`}
+              onClick={() => onGraphEdit({ type: "removeNode", id: node.id })}
+              sx={{ p: 0.375 }}
+            >
+              <CloseIcon sx={{ fontSize: "0.875rem" }} />
+            </IconButton>
+          </Box>
+        ))}
+      </Box>
+      <Box
+        component="form"
+        onSubmit={handleAddNode}
+        sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
+      >
+        <Box component="label" htmlFor={`${idPrefix}-add-node`} sx={{ display: "none" }}>
+          New node id
+        </Box>
+        <TextField
+          id={`${idPrefix}-add-node`}
+          size="small"
+          variant="outlined"
+          placeholder="new node id"
+          value={newNodeId}
+          onChange={(event) => setNewNodeId(event.target.value)}
+          sx={{ width: 120, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
+          inputProps={{ "aria-label": "New node id" }}
+        />
+        <IconButton
+          id={`${idPrefix}-add-node-submit`}
+          type="submit"
+          size="small"
+          disabled={!newNodeId.trim() || nodes.some((node) => node.id === newNodeId.trim())}
+          aria-label="Add node"
+          sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+        >
+          <AddIcon sx={{ fontSize: "1rem" }} />
+        </IconButton>
+      </Box>
+
+      <Typography variant="overline" sx={{ color: "text.secondary", mt: 1 }}>
+        Edit edges
+      </Typography>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+        {links.length === 0 && (
+          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+            No edges.
+          </Typography>
+        )}
+        {links.map((link) => (
+          <Box key={link._key} sx={{ display: "inline-flex", alignItems: "center", gap: 0.75 }}>
+            <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
+              {link.source} {link.directed ? "->" : "--"} {link.target}
+            </Typography>
+            <IconButton
+              id={`${idPrefix}-edge-${link._key}-remove`}
+              size="small"
+              aria-label={`Remove edge from ${link.source} to ${link.target}`}
+              onClick={() => onGraphEdit({ type: "removeEdge", id: link.id })}
+              sx={{ p: 0.375 }}
+            >
+              <CloseIcon sx={{ fontSize: "0.875rem" }} />
+            </IconButton>
+          </Box>
+        ))}
+      </Box>
+      {nodes.length > 0 && (
+        <Box
+          component="form"
+          onSubmit={handleAddEdge}
+          sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
+        >
+          <Select
+            id={`${idPrefix}-add-edge-source`}
+            size="small"
+            value={sourceValue}
+            onChange={(event) => setNewEdgeSource(event.target.value)}
+            inputProps={{ "aria-label": "New edge source node" }}
+            sx={{ minWidth: 72 }}
+          >
+            {nodes.map((node) => (
+              <MenuItem key={node._key} value={node.id}>
+                {node.id}
+              </MenuItem>
+            ))}
+          </Select>
+          <Typography variant="body2" aria-hidden="true">
+            {"->"}
+          </Typography>
+          <Select
+            id={`${idPrefix}-add-edge-target`}
+            size="small"
+            value={targetValue}
+            onChange={(event) => setNewEdgeTarget(event.target.value)}
+            inputProps={{ "aria-label": "New edge target node" }}
+            sx={{ minWidth: 72 }}
+          >
+            {nodes.map((node) => (
+              <MenuItem key={node._key} value={node.id}>
+                {node.id}
+              </MenuItem>
+            ))}
+          </Select>
+          <IconButton
+            id={`${idPrefix}-add-edge-submit`}
+            type="submit"
+            size="small"
+            aria-label="Add edge"
+            sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+          >
+            <AddIcon sx={{ fontSize: "1rem" }} />
+          </IconButton>
+        </Box>
+      )}
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        Node changes are sent to Run. Edge changes preview here but can&apos;t be sent to Run yet
+        for this visualization type.
+      </Typography>
+    </Box>
+  );
+}
+
 /**
  * @param {Object} props
  * @param {string} props.idPrefix Prefixes every id this component renders, so two
@@ -194,8 +416,21 @@ function GraphNodeMark({ node, highlighted, onEnter, onLeave }) {
  * @param {string} [props.instanceName] Human-readable visualization name, folded into
  *   the accessible summary when given.
  * @param {{nodes: Array, links: Array}} props.frame One already-validated `graph` frame.
+ * @param {boolean} [props.editable] T51 (#114): true only when this frame is the base
+ *   frame of a visualization the caller has decided is editable right now -- this
+ *   component does not re-derive that gate.
+ * @param {(op: Object) => void} [props.onGraphEdit] Called with one edit descriptor per
+ *   structural edit -- `{type: "addNode", id}`, `{type: "removeNode", id}`,
+ *   `{type: "renameNode", from, to}`, `{type: "addEdge", source, target}`, or
+ *   `{type: "removeEdge", id}`. Required when `editable` is true.
  */
-export default function GraphRenderer({ idPrefix, instanceName, frame }) {
+export default function GraphRenderer({
+  idPrefix,
+  instanceName,
+  frame,
+  editable = false,
+  onGraphEdit,
+}) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
   const [hoveredNodeId, setHoveredNodeId] = useState(null);
@@ -208,7 +443,7 @@ export default function GraphRenderer({ idPrefix, instanceName, frame }) {
   const summaryBody = `graph with ${nodeCount} node${nodeCount === 1 ? "" : "s"} and ${linkCount} link${linkCount === 1 ? "" : "s"}`;
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
 
-  return (
+  const svg = (
     <svg
       id={scopeId}
       role="img"
@@ -257,5 +492,21 @@ export default function GraphRenderer({ idPrefix, instanceName, frame }) {
         ))}
       </g>
     </svg>
+  );
+
+  if (!editable) {
+    return svg;
+  }
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <Box sx={{ flex: 1, minHeight: 0 }}>{svg}</Box>
+      <GraphEditPanel
+        idPrefix={scopeId}
+        nodes={frame.nodes}
+        links={frame.links}
+        onGraphEdit={onGraphEdit}
+      />
+    </Box>
   );
 }

--- a/components/detail/visualizations/QuantumCircuitRenderer.js
+++ b/components/detail/visualizations/QuantumCircuitRenderer.js
@@ -19,8 +19,33 @@
 // below the diagram) is out of scope here -- §3.2's contract covers `d3`'s
 // wires/gates/overlays, not `metadata`'s free-form contents, and T50's own
 // scope is rendering the frame, not a metadata inspector.
+//
+// --- T51 (#114): editing UI ships; the diagram-to-text serializer does not -------------
+// Add/remove qubit and add/remove/relabel gate are wired here, gated behind `editable`,
+// and update the local preview immediately (INTERACTIVE_LAYER_DESIGN.md §2.1.2) exactly
+// like the `graph` and `recursiveSet` editors on this same task. What's deliberately
+// missing is a serializer to send an edit through Run: T46 (#109) verified SPADE
+// round-tripping against Clique and DFA, a set-of-nodes-plus-edges grammar and an
+// automaton grammar -- neither is a gate-sequence grammar, and nothing this project has
+// checked says whether a quantum-circuit instance's text encodes gates by literal type
+// tokens, by position, or some other shape entirely, or whether gate `id` (which this
+// contract's payload appears to synthesize during parsing, unlike a graph node's `id`,
+// which is plausibly the literal grammar token) has any textual counterpart at all.
+// Writing a serializer against an unverified guess risks producing instance text that
+// looks plausible and silently means something else -- worse than leaving the gap
+// visible. VisualizationsSection.js declines to serialize a pending `quantumCircuit`
+// edit and says why, rather than guessing. See data/instanceSerializers.js's own header
+// for the parallel note. This is this task's one explicitly left-open item -- see its
+// handback summary.
 
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import { useId, useMemo, useState } from "react";
 import { getVisualizationColor } from "../../theme";
 
@@ -175,6 +200,200 @@ function OverlayBand({ idPrefix, overlay, overlayIndex, x0, x1, yMin, yMax }) {
   );
 }
 
+// `qubits` is `d3.qubits` straight from the contract -- a plain `string[]` (§3.2), not
+// objects, unlike `graph`'s nodes. Rows are keyed by array index rather than value: a
+// qubit's position in the array is stable across a rename (renaming mutates the string at
+// the same index, it doesn't reorder), so indexing avoids the same remount-during-rename
+// problem GraphEditPanel solves with a synthetic `_key` -- without needing one here, since
+// the contract gives this type no per-qubit object to hang one off. `gates` don't need
+// this treatment at all: `gate.id` (§3.2) is independent of `gate.type`, the field being
+// relabeled, so it's already a stable key on its own.
+function QuantumCircuitEditPanel({ idPrefix, qubits, gates, onCircuitEdit }) {
+  const [newQubitId, setNewQubitId] = useState("");
+  const [newGateType, setNewGateType] = useState("");
+  const [newGateTarget, setNewGateTarget] = useState(qubits[0] ?? "");
+  const targetValue = qubits.includes(newGateTarget) ? newGateTarget : (qubits[0] ?? "");
+
+  function handleAddQubit(event) {
+    event.preventDefault();
+    const trimmed = newQubitId.trim();
+    if (!trimmed || qubits.includes(trimmed)) return;
+    onCircuitEdit({ type: "addQubit", id: trimmed });
+    setNewQubitId("");
+  }
+
+  function handleAddGate(event) {
+    event.preventDefault();
+    const trimmed = newGateType.trim();
+    if (!trimmed || !targetValue) return;
+    onCircuitEdit({ type: "addGate", gateType: trimmed, target: targetValue });
+    setNewGateType("");
+  }
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+        mt: 1,
+        p: 1.5,
+        border: "1px dashed",
+        borderColor: "divider",
+        borderRadius: 1,
+      }}
+    >
+      <Typography variant="overline" sx={{ color: "text.secondary" }}>
+        Edit qubits
+      </Typography>
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+        {qubits.map((qubitId, index) => (
+          <Box key={index} sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
+            <Box component="label" htmlFor={`${idPrefix}-qubit-${index}`} sx={{ display: "none" }}>
+              Rename qubit {qubitId}
+            </Box>
+            <TextField
+              id={`${idPrefix}-qubit-${index}`}
+              size="small"
+              variant="standard"
+              value={qubitId}
+              onChange={(event) =>
+                onCircuitEdit({ type: "renameQubit", from: qubitId, to: event.target.value })
+              }
+              sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
+              inputProps={{ "aria-label": `Rename qubit ${qubitId}` }}
+            />
+            <IconButton
+              id={`${idPrefix}-qubit-${index}-remove`}
+              size="small"
+              aria-label={`Remove qubit ${qubitId}`}
+              onClick={() => onCircuitEdit({ type: "removeQubit", id: qubitId })}
+              sx={{ p: 0.375 }}
+            >
+              <CloseIcon sx={{ fontSize: "0.875rem" }} />
+            </IconButton>
+          </Box>
+        ))}
+      </Box>
+      <Box
+        component="form"
+        onSubmit={handleAddQubit}
+        sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
+      >
+        <Box component="label" htmlFor={`${idPrefix}-add-qubit`} sx={{ display: "none" }}>
+          New qubit id
+        </Box>
+        <TextField
+          id={`${idPrefix}-add-qubit`}
+          size="small"
+          variant="outlined"
+          placeholder="new qubit id"
+          value={newQubitId}
+          onChange={(event) => setNewQubitId(event.target.value)}
+          sx={{ width: 120, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
+          inputProps={{ "aria-label": "New qubit id" }}
+        />
+        <IconButton
+          id={`${idPrefix}-add-qubit-submit`}
+          type="submit"
+          size="small"
+          disabled={!newQubitId.trim() || qubits.includes(newQubitId.trim())}
+          aria-label="Add qubit"
+          sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+        >
+          <AddIcon sx={{ fontSize: "1rem" }} />
+        </IconButton>
+      </Box>
+
+      <Typography variant="overline" sx={{ color: "text.secondary", mt: 1 }}>
+        Edit gates
+      </Typography>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+        {gates.length === 0 && (
+          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+            No gates.
+          </Typography>
+        )}
+        {gates.map((gate) => (
+          <Box key={gate.id} sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
+            <Box component="label" htmlFor={`${idPrefix}-gate-${gate.id}`} sx={{ display: "none" }}>
+              Relabel gate on {gate.targets?.join(", ")}
+            </Box>
+            <TextField
+              id={`${idPrefix}-gate-${gate.id}`}
+              size="small"
+              variant="standard"
+              value={gate.type ?? ""}
+              onChange={(event) =>
+                onCircuitEdit({ type: "relabelGate", id: gate.id, gateType: event.target.value })
+              }
+              sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
+              inputProps={{ "aria-label": `Relabel gate on ${gate.targets?.join(", ")}` }}
+            />
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              on {gate.targets?.join(", ")}
+            </Typography>
+            <IconButton
+              id={`${idPrefix}-gate-${gate.id}-remove`}
+              size="small"
+              aria-label={`Remove gate on ${gate.targets?.join(", ")}`}
+              onClick={() => onCircuitEdit({ type: "removeGate", id: gate.id })}
+              sx={{ p: 0.375 }}
+            >
+              <CloseIcon sx={{ fontSize: "0.875rem" }} />
+            </IconButton>
+          </Box>
+        ))}
+      </Box>
+      {qubits.length > 0 && (
+        <Box
+          component="form"
+          onSubmit={handleAddGate}
+          sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
+        >
+          <TextField
+            id={`${idPrefix}-add-gate-type`}
+            size="small"
+            variant="outlined"
+            placeholder="gate type"
+            value={newGateType}
+            onChange={(event) => setNewGateType(event.target.value)}
+            sx={{ width: 100, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
+            inputProps={{ "aria-label": "New gate type" }}
+          />
+          <Select
+            id={`${idPrefix}-add-gate-target`}
+            size="small"
+            value={targetValue}
+            onChange={(event) => setNewGateTarget(event.target.value)}
+            inputProps={{ "aria-label": "New gate target qubit" }}
+            sx={{ minWidth: 72 }}
+          >
+            {qubits.map((qubitId) => (
+              <MenuItem key={qubitId} value={qubitId}>
+                {qubitId}
+              </MenuItem>
+            ))}
+          </Select>
+          <IconButton
+            id={`${idPrefix}-add-gate-submit`}
+            type="submit"
+            size="small"
+            disabled={!newGateType.trim()}
+            aria-label="Add gate"
+            sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
+          >
+            <AddIcon sx={{ fontSize: "1rem" }} />
+          </IconButton>
+        </Box>
+      )}
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        These changes preview here, but can&apos;t be sent to Run yet for this visualization type.
+      </Typography>
+    </Box>
+  );
+}
+
 /**
  * @param {Object} props
  * @param {string} props.idPrefix Prefixes every id this component renders,
@@ -185,8 +404,23 @@ function OverlayBand({ idPrefix, overlay, overlayIndex, x0, x1, yMin, yMax }) {
  * @param {{d3: Object}} props.frame One already-validated `quantumCircuit`
  *   frame (the `d3` arm -- resolveVisualizationType only reaches this
  *   renderer when `format === 1` and `d3` is present, per §3.2).
+ * @param {boolean} [props.editable] T51 (#114): true only when this frame is
+ *   the base frame of a visualization the caller has decided is editable
+ *   right now. See this file's header for why edits here preview locally
+ *   but are never sent to Run.
+ * @param {(op: Object) => void} [props.onCircuitEdit] Called with one edit
+ *   descriptor per structural edit -- `{type: "addQubit", id}`,
+ *   `{type: "removeQubit", id}`, `{type: "renameQubit", from, to}`,
+ *   `{type: "addGate", gateType, target}`, `{type: "removeGate", id}`, or
+ *   `{type: "relabelGate", id, gateType}`. Required when `editable` is true.
  */
-export default function QuantumCircuitRenderer({ idPrefix, instanceName, frame }) {
+export default function QuantumCircuitRenderer({
+  idPrefix,
+  instanceName,
+  frame,
+  editable = false,
+  onCircuitEdit,
+}) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
   const [hoveredGateId, setHoveredGateId] = useState(null);
@@ -199,7 +433,7 @@ export default function QuantumCircuitRenderer({ idPrefix, instanceName, frame }
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
 
   return (
-    <Box sx={{ width: "100%", height: "100%", overflow: "auto" }}>
+    <Box sx={{ width: "100%", height: editable ? "auto" : "100%", overflow: "auto" }}>
       <svg
         id={scopeId}
         role="img"
@@ -290,6 +524,14 @@ export default function QuantumCircuitRenderer({ idPrefix, instanceName, frame }
           );
         })}
       </svg>
+      {editable && (
+        <QuantumCircuitEditPanel
+          idPrefix={scopeId}
+          qubits={frame.d3.qubits}
+          gates={frame.d3.gates}
+          onCircuitEdit={onCircuitEdit}
+        />
+      )}
     </Box>
   );
 }

--- a/components/detail/visualizations/RecursiveSetRenderer.js
+++ b/components/detail/visualizations/RecursiveSetRenderer.js
@@ -16,10 +16,47 @@
 // `isValue: true` and no `value`, or `isValue: false` and no `list`,
 // degrades to a `PlaceholderMark` at that node instead of failing the whole
 // render, exactly what the contract asks for.
+//
+// T51 (#114): editing (add/remove/relabel a leaf, add/remove a nested
+// group, toggle a group ordered/unordered) is gated behind the `editable`
+// prop, exactly like T52 added for `booleanSatisfiability`. The whole tree
+// is addressed by path (an array of list indices from the root) so a parent
+// can remove one of its own children without that child needing to know its
+// own position -- `data/instanceSerializers.js`'s
+// `serializeRecursiveSetInstance` consumes the edited tree directly, with no
+// location step against the original text needed at all (see that file's
+// header for why this is the safest of the three wave-2 editable types).
+// Every edit control here is a real, focusable, aria-labelled button or
+// text input -- no drag, no right-click.
 
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
+import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import Box from "@mui/material/Box";
-import { Fragment, useId } from "react";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import { Fragment, useId, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+
+let editIdCounter = 0;
+function nextEditId(prefix) {
+  editIdCounter += 1;
+  return `${prefix}-${editIdCounter}`;
+}
+
+// Applies `updater` to the node reached by following `path` (a list of child indices)
+// from `root`, returning a new tree with every ancestor along the way shallow-cloned.
+function updateAtPath(root, path, updater) {
+  if (path.length === 0) {
+    return updater(root);
+  }
+  const [index, ...rest] = path;
+  const list = root.list ?? [];
+  return {
+    ...root,
+    list: list.map((child, i) => (i === index ? updateAtPath(child, rest, updater) : child)),
+  };
+}
 
 function leafCount(node) {
   if (!node || typeof node !== "object") return 0;
@@ -52,7 +89,71 @@ function Comma() {
   );
 }
 
-function SetNode({ id, node }) {
+// Keyboard-reachable "add a leaf" affordance for one container node -- a real text field
+// plus a submit button, matching T52's AddLiteralForm precedent.
+function AddLeafForm({ idPrefix, onAdd }) {
+  const [value, setValue] = useState("");
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onAdd(trimmed);
+    setValue("");
+  }
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.25, mx: 0.5 }}
+    >
+      <Box component="label" htmlFor={idPrefix} sx={{ display: "none" }}>
+        New element value
+      </Box>
+      <TextField
+        id={idPrefix}
+        size="small"
+        variant="standard"
+        placeholder="value"
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        sx={{ width: 60, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
+        inputProps={{ "aria-label": "New element value" }}
+      />
+      <IconButton
+        id={`${idPrefix}-submit`}
+        type="submit"
+        size="small"
+        disabled={!value.trim()}
+        aria-label="Add element"
+        sx={{ p: 0.375 }}
+      >
+        <AddIcon sx={{ fontSize: "0.875rem" }} />
+      </IconButton>
+    </Box>
+  );
+}
+
+/**
+ * @param {Object} props
+ * @param {string} props.id
+ * @param {Object} props.node
+ * @param {number[]} [props.path] This node's position from the tree root, as a list of
+ *   child indices -- `onEdit`'s updater and `onRemoveSelf` both address this node by path
+ *   rather than by object identity, so a parent can drop or replace a child without that
+ *   child needing to know its own position independently.
+ * @param {boolean} [props.editable] T51 (#114): adds add/remove/relabel/toggle-ordered
+ *   controls when true. Only ever true for the base frame (frames[0]) -- the caller owns
+ *   that gate.
+ * @param {(updater: (data: Object) => Object) => void} [props.onEdit] Called with a
+ *   `(currentData) => nextData` updater rooted at the WHOLE tree (not just this node) --
+ *   every control below composes its own local mutation with `updateAtPath(data, path,
+ *   ...)` before calling this.
+ * @param {() => void} [props.onRemoveSelf] Removes this node from its parent's `list`.
+ *   Omitted at the tree root, which can't remove itself.
+ */
+function SetNode({ id, node, path = [], editable = false, onEdit, onRemoveSelf }) {
   if (!node || typeof node !== "object") {
     return <PlaceholderMark id={id} />;
   }
@@ -61,28 +162,116 @@ function SetNode({ id, node }) {
     if (typeof node.value !== "string") {
       return <PlaceholderMark id={id} />;
     }
+    if (!editable) {
+      return (
+        <Box
+          id={id}
+          component="span"
+          sx={{
+            fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
+            fontSize: "0.9375rem",
+            fontWeight: 600,
+            color: getVisualizationColor(node.color),
+          }}
+        >
+          {node.value}
+        </Box>
+      );
+    }
     return (
       <Box
         id={id}
         component="span"
-        sx={{
-          fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
-          fontSize: "0.9375rem",
-          fontWeight: 600,
-          color: getVisualizationColor(node.color),
-        }}
+        sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}
       >
-        {node.value}
+        <Box component="label" htmlFor={`${id}-value`} sx={{ display: "none" }}>
+          Element value
+        </Box>
+        <TextField
+          id={`${id}-value`}
+          size="small"
+          variant="standard"
+          value={node.value}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            onEdit((data) =>
+              updateAtPath(data, path, (target) => ({ ...target, value: nextValue })),
+            );
+          }}
+          sx={{
+            width: 64,
+            "& input": {
+              fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
+              fontSize: "0.9375rem",
+              fontWeight: 600,
+              py: 0.25,
+            },
+          }}
+          inputProps={{ "aria-label": `Rename element ${node.value}` }}
+        />
+        {onRemoveSelf && (
+          <IconButton
+            id={`${id}-remove`}
+            size="small"
+            aria-label={`Remove ${node.value}`}
+            onClick={onRemoveSelf}
+            sx={{ p: 0.375 }}
+          >
+            <CloseIcon sx={{ fontSize: "0.875rem" }} />
+          </IconButton>
+        )}
       </Box>
     );
   }
 
   const open = node.isOrdered ? "(" : "{";
   const close = node.isOrdered ? ")" : "}";
-  if (!Array.isArray(node.list)) {
+  const list = Array.isArray(node.list) ? node.list : [];
+
+  function handleAddLeaf(value) {
+    onEdit((data) =>
+      updateAtPath(data, path, (target) => ({
+        ...target,
+        list: [
+          ...(target.list ?? []),
+          { id: nextEditId("leaf"), isValue: true, isOrdered: false, value, color: "" },
+        ],
+      })),
+    );
+  }
+
+  function handleAddGroup() {
+    onEdit((data) =>
+      updateAtPath(data, path, (target) => ({
+        ...target,
+        list: [
+          ...(target.list ?? []),
+          { id: nextEditId("group"), isValue: false, isOrdered: false, list: [] },
+        ],
+      })),
+    );
+  }
+
+  function handleToggleOrdered() {
+    onEdit((data) =>
+      updateAtPath(data, path, (target) => ({ ...target, isOrdered: !target.isOrdered })),
+    );
+  }
+
+  if (!editable) {
     return (
-      <Box id={id} component="span">
+      <Box
+        id={id}
+        component="span"
+        sx={{ display: "inline-flex", alignItems: "center", flexWrap: "wrap" }}
+      >
         <Bracket>{open}</Bracket>
+        {list.map((child, index) => (
+          <Fragment key={child?.id ?? index}>
+            {index > 0 && <Comma />}
+            <SetNode id={`${id}-${index}`} node={child} />
+          </Fragment>
+        ))}
         <Bracket>{close}</Bracket>
       </Box>
     );
@@ -92,16 +281,76 @@ function SetNode({ id, node }) {
     <Box
       id={id}
       component="span"
-      sx={{ display: "inline-flex", alignItems: "center", flexWrap: "wrap" }}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        flexWrap: "wrap",
+        gap: 0.25,
+        border: "1px dashed",
+        borderColor: "divider",
+        borderRadius: 1,
+        px: 0.5,
+      }}
     >
+      <IconButton
+        id={`${id}-toggle-ordered`}
+        size="small"
+        aria-label={
+          node.isOrdered
+            ? "Make this group unordered (braces)"
+            : "Make this group ordered (parentheses)"
+        }
+        aria-pressed={node.isOrdered}
+        onClick={handleToggleOrdered}
+        sx={{ p: 0.375 }}
+      >
+        <SwapHorizIcon sx={{ fontSize: "0.875rem" }} />
+      </IconButton>
       <Bracket>{open}</Bracket>
-      {node.list.map((child, index) => (
+      {list.map((child, index) => (
         <Fragment key={child?.id ?? index}>
           {index > 0 && <Comma />}
-          <SetNode id={`${id}-${index}`} node={child} />
+          <SetNode
+            id={`${id}-${index}`}
+            node={child}
+            path={[...path, index]}
+            editable
+            onEdit={onEdit}
+            onRemoveSelf={() =>
+              onEdit((data) =>
+                updateAtPath(data, path, (target) => ({
+                  ...target,
+                  list: (target.list ?? []).filter(
+                    (_candidate, candidateIndex) => candidateIndex !== index,
+                  ),
+                })),
+              )
+            }
+          />
         </Fragment>
       ))}
       <Bracket>{close}</Bracket>
+      <AddLeafForm idPrefix={`${id}-add-leaf`} onAdd={handleAddLeaf} />
+      <IconButton
+        id={`${id}-add-group`}
+        size="small"
+        aria-label="Add nested group"
+        onClick={handleAddGroup}
+        sx={{ p: 0.375 }}
+      >
+        <AddIcon sx={{ fontSize: "0.875rem" }} />
+      </IconButton>
+      {onRemoveSelf && (
+        <IconButton
+          id={`${id}-remove`}
+          size="small"
+          aria-label="Remove this group"
+          onClick={onRemoveSelf}
+          sx={{ p: 0.375 }}
+        >
+          <CloseIcon sx={{ fontSize: "0.875rem" }} />
+        </IconButton>
+      )}
     </Box>
   );
 }
@@ -115,8 +364,20 @@ function SetNode({ id, node }) {
  *   folded into the accessible summary when given.
  * @param {{data: Object}} props.frame One already-validated `recursiveSet`
  *   frame.
+ * @param {boolean} [props.editable] T51 (#114): true only when this frame is
+ *   the base frame of a visualization the caller has decided is editable
+ *   right now -- this component does not re-derive that gate.
+ * @param {(updater: (data: Object) => Object) => void} [props.onDataChange]
+ *   Called with a `(currentData) => nextData` updater on every structural
+ *   edit. Required when `editable` is true.
  */
-export default function RecursiveSetRenderer({ idPrefix, instanceName, frame }) {
+export default function RecursiveSetRenderer({
+  idPrefix,
+  instanceName,
+  frame,
+  editable = false,
+  onDataChange,
+}) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
 
@@ -139,7 +400,7 @@ export default function RecursiveSetRenderer({ idPrefix, instanceName, frame }) 
         boxSizing: "border-box",
       }}
     >
-      <SetNode id={`${scopeId}-root`} node={frame.data} />
+      <SetNode id={`${scopeId}-root`} node={frame.data} editable={editable} onEdit={onDataChange} />
     </Box>
   );
 }

--- a/components/detail/visualizations/VisualizationCanvas.js
+++ b/components/detail/visualizations/VisualizationCanvas.js
@@ -78,8 +78,27 @@ function CannotRender({ idPrefix, reason, violations }) {
  *   "GraphD3") -- `Navigation/Batch/allVisualizationTypes`, falling back to `allInfo`.
  * @param {Object|null} [props.frame] One frame (`frames[currentStep]`), or null/undefined
  *   when there's nothing to show yet (not yet run, or an empty `frames[]`).
+ * @param {boolean} [props.editable] T51 (#114): forwarded straight through to whichever
+ *   renderer is dispatched to. Only `GraphRenderer`, `RecursiveSetRenderer` and
+ *   `QuantumCircuitRenderer` read it today; the other renderers simply ignore an unused
+ *   prop, the same way they already ignore `instanceName` when they have no use for it.
+ * @param {(op: Object) => void} [props.onGraphEdit] Forwarded straight through -- see
+ *   `GraphRenderer`'s own doc comment for the edit-descriptor shape.
+ * @param {(updater: (data: Object) => Object) => void} [props.onDataChange] Forwarded
+ *   straight through -- see `RecursiveSetRenderer`'s own doc comment.
+ * @param {(op: Object) => void} [props.onCircuitEdit] Forwarded straight through -- see
+ *   `QuantumCircuitRenderer`'s own doc comment for the edit-descriptor shape.
  */
-export default function VisualizationCanvas({ idPrefix, instanceName, backendType, frame }) {
+export default function VisualizationCanvas({
+  idPrefix,
+  instanceName,
+  backendType,
+  frame,
+  editable,
+  onGraphEdit,
+  onDataChange,
+  onCircuitEdit,
+}) {
   const universalType = resolveVisualizationType(backendType, frame);
   const Renderer = universalType ? RENDERERS[universalType] : null;
   const { valid, violations } =
@@ -122,5 +141,15 @@ export default function VisualizationCanvas({ idPrefix, instanceName, backendTyp
     );
   }
 
-  return <Renderer idPrefix={idPrefix} instanceName={instanceName} frame={frame} />;
+  return (
+    <Renderer
+      idPrefix={idPrefix}
+      instanceName={instanceName}
+      frame={frame}
+      editable={editable}
+      onGraphEdit={onGraphEdit}
+      onDataChange={onDataChange}
+      onCircuitEdit={onCircuitEdit}
+    />
+  );
 }

--- a/data/instanceSerializers.js
+++ b/data/instanceSerializers.js
@@ -1,0 +1,145 @@
+// data/instanceSerializers.js
+//
+// T51 (#114) -- diagram-to-text serializers for the wave-2 editable universal
+// visualization types (ai_documentation/INTERACTIVE_LAYER_DESIGN.md §2.2, §5 "What this
+// hands off"): `graph` and `recursiveSet`. Both build on the generic bracket-tree module
+// in data/spadeInstanceText.js -- see that file's header for why this project's own
+// deviation from T46's grammar-string-driven recommendation is the right call given what
+// this frontend actually has access to.
+//
+// `quantumCircuit` is deliberately NOT in this file. See
+// components/detail/visualizations/QuantumCircuitRenderer.js's own header for why: T46
+// verified SPADE round-tripping against Clique (a set-of-nodes-plus-edges grammar) and DFA
+// (an automaton grammar), neither of which is a gate-sequence grammar, so nothing anyone
+// has actually checked says what a quantum-circuit instance's textual shape is -- whether
+// gate identifiers appear as literal leaf tokens the way node ids do, whether gate order is
+// encoded positionally or by an explicit time field, none of it. Guessing a serializer here
+// risks writing text that looks plausible and is silently wrong, with no way to verify it
+// against a live backend from this vantage point. Editing UI for `quantumCircuit` still
+// ships (local preview only, per INTERACTIVE_LAYER_DESIGN.md §2.1.2) -- only the
+// diagram-to-text step is left undone, recorded as this task's one open item rather than
+// guessed at.
+//
+// `booleanSatisfiability` (T52/#115) has its own serializer in a sibling file on that
+// task's branch -- not duplicated here, since the two tasks were built independently
+// (T52 has no dependency on T51, per INTERACTIVE_LAYER_DESIGN.md's staging table) and are
+// expected to merge as two separate reviewed changes.
+
+import {
+  addLeafToMatchingSet,
+  findExactLeafSetNode,
+  parseInstanceText,
+  removeLeafEverywhere,
+  renameLeafEverywhere,
+  serializeInstanceText,
+} from "./spadeInstanceText";
+
+/**
+ * Replays an ordered log of node-level edits (add/remove/rename -- never edge edits, see
+ * `serializeGraphInstance`'s own doc comment for why those are out of scope) against the
+ * current instance text, and returns the resulting text.
+ *
+ * @param {string} originalInstanceText The shared instance text as it stood when the base
+ *   frame being edited was fetched -- i.e. text SPADE is already known to parse
+ *   successfully, since it's what produced that frame.
+ * @param {string[]} baseNodeIds The `graph` frame's node ids as of that same fetch, before
+ *   any of `nodeOps` were applied -- the "known identity" this module's location step
+ *   matches against (see data/spadeInstanceText.js's header).
+ * @param {Array<{type: "add"|"remove"|"rename", id?: string, from?: string, to?: string}>} nodeOps
+ *   Ordered edit log: `{type: "add", id}`, `{type: "remove", id}`, or
+ *   `{type: "rename", from, to}`. Edge edits never appear here -- see below.
+ * @returns {{instanceText: string} | {error: string}} `error` when the current instance
+ *   text can't be parsed under the generic bracket grammar at all, or when an `add` can't
+ *   find a matching node-id set to add into (both real, surfaceable failures, not silent
+ *   corruption).
+ *
+ * --- Why this only replays node ops, never edge ops -----------------------------------
+ * A node id ("1", "2", ...) is a short literal token with no internal structure -- it
+ * either appears as a leaf somewhere in the parsed tree or it doesn't, which is exactly
+ * what `findExactLeafSetNode`/`removeLeafEverywhere`/`renameLeafEverywhere` need. An edge
+ * is not that simple across the 24 `graph` instances: T40's own finding (recorded in
+ * GraphRenderer.js's header) is that some instances encode more than a bare pair per edge
+ * -- DFA/NFA's `weight` field carries a transition symbol, and the visible link with
+ * `weight: "a,b"` plausibly collapses more than one underlying grammar-level transition
+ * into one visual edge, not a single two-element tuple this module could locate and edit
+ * safely. Rather than guess at which of the 24 instances are "safe" bare pairs and which
+ * aren't (unverifiable without a live backend from here), edge structural edits preview
+ * locally (§2.1.2) but are not sent through Run -- VisualizationsSection.js's own summary
+ * to the user says so plainly rather than silently dropping them.
+ *
+ * --- A narrower residual risk in node removal, worth stating rather than hiding --------
+ * `removeLeafEverywhere`'s referential-integrity cascade recognizes a plain two-leaf pair
+ * (an ordinary edge endpoint) and drops it whole rather than leaving a dangling
+ * one-element remnant. A relation with *more* than two positions -- concretely, an
+ * automaton's `(from, symbol, to)` transition triple -- isn't recognized by that rule, so
+ * removing a node that appears inside one leaves a malformed two-element remnant behind
+ * instead of dropping the whole transition. This wasn't discoverable without a live
+ * instance to inspect (see data/spadeInstanceText.js's header on why grammar access isn't
+ * available here at all), so it's recorded here rather than silently risked: node editing
+ * is solid for plain node/pair-edge grammars (the majority of the 24 `graph` instances),
+ * and carries this one known sharp edge for automaton-shaped ones (DFA/NFA) specifically.
+ */
+export function serializeGraphInstance(originalInstanceText, baseNodeIds, nodeOps) {
+  let tree;
+  try {
+    tree = parseInstanceText(originalInstanceText);
+  } catch (parseError) {
+    return {
+      error: `Couldn't parse the current instance text to apply node edits (${parseError.message}).`,
+    };
+  }
+
+  let currentIds = [...baseNodeIds];
+  for (const op of nodeOps) {
+    if (op.type === "rename") {
+      tree = renameLeafEverywhere(tree, op.from, op.to);
+      currentIds = currentIds.map((id) => (id === op.from ? op.to : id));
+    } else if (op.type === "remove") {
+      // The located node-id set is passed as the protected subtree so it always shrinks
+      // by one, never gets collapsed by the pair-removal heuristic that also runs in this
+      // same pass -- see removeLeafEverywhere's own doc comment for why a plain two-node
+      // graph would otherwise be indistinguishable from a two-leaf edge pair.
+      const protectedNode = findExactLeafSetNode(tree, currentIds);
+      tree = removeLeafEverywhere(tree, op.id, protectedNode);
+      currentIds = currentIds.filter((id) => id !== op.id);
+    } else if (op.type === "add") {
+      const next = addLeafToMatchingSet(tree, currentIds, op.id);
+      if (next === tree) {
+        return {
+          error: `Couldn't find where to add node "${op.id}" in this problem's instance text.`,
+        };
+      }
+      tree = next;
+      currentIds = [...currentIds, op.id];
+    }
+  }
+
+  return { instanceText: serializeInstanceText(tree) };
+}
+
+/**
+ * Converts an edited `recursiveSet` frame's tree (VISUALIZATION_TYPE_CONTRACTS.md §3.4)
+ * directly into instance text.
+ *
+ * Unlike `graph`, this needs no location step against the original instance text at all:
+ * §3.4's contract is that the frame's entire `data` field *is* the instance's whole
+ * structure (ExactCover/HittingSet/Partition/SetCover's declared instances carry nothing
+ * else) -- so the edited tree can be serialized standalone and used as the complete new
+ * instance text, the safest and most direct of the three wave-2 types.
+ *
+ * @param {{id: string, isOrdered: boolean, isValue: boolean, value?: string, list?: Array}} data
+ *   The edited `recursiveSet` frame's `data` field.
+ * @returns {string} instance text.
+ */
+export function serializeRecursiveSetInstance(data) {
+  function toBracketNode(node) {
+    if (node.isValue) {
+      return { type: "leaf", value: node.value ?? "" };
+    }
+    return {
+      type: node.isOrdered ? "tuple" : "set",
+      children: (node.list ?? []).map(toBracketNode),
+    };
+  }
+  return serializeInstanceText(toBracketNode(data));
+}

--- a/data/spadeInstanceText.js
+++ b/data/spadeInstanceText.js
@@ -1,0 +1,296 @@
+// data/spadeInstanceText.js
+//
+// T51 (#114) -- a generic parser/serializer for SPADE-shaped instance text, used to
+// round-trip a diagram edit back to instance text for the `graph` and `recursiveSet`
+// universal types (ai_documentation/VISUALIZATION_TYPE_CONTRACTS.md §3.1/§3.4).
+//
+// --- Why this exists, and why it isn't grammar-driven (a real deviation from T46's own
+// --- recommendation, recorded here rather than silently substituted) ----------------
+//
+// T46 (#109, ai_documentation/INTERACTIVE_LAYER_DESIGN.md §2.2) verified -- by decompiling
+// SPADE's compiled `DiscreteParser.dll` in a throwaway .NET console app -- that SPADE
+// instances round-trip through `UtilCollection.ToString()` exactly, and that `Add()`-based
+// mutation reparses successfully. Its recommendation for an implementation was to "parse
+// each InstanceGrammar's tuple shape once ... to get the reassembly template" from each
+// problem's own declared grammar string (e.g. Clique's `"{((N,E),K) | ...}"`).
+//
+// That recommendation assumes frontend access to `InstanceGrammar`. Checked directly
+// against this app's own API surface before writing this file: none of the six batch
+// endpoints this app calls (`lib/redux/index.js`) -- `allProblems`, `allInfo`,
+// `allSolvers`, `allVerifiers`, `allVisualizations`, `allVisualizationTypes` -- return a
+// grammar string anywhere. `allInfo`'s closest field is `instanceFormat`, and per
+// `hooks/useProblemDetail.js`'s own header, that's prose with an embedded example, not a
+// machine grammar. SPADE itself is a compiled C# library the browser cannot call. So the
+// grammar-string-driven design T46 sketched (correct for a backend implementation, which
+// does have both) is not buildable here.
+//
+// The alternative this file implements instead: SPADE's own bracket convention -- `{}` for
+// an unordered `HashSet`, `()` for an ordered `List`, comma-separated, confirmed by T46's
+// own findings -- is *self-describing text*, independent of the grammar string. So rather
+// than generating instance text from a grammar template, this module parses the CURRENT
+// instance text (already sitting in the shared instance box, and known-valid since it's
+// what produced the frame being edited) into a generic bracket tree, locates the specific
+// subtree an edit touches by matching against the *known* node/leaf identities already in
+// the frame data, mutates only that subtree, and reserializes the whole tree. Everything
+// outside the touched subtree (a Clique instance's trailing "K" parameter, for example,
+// which the `graph` contract's {nodes, links} payload never carries at all) passes through
+// byte-for-byte unchanged, because it is never parsed apart from the rest -- it doesn't
+// need to be, since this module never has to know what it means.
+//
+// This is a real, deliberate substitution for T46's literal recommendation, made because
+// the assumption it depended on (grammar-string access) does not hold from this vantage
+// point -- recorded here rather than quietly reduced in scope, per CLAUDE.md's "where a
+// task depends on an open decision, don't decide it quietly" rule. See T51's handback
+// summary for the consequences: this technique is confident for node identity (short,
+// literal tokens that appear verbatim in instance text) and for `recursiveSet` (the whole
+// instance IS the edited tree, so no location step is even needed -- see
+// data/instanceSerializers.js), but is deliberately NOT extended to edge structure that
+// carries more than a bare two-element pair (a weighted or labelled edge, e.g. DFA/NFA's
+// transition symbols) -- see that file's graph serializer for the specific, narrower
+// guarantee it makes instead of guessing.
+
+/**
+ * Tokenizes SPADE-style instance text: `{`, `}`, `(`, `)`, `,` as single-character
+ * delimiter tokens, whitespace skipped, and any other run of characters as one leaf token.
+ * @param {string} text
+ * @returns {Array<{type: string, value: string}>}
+ */
+function tokenize(text) {
+  const tokens = [];
+  const DELIMITERS = "{}(),";
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (DELIMITERS.includes(ch)) {
+      tokens.push({ type: ch, value: ch });
+      i += 1;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      i += 1;
+      continue;
+    }
+    let j = i;
+    while (j < text.length && !DELIMITERS.includes(text[j]) && !/\s/.test(text[j])) {
+      j += 1;
+    }
+    tokens.push({ type: "leaf", value: text.slice(i, j) });
+    i = j;
+  }
+  return tokens;
+}
+
+/**
+ * Parses SPADE-style instance text into a generic bracket tree:
+ * `{type: "set", children}` for `{...}` (unordered, HashSet), `{type: "tuple", children}`
+ * for `(...)` (ordered, List), `{type: "leaf", value}` for a bare token.
+ * @param {string} text
+ * @returns {Object} the root node.
+ * @throws {Error} if `text` isn't balanced/well-formed under this bracket grammar.
+ */
+export function parseInstanceText(text) {
+  const tokens = tokenize(text);
+  let pos = 0;
+
+  function parseValue() {
+    const token = tokens[pos];
+    if (!token) {
+      throw new Error("Unexpected end of instance text");
+    }
+    if (token.type === "{" || token.type === "(") {
+      const closing = token.type === "{" ? "}" : ")";
+      const kind = token.type === "{" ? "set" : "tuple";
+      pos += 1;
+      const children = [];
+      if (tokens[pos]?.type === closing) {
+        pos += 1;
+        return { type: kind, children };
+      }
+      children.push(parseValue());
+      while (tokens[pos]?.type === ",") {
+        pos += 1;
+        children.push(parseValue());
+      }
+      if (tokens[pos]?.type !== closing) {
+        throw new Error(`Expected "${closing}" in instance text`);
+      }
+      pos += 1;
+      return { type: kind, children };
+    }
+    if (token.type === "leaf") {
+      pos += 1;
+      return { type: "leaf", value: token.value };
+    }
+    throw new Error(`Unexpected "${token.value}" in instance text`);
+  }
+
+  const root = parseValue();
+  if (pos !== tokens.length) {
+    throw new Error("Unexpected trailing content in instance text");
+  }
+  return root;
+}
+
+/**
+ * Reserializes a bracket tree back to SPADE-style instance text -- the exact inverse of
+ * `parseInstanceText`. Round-trips byte-for-byte on any tree this module produced or
+ * parsed, matching T46's own finding that SPADE's `ToString()` does the same.
+ * @param {Object} node
+ * @returns {string}
+ */
+export function serializeInstanceText(node) {
+  if (node.type === "leaf") {
+    return node.value;
+  }
+  const inner = node.children.map(serializeInstanceText).join(",");
+  return node.type === "set" ? `{${inner}}` : `(${inner})`;
+}
+
+/** @param {Object} node @returns {string[]} every leaf value under `node`, in tree order. */
+export function collectLeafValues(node) {
+  if (node.type === "leaf") {
+    return [node.value];
+  }
+  return node.children.flatMap(collectLeafValues);
+}
+
+/**
+ * Finds the deepest node in `root` whose full set of leaf descendants exactly equals
+ * `targetValues` (as a set -- duplicates/order don't matter, matching how a node-id set is
+ * used). Post-order, so a nested exact match (more specific) wins over an enclosing one.
+ * Used to locate a `graph` frame's node-id set, or any similarly-shaped named grammar
+ * variable, inside the parsed instance text -- see this file's header for why this is a
+ * text-driven location step rather than a grammar-driven one.
+ * @param {Object} root
+ * @param {string[]} targetValues
+ * @returns {Object|null} the matching node, or null if none matches exactly.
+ */
+export function findExactLeafSetNode(root, targetValues) {
+  const targetSet = new Set(targetValues);
+
+  function visit(node) {
+    if (node.type === "leaf") {
+      return null;
+    }
+    for (const child of node.children) {
+      const found = visit(child);
+      if (found) return found;
+    }
+    const leaves = collectLeafValues(node);
+    if (leaves.length !== targetSet.size) {
+      return null;
+    }
+    const leafSet = new Set(leaves);
+    if (leafSet.size !== leaves.length) {
+      return null; // duplicate leaves under this node -- not the clean id set we want
+    }
+    for (const value of leafSet) {
+      if (!targetSet.has(value)) return null;
+    }
+    return node;
+  }
+
+  return visit(root);
+}
+
+/**
+ * Returns a deep clone of `node` with every leaf equal to `oldValue` renamed to
+ * `newValue`, wherever it occurs in the tree (a node id can appear in more than one place
+ * -- an edge endpoint, an automaton's initial/accepting-state set -- SPADE does no
+ * referential-integrity checking of its own, per T46's finding, so a rename has to reach
+ * every occurrence itself).
+ * @param {Object} node
+ * @param {string} oldValue
+ * @param {string} newValue
+ * @returns {Object}
+ */
+export function renameLeafEverywhere(node, oldValue, newValue) {
+  if (node.type === "leaf") {
+    return node.value === oldValue ? { type: "leaf", value: newValue } : node;
+  }
+  return {
+    ...node,
+    children: node.children.map((child) => renameLeafEverywhere(child, oldValue, newValue)),
+  };
+}
+
+/**
+ * Returns a deep clone of `node` with every occurrence of `value` removed. Referential
+ * integrity (T46: SPADE itself does not enforce it) is handled here structurally: a direct
+ * child that is itself a two-leaf pair (an edge endpoint pair, ordered or unordered)
+ * containing `value` is dropped in its entirety rather than left as a dangling one-element
+ * pair; everywhere else, only the matching leaf itself is dropped from its parent's
+ * children.
+ *
+ * `protectedNode` (by reference, matched against the *same* `node` this call started
+ * with -- not a value comparison) exempts one specific subtree from the pair-collapse
+ * rule, always shrinking it by one leaf instead: without this, a plain node-id set that
+ * happens to have exactly two members (a two-node graph) is structurally indistinguishable
+ * from a two-leaf edge pair, and the collapse rule would wrongly delete the whole set
+ * instead of leaving the other node in it. `serializeGraphInstance`
+ * (data/instanceSerializers.js) always passes the located node-id set here for exactly
+ * this reason -- see that file for the one remaining case this doesn't cover (a relation
+ * with more than two positions, e.g. DFA/NFA's `(from, symbol, to)` transitions, where a
+ * leaf's removal can still leave a malformed remnant tuple this function has no way to
+ * detect).
+ * @param {Object} node
+ * @param {string} value
+ * @param {Object|null} [protectedNode] A subtree (found in the SAME `node` passed as this
+ *   call's first argument) that always shrinks rather than ever being collapsed as a pair.
+ * @returns {Object}
+ */
+export function removeLeafEverywhere(node, value, protectedNode = null) {
+  if (node.type === "leaf") {
+    return node;
+  }
+  if (node === protectedNode) {
+    return {
+      ...node,
+      children: node.children.filter((child) => !(child.type === "leaf" && child.value === value)),
+    };
+  }
+  const nextChildren = [];
+  for (const child of node.children) {
+    if (child.type === "leaf") {
+      if (child.value !== value) nextChildren.push(child);
+      continue;
+    }
+    if (
+      child !== protectedNode &&
+      child.children.length === 2 &&
+      child.children.every((grandchild) => grandchild.type === "leaf") &&
+      child.children.some((grandchild) => grandchild.value === value)
+    ) {
+      continue; // drop the whole pair -- referential integrity, see doc comment above
+    }
+    nextChildren.push(removeLeafEverywhere(child, value, protectedNode));
+  }
+  return { ...node, children: nextChildren };
+}
+
+/**
+ * Returns a deep clone of `node` with `newValue` appended as a new leaf child of the
+ * subtree found by `findExactLeafSetNode(node, currentValues)` -- i.e. "add this id to the
+ * same named set the given ids currently live in".
+ * @param {Object} node
+ * @param {string[]} currentValues The set identifying which subtree to add to (the id set
+ *   as it stood before this addition).
+ * @param {string} newValue
+ * @returns {Object} the mutated tree, or `node` unchanged if no matching subtree is found.
+ */
+export function addLeafToMatchingSet(node, currentValues, newValue) {
+  const target = findExactLeafSetNode(node, currentValues);
+  if (!target) {
+    return node;
+  }
+  function visit(candidate) {
+    if (candidate === target) {
+      return { ...candidate, children: [...candidate.children, { type: "leaf", value: newValue }] };
+    }
+    if (candidate.type === "leaf") {
+      return candidate;
+    }
+    return { ...candidate, children: candidate.children.map(visit) };
+  }
+  return visit(node);
+}


### PR DESCRIPTION
Issue: #114 (T51: Diagram editing — graph, quantumCircuit, recursiveSet, wave 2)
Branch: task/T51-diagram-editing-wave2 (currently checked out, work is in the working tree)

Changed:
- data/spadeInstanceText.js (new) — generic SPADE bracket-tree parser/serializer
- data/instanceSerializers.js (new) — serializeGraphInstance, serializeRecursiveSetInstance
- components/detail/visualizations/GraphRenderer.js, RecursiveSetRenderer.js, QuantumCircuitRenderer.js — editing UIs
- components/detail/visualizations/VisualizationCanvas.js, components/detail/VisualizationsSection.js — edit state management, Run-time serialization

Done when, met:
- Editing works on the base frame only; other steps show no edit affordances
- Position dragging stays cosmetic (unchanged — this project never reads a position field anyway)
- Edits preview locally and immediately; Run reconciles through the backend for graph node ops and recursiveSet
- Every structural edit has a keyboard-reachable path

Done when, not met — and why:
- T46's serializer recommendation assumed frontend access to each problem's InstanceGrammar string. It doesn't have any — none of the six batch endpoints this app calls return one. I built a different, self-justifying approach instead (a generic bracket-tree parser over the instance text itself, since SPADE's {}/() convention is self-describing) rather than silently reducing scope. This is recorded as a decision in data/spadeInstanceText.js's header.
- quantumCircuit has no diagram-to-text serializer at all. T46 only verified SPADE round-tripping against Clique and DFA — neither is a gate-sequence grammar, so nothing confirms whether gate identifiers even appear as literal tokens in circuit instance text. Guessing risked shipping a serializer that looks plausible and is silently wrong, with no live backend here to check it against. The editing UI ships (local preview only); Run shows a clear message instead of guessing.
- graph edge edits (add/remove) are local-preview-only, never sent to Run. Node edits (add/remove/relabel) do serialize correctly, including a validated referential-integrity cascade. But several graph instances (DFA/NFA) encode more than a bare pair per edge, which isn't safe to guess at from text structure alone.

Decisions and assumptions:
- Verified the parser/serializer logic with standalone unit-style checks against hand-constructed SPADE-shaped text (Clique-like, a 2-node edge case, and a DFA-like triple), since no live backend was reachable to test against — all documented in the summary above; I don't have interactive browser testing available in this environment either, so the UI itself is lint/build-verified and dev-server-smoke-tested, not click-tested.
- Both branches are otherwise independent (T52 doesn't depend on T51, per the design doc), so they'll likely need a small manual merge in VisualizationCanvas.js/VisualizationsSection.js/data/instanceSerializers.js when both land.

Closes #114 