### PR TITLE
Added More Diagram Editing

### DIFF
--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -25,13 +25,28 @@
 // T47 (#110): step playback (play/pause/step/speed/scrub bar) is the shared
 // StepScrubber component, now driven by the real frame count a completed
 // run returns rather than a fallback of 1.
+//
+// T52 (#115): structural editing for the `booleanSatisfiability` universal
+// type. Per INTERACTIVE_LAYER_DESIGN.md §2.3, editing only ever applies to
+// the base frame (frames[0]) -- `editedClauses` below is local-preview-only
+// state, seeded from the fetched frame on first edit and cleared whenever
+// the selected visualization changes or a fresh Run replaces the frames
+// (§2.1.2: "editing previews locally; Run reconciles through the real
+// backend round trip"). Pressing Run (handleRun below) serializes any
+// pending local edit into the shared instance text via `onInstanceChange`
+// *before* triggering the shared Run action, so a diagram edit reaches
+// `/solve`/`/visualize` exactly like a textarea edit already does
+// (§2.4). `graph`/`quantumCircuit`/`recursiveSet` editing is T51/#114, not
+// this task -- selecting one of those types never turns editing on here.
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { serializeBooleanSatisfiabilityInstance } from "../../data/instanceSerializers";
 import { TAXONOMY, UNCLASSIFIED } from "../../data/taxonomy";
+import { VISUALIZATION_TYPE_MAP } from "../../data/visualizationTypes";
 import {
   COMPUTE_CANCELLED,
   COMPUTE_DONE,
@@ -47,6 +62,14 @@ import StepScrubber from "./StepScrubber";
 import VisualizationCanvas from "./visualizations/VisualizationCanvas";
 
 const VISUALIZATION_TYPE_FACET = TAXONOMY.find((facet) => facet.key === "visualizationType");
+
+// SAT3's literal-per-clause cap (VISUALIZATION_TYPE_CONTRACTS.md §3.3, this section's own
+// issue body) -- SAT itself has no cap. "3SAT" is the real backend `problemName` (per
+// data/supplementalTags.js's own header note: code "SAT3" -> problemName "3SAT"), not the
+// visualization/solver class-name spelling, so this checks the problem, not the
+// visualization, since the cap is a property of the problem's grammar, not of any one
+// visualization instance.
+const SAT3_MAX_LITERALS_PER_CLAUSE = 3;
 
 // #71: fixed rail height so a problem with many declared visualizations
 // scrolls inside the rail instead of stretching the section indefinitely.
@@ -99,8 +122,9 @@ function TypeBadge({ typeKey }) {
  * @param {string} [props.instanceValue] The shared problem instance, owned by
  *   components/ProblemDetailLayout.js (T35/#93).
  * @param {(next: string) => void} [props.onInstanceChange] Called with the new
- *   text whenever the visitor edits the instance elsewhere (Solvers' box) --
- *   this section reads the value but does not render its own copy of the box.
+ *   text whenever the visitor edits the instance elsewhere (Solvers' box), and
+ *   (T52/#115) called by this section itself, just before Run, to write a
+ *   pending diagram edit's serialized text into the shared instance.
  * @param {number} [props.runToken] The shared Run trigger (T48/#111). A change
  *   in value, not the value itself, means Run was pressed somewhere.
  * @param {() => void} [props.onRunRequest] Bumps `runToken`. Called by this
@@ -111,6 +135,7 @@ function TypeBadge({ typeKey }) {
 export default function VisualizationsSection({
   problem,
   instanceValue = "",
+  onInstanceChange,
   runToken,
   onRunRequest,
   dragHandleProps,
@@ -137,12 +162,38 @@ export default function VisualizationsSection({
       : null;
   const instanceChangedSinceRun = Boolean(liveFrames) && liveFrames.instance !== instanceValue;
 
+  // T52 (#115): which universal type the selected visualization renders as,
+  // and whether that type has editing support at all -- only
+  // `booleanSatisfiability` does today (T51/#114 covers the other three
+  // editable types, wave 2). Derived from the static backend-type map alone
+  // (not `resolveVisualizationType`, which also consults a live frame) since
+  // this needs to be known before a frame exists, to decide whether edit
+  // affordances can ever apply to this visualization.
+  const universalType = VISUALIZATION_TYPE_MAP[selected?.backendType] ?? null;
+  const isBooleanSatisfiability = universalType === "booleanSatisfiability";
+  // "3SAT" is the real backend problemName SAT3 resolves to (see the module
+  // header note) -- SAT itself has no per-clause literal cap.
+  const maxLiteralsPerClause =
+    isBooleanSatisfiability && problem.name === "3SAT" ? SAT3_MAX_LITERALS_PER_CLAUSE : undefined;
+
+  // Local-preview-only edit state for the base frame (INTERACTIVE_LAYER_DESIGN.md
+  // §2.1.2/§2.3) -- null means "no pending edit, show the fetched frame as-is".
+  // Reset (see the render-time adjustments below) whenever the selected
+  // visualization changes or a fresh Run replaces `visualize.result`.
+  const [editedClauses, setEditedClauses] = useState(null);
+  const hasPendingEdit = editedClauses !== null;
+
+  function handleClausesChange(updater) {
+    setEditedClauses((current) => updater(current ?? liveFrames?.frames?.[0]?.clauses ?? []));
+  }
+
   function handleSelectVisualization(index) {
     if (index === selectedIndex) return;
     // Drops any in-flight request and clears the pane, so nothing from the
     // previous visualization survives the switch.
     visualize.reset();
     setSelectedIndex(index);
+    setEditedClauses(null);
   }
 
   const { start: startVisualize } = visualize;
@@ -166,6 +217,27 @@ export default function VisualizationsSection({
     });
   }, [canRun, selected, instanceValue, startVisualize]);
 
+  // T52 (#115): the Run affordance's onClick, not `handleRun`/`onRunRequest`
+  // directly -- if a diagram edit is pending, it must be serialized into the
+  // shared instance *before* Run fires, so the run that follows (whichever
+  // section's Run button triggered it -- runToken is shared) acts on the
+  // edited instance. `onInstanceChange` and `onRunRequest` are both setters
+  // on the same parent (ProblemDetailLayout.js) and React batches them into
+  // one re-render, so by the time the runToken effect below (or Solvers'
+  // identical one) fires, `instanceValue` already reflects the edit -- see
+  // this task's handback summary for why this ordering is safe rather than
+  // a race.
+  function handleRunClick() {
+    if (hasPendingEdit) {
+      onInstanceChange?.(serializeBooleanSatisfiabilityInstance(editedClauses));
+    }
+    if (onRunRequest) {
+      onRunRequest();
+    } else {
+      handleRun();
+    }
+  }
+
   // Reacts to the shared Run trigger (T48/#111) rather than fetching inline
   // in the button's onClick -- see components/ProblemDetailLayout.js and
   // components/detail/SolversSection.js, which does the identical thing.
@@ -176,11 +248,12 @@ export default function VisualizationsSection({
     handleRun();
   }, [runToken, handleRun]);
 
-  // Two independent render-time step resets (React's documented "adjust
-  // state" pattern, not a useEffect): selecting a different visualization
-  // starts its playback over, and so does a freshly-completed run replacing
-  // the frames currently shown -- both can leave a stale `currentStep`
-  // pointing past the end of a differently-sized frames[].
+  // Three independent render-time resets (React's documented "adjust state"
+  // pattern, not a useEffect): selecting a different visualization starts its
+  // playback over and drops its edit state; so does a freshly-completed run
+  // replacing the frames currently shown, since §2.1.2 requires Run to
+  // replace the local preview with what the backend actually parsed back
+  // rather than leaving the pre-Run edit displayed on top of new data.
   const [stepResetKey, setStepResetKey] = useState(selectedIndex);
   if (stepResetKey !== selectedIndex) {
     setStepResetKey(selectedIndex);
@@ -190,10 +263,17 @@ export default function VisualizationsSection({
   if (lastVisualizeResult !== visualize.result) {
     setLastVisualizeResult(visualize.result);
     setCurrentStep(0);
+    if (editedClauses !== null) setEditedClauses(null);
   }
 
   const frameCount = liveFrames?.frames?.length ?? 1;
-  const currentFrame = liveFrames?.frames?.[currentStep] ?? null;
+  const fetchedFrame = liveFrames?.frames?.[currentStep] ?? null;
+  // T52 (#115): on the base frame (frames[0]) only, a pending local edit
+  // shows instead of the fetched frame -- the diagram's own preview of an
+  // edit that hasn't been sent to the backend yet (§2.1.2). Any other step
+  // is always playback-only, never edited (§2.3).
+  const isEditingStep0 = currentStep === 0 && isBooleanSatisfiability;
+  const currentFrame = isEditingStep0 && hasPendingEdit ? { clauses: editedClauses } : fetchedFrame;
 
   const visualizationName = selected?.name ?? "this visualization";
   let announcement = "";
@@ -297,7 +377,7 @@ export default function VisualizationsSection({
                 variant="outlined"
                 size="small"
                 disabled={!canRun || visualize.isRunning}
-                onClick={() => (onRunRequest ? onRunRequest() : handleRun())}
+                onClick={handleRunClick}
               >
                 Run
               </Button>
@@ -341,8 +421,16 @@ export default function VisualizationsSection({
                     instanceName={selected.name}
                     backendType={selected.backendType}
                     frame={currentFrame}
+                    editable={isEditingStep0}
+                    onClausesChange={isEditingStep0 ? handleClausesChange : undefined}
+                    maxLiteralsPerClause={maxLiteralsPerClause}
                   />
                 </Box>
+                {hasPendingEdit && (
+                  <Typography variant="body2" sx={{ color: "warning.light" }}>
+                    This diagram has unsaved edits. Press Run to send them to the backend.
+                  </Typography>
+                )}
                 {instanceChangedSinceRun && (
                   <Typography variant="body2" sx={{ color: "warning.light" }}>
                     The instance has been edited since this ran. Run again to visualize the instance

--- a/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
+++ b/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
@@ -18,19 +18,47 @@
 // backend returned" call §3.5 already made for stepTable's cell text, extended here on
 // the same reasoning: this is the backend's own data, not this project's UI copy.
 //
-// This is deliberately structured to grow editing affordances in T52 (`clauses`/
-// `literals` map straight onto per-clause/per-literal React elements already) --
-// T49 itself is static rendering only, per the issue's own scope note.
+// T52 (#115): editing affordances (add/remove/negate a literal, add/remove a clause) are
+// now here, gated behind the `editable` prop -- exactly the growth this component was
+// structured for. Only ever passed `editable` when the frame being shown is the base
+// frame (frames[0], per INTERACTIVE_LAYER_DESIGN.md §2.3) -- VisualizationsSection.js
+// owns that gate, this component doesn't re-derive it. Every edit control here is a
+// real, focusable, aria-labelled button or text input -- no drag, no right-click -- per
+// §3's keyboard-reachable requirement (same precedent as T18's KeyboardSensor).
 
+import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
-import { useId, useState } from "react";
+import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { useId, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
 
 const CONJUNCTION = "∧"; // AND, between literals within a clause (T40's finding, see header)
 const DISJUNCTION = "∨"; // OR, between clauses
 
+// A bare CNF variable name: a letter, then letters/digits/underscores. Deliberately not
+// restricted to the "x<number>" shape the observed contract examples ("x1", "!x2") use --
+// SAT/SAT3's grammar is not known to require that specific naming, only that a literal is
+// a variable name optionally prefixed with "!".
+const VARIABLE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+
 function literalVariable(literalText) {
   return typeof literalText === "string" ? literalText.replace(/^!/, "") : literalText;
+}
+
+function isNegated(literalText) {
+  return typeof literalText === "string" && literalText.startsWith("!");
+}
+
+// Ids only need to be unique within one edited frame (React keys, DOM ids) -- a
+// module-level counter is enough, no persistence or cross-session uniqueness required.
+let editIdCounter = 0;
+function nextEditId(prefix) {
+  editIdCounter += 1;
+  return `${prefix}-${editIdCounter}`;
 }
 
 function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
@@ -60,6 +88,134 @@ function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
   );
 }
 
+// The negate toggle and remove button share this compact icon-button style -- kept small
+// enough to sit inline with the clause's literal text without dominating it.
+function EditIconButton({ id, label, pressed, onClick, children }) {
+  return (
+    <IconButton
+      id={id}
+      size="small"
+      aria-label={label}
+      aria-pressed={pressed}
+      onClick={onClick}
+      sx={{ p: 0.375 }}
+    >
+      {children}
+    </IconButton>
+  );
+}
+
+function EditableLiteral({ idPrefix, clauseIndex, literalIndex, literal, canRemove, onEdit }) {
+  const variable = literalVariable(literal.literal);
+  const negated = isNegated(literal.literal);
+  return (
+    <Box component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
+      <LiteralMark id={`${idPrefix}-literal-${literal.id}`} literal={literal} />
+      <EditIconButton
+        id={`${idPrefix}-literal-${literal.id}-negate`}
+        label={`${negated ? "Remove negation from" : "Negate"} ${variable} in clause ${clauseIndex + 1}`}
+        pressed={negated}
+        onClick={() =>
+          onEdit((clauses) => {
+            const next = clauses.map((clause) => ({ ...clause, literals: [...clause.literals] }));
+            const target = next[clauseIndex].literals[literalIndex];
+            next[clauseIndex].literals[literalIndex] = {
+              ...target,
+              literal: negated ? variable : `!${variable}`,
+            };
+            return next;
+          })
+        }
+      >
+        <Typography
+          component="span"
+          aria-hidden="true"
+          sx={{ fontSize: "0.75rem", fontWeight: 700 }}
+        >
+          !
+        </Typography>
+      </EditIconButton>
+      {canRemove && (
+        <EditIconButton
+          id={`${idPrefix}-literal-${literal.id}-remove`}
+          label={`Remove ${literal.literal} from clause ${clauseIndex + 1}`}
+          onClick={() =>
+            onEdit((clauses) => {
+              const next = clauses.map((clause) => ({
+                ...clause,
+                literals: [...clause.literals],
+              }));
+              next[clauseIndex].literals.splice(literalIndex, 1);
+              return next;
+            })
+          }
+        >
+          <CloseIcon sx={{ fontSize: "0.875rem" }} />
+        </EditIconButton>
+      )}
+    </Box>
+  );
+}
+
+// Keyboard-reachable "add literal" affordance (§3 of INTERACTIVE_LAYER_DESIGN.md): a real
+// text field plus a submit button, not a drag/right-click gesture. Disabled once the
+// clause is at `maxLiteralsPerClause` (SAT3's 3-literal cap, enforced here rather than
+// left for the backend to reject).
+function AddLiteralForm({ idPrefix, clauseIndex, atCap, onEdit }) {
+  const [value, setValue] = useState("");
+  const fieldId = `${idPrefix}-clause-${clauseIndex}-add-literal`;
+  const isValid = VARIABLE_NAME_PATTERN.test(value.trim());
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    if (!isValid || atCap) return;
+    const variable = value.trim();
+    onEdit((clauses) => {
+      const next = clauses.map((clause) => ({ ...clause, literals: [...clause.literals] }));
+      next[clauseIndex].literals.push({
+        id: nextEditId("literal"),
+        literal: variable,
+        color: "",
+      });
+      return next;
+    });
+    setValue("");
+  }
+
+  return (
+    <Box
+      component="form"
+      onSubmit={handleSubmit}
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, ml: 0.5 }}
+    >
+      <Box component="label" htmlFor={fieldId} sx={{ display: "none" }}>
+        Variable name to add to clause {clauseIndex + 1}
+      </Box>
+      <TextField
+        id={fieldId}
+        size="small"
+        variant="standard"
+        placeholder="x1"
+        value={value}
+        disabled={atCap}
+        onChange={(event) => setValue(event.target.value)}
+        sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
+        inputProps={{ "aria-label": `Variable name to add to clause ${clauseIndex + 1}` }}
+      />
+      <IconButton
+        id={`${fieldId}-submit`}
+        type="submit"
+        size="small"
+        disabled={atCap || !isValid}
+        aria-label={`Add literal to clause ${clauseIndex + 1}`}
+        sx={{ p: 0.375 }}
+      >
+        <AddIcon sx={{ fontSize: "0.875rem" }} />
+      </IconButton>
+    </Box>
+  );
+}
+
 /**
  * @param {Object} props
  * @param {string} props.idPrefix Prefixes every id this component renders, so two
@@ -68,20 +224,59 @@ function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
  *   the accessible summary when given.
  * @param {{clauses: Array}} props.frame One already-validated `booleanSatisfiability`
  *   frame.
+ * @param {boolean} [props.editable] T52 (#115): true only when this frame is the base
+ *   frame (frames[0]) of a visualization the caller has decided is editable right now --
+ *   this component does not re-derive that gate. Adds add/remove/negate-literal and
+ *   add/remove-clause controls when true; renders exactly as before (T49) when false or
+ *   omitted, so Reductions' still-static panes (§2.5, T53 not yet built) are unaffected.
+ * @param {(updater: (clauses: Array) => Array) => void} [props.onClausesChange] Called
+ *   with a `(currentClauses) => nextClauses` updater on every structural edit -- the
+ *   caller owns whether "currentClauses" is the frame's own `clauses` or an already-
+ *   edited copy from an earlier edit in the same session (INTERACTIVE_LAYER_DESIGN.md
+ *   §2.1.2: edits preview locally; only Run round-trips through the backend). Required
+ *   when `editable` is true.
+ * @param {number} [props.maxLiteralsPerClause] SAT3's 3-literal-per-clause cap, enforced
+ *   in this UI rather than left for the backend to reject. Omitted (no cap) for SAT.
  */
-export default function BooleanSatisfiabilityRenderer({ idPrefix, instanceName, frame }) {
+export default function BooleanSatisfiabilityRenderer({
+  idPrefix,
+  instanceName,
+  frame,
+  editable = false,
+  onClausesChange,
+  maxLiteralsPerClause,
+}) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
   // Hovering or focusing one literal highlights every literal for the same variable
   // (ignoring negation) across the whole formula -- the hover-triggered highlight §4.2
   // requires stay keyboard-reachable, via the identical onFocus/onBlur pair LiteralMark
-  // already wires to the same mouse handlers.
+  // already wires to the same mouse handlers. Suppressed in edit mode: EditableLiteral
+  // renders its own negate/remove controls in the same slot instead of a hover target.
   const [hoveredVariable, setHoveredVariable] = useState(null);
+  const addClauseFieldRef = useRef(null);
+  const [newClauseValue, setNewClauseValue] = useState("");
 
   const clauses = frame.clauses;
   const clauseCount = clauses.length;
   const summaryBody = `boolean formula with ${clauseCount} clause${clauseCount === 1 ? "" : "s"}`;
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
+  const isNewClauseValid = VARIABLE_NAME_PATTERN.test(newClauseValue.trim());
+
+  function handleAddClause(event) {
+    event.preventDefault();
+    if (!isNewClauseValid) return;
+    const variable = newClauseValue.trim();
+    onClausesChange?.((current) => [
+      ...current,
+      {
+        id: nextEditId("clause"),
+        literals: [{ id: nextEditId("literal"), literal: variable, color: "" }],
+      },
+    ]);
+    setNewClauseValue("");
+    addClauseFieldRef.current?.focus();
+  }
 
   return (
     <Box
@@ -90,67 +285,147 @@ export default function BooleanSatisfiabilityRenderer({ idPrefix, instanceName, 
       aria-label={summary}
       sx={{
         display: "flex",
-        flexWrap: "wrap",
-        alignItems: "center",
-        gap: 1,
+        flexDirection: "column",
+        gap: 1.5,
         p: 2,
         minHeight: "100%",
         boxSizing: "border-box",
       }}
     >
-      {clauseCount === 0 ? (
-        <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
-          No clauses.
-        </Box>
-      ) : (
-        clauses.map((clause, clauseIndex) => (
-          <Box
-            key={clause.id}
-            component="span"
-            sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
-          >
-            {clauseIndex > 0 && (
-              <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mx: 0.5 }}>
-                {DISJUNCTION}
-              </Box>
-            )}
-            <Box component="span" sx={{ color: "text.secondary" }}>
-              (
-            </Box>
-            {clause.literals.map((literal, literalIndex) => {
-              const variable = literalVariable(literal.literal);
-              return (
-                <Box
-                  key={literal.id}
-                  component="span"
-                  sx={{ display: "inline-flex", alignItems: "center" }}
-                >
-                  {literalIndex > 0 && (
-                    <Box
-                      component="span"
-                      aria-hidden="true"
-                      sx={{ color: "text.secondary", mx: 0.5 }}
-                    >
-                      {CONJUNCTION}
-                    </Box>
-                  )}
-                  <LiteralMark
-                    id={`${scopeId}-literal-${literal.id}`}
-                    literal={literal}
-                    highlighted={hoveredVariable != null && variable === hoveredVariable}
-                    onEnter={() => setHoveredVariable(variable)}
-                    onLeave={() =>
-                      setHoveredVariable((current) => (current === variable ? null : current))
-                    }
-                  />
-                </Box>
-              );
-            })}
-            <Box component="span" sx={{ color: "text.secondary" }}>
-              )
-            </Box>
+      <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1 }}>
+        {clauseCount === 0 ? (
+          <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+            No clauses.
           </Box>
-        ))
+        ) : (
+          clauses.map((clause, clauseIndex) => {
+            const atCap =
+              typeof maxLiteralsPerClause === "number" &&
+              clause.literals.length >= maxLiteralsPerClause;
+            return (
+              <Box
+                key={clause.id}
+                component="span"
+                sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+              >
+                {clauseIndex > 0 && (
+                  <Box
+                    component="span"
+                    aria-hidden="true"
+                    sx={{ color: "text.secondary", mx: 0.5 }}
+                  >
+                    {DISJUNCTION}
+                  </Box>
+                )}
+                <Box component="span" sx={{ color: "text.secondary" }}>
+                  (
+                </Box>
+                {clause.literals.map((literal, literalIndex) => {
+                  const variable = literalVariable(literal.literal);
+                  return (
+                    <Box
+                      key={literal.id}
+                      component="span"
+                      sx={{ display: "inline-flex", alignItems: "center" }}
+                    >
+                      {literalIndex > 0 && (
+                        <Box
+                          component="span"
+                          aria-hidden="true"
+                          sx={{ color: "text.secondary", mx: 0.5 }}
+                        >
+                          {CONJUNCTION}
+                        </Box>
+                      )}
+                      {editable ? (
+                        <EditableLiteral
+                          idPrefix={scopeId}
+                          clauseIndex={clauseIndex}
+                          literalIndex={literalIndex}
+                          literal={literal}
+                          canRemove={clause.literals.length > 1}
+                          onEdit={onClausesChange}
+                        />
+                      ) : (
+                        <LiteralMark
+                          id={`${scopeId}-literal-${literal.id}`}
+                          literal={literal}
+                          highlighted={hoveredVariable != null && variable === hoveredVariable}
+                          onEnter={() => setHoveredVariable(variable)}
+                          onLeave={() =>
+                            setHoveredVariable((current) => (current === variable ? null : current))
+                          }
+                        />
+                      )}
+                    </Box>
+                  );
+                })}
+                <Box component="span" sx={{ color: "text.secondary" }}>
+                  )
+                </Box>
+                {editable && (
+                  <>
+                    <AddLiteralForm
+                      idPrefix={scopeId}
+                      clauseIndex={clauseIndex}
+                      atCap={atCap}
+                      onEdit={onClausesChange}
+                    />
+                    <EditIconButton
+                      id={`${scopeId}-clause-${clause.id}-remove`}
+                      label={`Remove clause ${clauseIndex + 1}`}
+                      onClick={() =>
+                        onClausesChange?.((current) =>
+                          current.filter((_candidate, index) => index !== clauseIndex),
+                        )
+                      }
+                    >
+                      <CloseIcon sx={{ fontSize: "0.875rem" }} />
+                    </EditIconButton>
+                  </>
+                )}
+              </Box>
+            );
+          })
+        )}
+      </Box>
+
+      {editable && (
+        <Box
+          component="form"
+          onSubmit={handleAddClause}
+          sx={{ display: "flex", alignItems: "center", gap: 0.75 }}
+        >
+          <Box component="label" htmlFor={`${scopeId}-add-clause`} sx={{ display: "none" }}>
+            First variable for the new clause
+          </Box>
+          <TextField
+            id={`${scopeId}-add-clause`}
+            inputRef={addClauseFieldRef}
+            size="small"
+            variant="outlined"
+            placeholder="x1"
+            value={newClauseValue}
+            onChange={(event) => setNewClauseValue(event.target.value)}
+            sx={{ width: 88, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
+            inputProps={{ "aria-label": "First variable for the new clause" }}
+          />
+          <Button
+            id={`${scopeId}-add-clause-submit`}
+            type="submit"
+            size="small"
+            variant="outlined"
+            disabled={!isNewClauseValid}
+            startIcon={<AddIcon sx={{ fontSize: "1rem" }} />}
+          >
+            Add clause
+          </Button>
+          {typeof maxLiteralsPerClause === "number" && (
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              Up to {maxLiteralsPerClause} literals per clause.
+            </Typography>
+          )}
+        </Box>
       )}
     </Box>
   );

--- a/components/detail/visualizations/VisualizationCanvas.js
+++ b/components/detail/visualizations/VisualizationCanvas.js
@@ -78,8 +78,24 @@ function CannotRender({ idPrefix, reason, violations }) {
  *   "GraphD3") -- `Navigation/Batch/allVisualizationTypes`, falling back to `allInfo`.
  * @param {Object|null} [props.frame] One frame (`frames[currentStep]`), or null/undefined
  *   when there's nothing to show yet (not yet run, or an empty `frames[]`).
+ * @param {boolean} [props.editable] T52 (#115): forwarded straight through to whichever
+ *   renderer is dispatched to. Only `BooleanSatisfiabilityRenderer` reads it today; the
+ *   other renderers simply ignore an unused prop, the same way they already ignore
+ *   `instanceName` when they have no use for it.
+ * @param {Function} [props.onClausesChange] Forwarded straight through -- see
+ *   `BooleanSatisfiabilityRenderer`'s own doc comment for the updater-function shape.
+ * @param {number} [props.maxLiteralsPerClause] Forwarded straight through -- SAT3's
+ *   3-literal cap.
  */
-export default function VisualizationCanvas({ idPrefix, instanceName, backendType, frame }) {
+export default function VisualizationCanvas({
+  idPrefix,
+  instanceName,
+  backendType,
+  frame,
+  editable,
+  onClausesChange,
+  maxLiteralsPerClause,
+}) {
   const universalType = resolveVisualizationType(backendType, frame);
   const Renderer = universalType ? RENDERERS[universalType] : null;
   const { valid, violations } =
@@ -122,5 +138,14 @@ export default function VisualizationCanvas({ idPrefix, instanceName, backendTyp
     );
   }
 
-  return <Renderer idPrefix={idPrefix} instanceName={instanceName} frame={frame} />;
+  return (
+    <Renderer
+      idPrefix={idPrefix}
+      instanceName={instanceName}
+      frame={frame}
+      editable={editable}
+      onClausesChange={onClausesChange}
+      maxLiteralsPerClause={maxLiteralsPerClause}
+    />
+  );
 }

--- a/data/instanceSerializers.js
+++ b/data/instanceSerializers.js
@@ -1,0 +1,37 @@
+// data/instanceSerializers.js
+//
+// T52 (#115) -- diagram-to-text serializers for the editable universal
+// visualization types (ai_documentation/INTERACTIVE_LAYER_DESIGN.md §2.2).
+// Turns an edited in-memory frame structure back into instance text the
+// backend's own parser accepts, so a structural diagram edit can round-trip
+// through Run (`/solve`/`/visualize`) the same way a textarea edit already
+// does.
+//
+// `booleanSatisfiability` (SAT, SAT3) is the only type covered here. Per
+// INTERACTIVE_LAYER_DESIGN.md §2.2, SAT/SAT3 don't use the SPADE grammar
+// library at all -- they parse a small hand-rolled CNF grammar (`&` between
+// clauses, `|` between literals, `!` negation;
+// `Problems/NPComplete/NPC_SAT3/SAT3_Class.cs`). The contract's literal
+// strings ("x1", "!x2", VISUALIZATION_TYPE_CONTRACTS.md §3.3) already match
+// this text format, so the serializer named in issue #115's own body is a
+// straightforward join: literals within a clause joined with " | " inside
+// parentheses, clauses joined with " & ".
+//
+// `graph`/`quantumCircuit`/`recursiveSet` (T51/#114) are SPADE-grammar-based
+// and are not covered by this file -- a different serialization strategy,
+// with its own reasoning recorded where that work lands.
+
+/**
+ * @param {Array<{literals: Array<{literal: string}>}>} clauses
+ * @returns {string} Instance text a SAT/SAT3 instance's hand-rolled parser accepts, e.g.
+ *   "(x1 | !x2) & (x2 | x3 | !x1)". An empty clause list serializes to "" -- the parser's
+ *   own handling of a 0-clause formula, not something this function invents.
+ */
+export function serializeBooleanSatisfiabilityInstance(clauses) {
+  if (!Array.isArray(clauses) || clauses.length === 0) {
+    return "";
+  }
+  return clauses
+    .map((clause) => `(${(clause.literals ?? []).map((literal) => literal.literal).join(" | ")})`)
+    .join(" & ");
+}


### PR DESCRIPTION
Issue: #115 (T52: Diagram editing — booleanSatisfiability, wave 1)
Branch: task/T52-boolean-satisfiability-editing (work is stashed, not applied to the working tree right now — see note at the end)

Changed:
- data/instanceSerializers.js (new) — serializeBooleanSatisfiabilityInstance
- components/detail/visualizations/BooleanSatisfiabilityRenderer.js — add/remove/negate literal, add/remove clause controls
- components/detail/visualizations/VisualizationCanvas.js — forwards edit props
- components/detail/VisualizationsSection.js — local edit state, SAT3 cap, Run-time serialization

Done when, met:
- Editing works on the base frame only (frames[0]); other steps show no edit affordances
- Serializer matches the format the issue itself specified (literals joined " | ", clauses joined " & ")
- SAT3's 3-literal-per-clause cap is enforced in the UI (via problem.name === "3SAT")
- Every structural edit has a keyboard-reachable path — real buttons/text fields, no drag or right-click

Done when, not met:
- "Verified by round-tripping a hand-edited instance through Run" — couldn't do this in this environment; there's no live Redux backend reachable here. Logic is correct against the format the issue itself specifies, but hasn't been confirmed against a real backend response.

Closes #115 