### PR TITLE
Wiring Reductions With Real Data

### DIFF
--- a/components/ProblemDetailLayout.js
+++ b/components/ProblemDetailLayout.js
@@ -122,7 +122,14 @@ import VisualizationsSection from "./detail/VisualizationsSection";
 // not: Verify checks a user-supplied certificate against an instance, it
 // does not run a solver, and its certificate has no guaranteed relationship
 // to a fresh /visualize call (INTERACTIVE_LAYER_DESIGN.md §2.1). Reductions
-// joins `usesRun` in T53, once it has real data to refresh.
+// joins `usesRun` in T53 (#116), now that it has real data to refresh.
+//
+// `providesCertificate`/`usesCertificate` (T53) are the other half of that same wiring:
+// `ProblemProvider/visualizeReduction` requires a certificate for the source instance
+// (INTERACTIVE_LAYER_DESIGN.md §1.3), and the only thing that ever produces one is a
+// completed Solvers run -- so Solvers reports its own solve's output up through
+// `onCertificateChange`, this component holds the one shared copy the same way it holds
+// `instance`, and Reductions reads it back as `certificate`.
 const SECTIONS = [
   { key: "overview", title: "Overview", Component: OverviewSection },
   {
@@ -138,9 +145,17 @@ const SECTIONS = [
     Component: SolversSection,
     usesInstance: true,
     usesRun: true,
+    providesCertificate: true,
   },
   { key: "verifier", title: "Verifier", Component: VerifierSection, usesInstance: true },
-  { key: "reductions", title: "Reductions", Component: ReductionsSection },
+  {
+    key: "reductions",
+    title: "Reductions",
+    Component: ReductionsSection,
+    usesInstance: true,
+    usesRun: true,
+    usesCertificate: true,
+  },
 ];
 
 const SECTIONS_BY_KEY = new Map(SECTIONS.map((section) => [section.key, section]));
@@ -214,6 +229,12 @@ export default function ProblemDetailLayout({ problem }) {
   // real declared `defaultInstance`.
   const [instance, setInstance] = useState(problem.defaultInstance ?? "");
 
+  // The shared certificate (T53/#116, see header) -- `null` until Solvers' own Run
+  // produces one. Shaped `{ value, instance }` (mirroring SolversSection's own
+  // `liveResult`/`instanceChangedSinceRun` pattern) so a consumer can tell a certificate
+  // for the *current* instance apart from a stale one left over from a since-edited box.
+  const [certificate, setCertificate] = useState(null);
+
   // Re-seed the box when the page switches to a different problem, so one
   // problem's instance can never be left sitting in another's input. In
   // practice pages/[problem].js unmounts this component while the next
@@ -222,11 +243,13 @@ export default function ProblemDetailLayout({ problem }) {
   // than something this component should depend on. React's documented
   // "adjust state when a prop changes" pattern, not an effect: it settles
   // during the same render instead of flashing the previous problem's
-  // instance for a frame first.
+  // instance for a frame first. The certificate resets alongside it -- a
+  // certificate for the previous problem's instance is never valid here.
   const [instanceProblemName, setInstanceProblemName] = useState(problem.name);
   if (instanceProblemName !== problem.name) {
     setInstanceProblemName(problem.name);
     setInstance(problem.defaultInstance ?? "");
+    setCertificate(null);
   }
 
   // The shared Run trigger (T48/#111, see file header). A `usesRun` section
@@ -318,14 +341,25 @@ export default function ProblemDetailLayout({ problem }) {
         <SortableContext items={order} strategy={verticalListSortingStrategy}>
           <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
             {order.map((key) => {
-              const { Component, usesInstance, usesRun } = SECTIONS_BY_KEY.get(key);
+              const { Component, usesInstance, usesRun, providesCertificate, usesCertificate } =
+                SECTIONS_BY_KEY.get(key);
               const instanceProps = usesInstance
                 ? { instanceValue: instance, onInstanceChange: setInstance }
                 : null;
               const runProps = usesRun ? { runToken, onRunRequest: triggerRun } : null;
+              const certificateProps = providesCertificate
+                ? { onCertificateChange: setCertificate }
+                : usesCertificate
+                  ? { certificate }
+                  : null;
               return (
                 <SortableSection key={key} id={key}>
-                  <Component problem={problem} {...instanceProps} {...runProps} />
+                  <Component
+                    problem={problem}
+                    {...instanceProps}
+                    {...runProps}
+                    {...certificateProps}
+                  />
                 </SortableSection>
               );
             })}

--- a/components/detail/ReductionsSection.js
+++ b/components/detail/ReductionsSection.js
@@ -3,39 +3,91 @@
 // T16e (#25) — the most complex-looking panel in the mockup, and deliberately
 // the most scoped-down. Reduces-to/reduces-from lists and cost badges are
 // real declared data (data/fixtures.js's `reductions` shape aligns well with
-// the backend); the source/target instance diagrams are still static
-// placeholders (real diagram rendering is T53, once T48-T50 land) — no
-// draggable/editable nodes (v1 scope).
+// the backend); the source/target instance diagrams were static placeholders
+// until T53.
 //
-// The step-scrubber row is real now (T47/#110), via the shared StepScrubber
-// component. A reduction is structurally a 2-frame case, not a UI limitation
-// to work around: `POST /ProblemProvider/visualizeReduction` always returns
-// an empty steps list (`AdditionalControllers/ProblemProvider.cs:312`), so
-// there is only ever a source-shape base frame and a reduced/solved frame,
-// never intermediate steps (INTERACTIVE_LAYER_DESIGN.md §1.3) — so this
-// section always passes `frameCount={2}` rather than deriving a count from
-// data that will never carry more than that.
+// T53 (#116): the source/target canvas is real now, via
+// `POST /ProblemProvider/visualizeReduction` (`requestReducedInstance`,
+// lib/redux/index.js) — reusing the same VisualizationCanvas/renderer dispatch
+// T48-T50 built for the Visualizations section, per
+// ai_documentation/INTERACTIVE_LAYER_DESIGN.md §2.5's source/target asymmetry:
 //
-// The source/target canvas cards are likewise static placeholders (no real
-// diagram-rendering exists yet) rather than an attempt to actually draw a
-// graph — selecting a different "Reduces to" row still updates which target
-// problem the placeholder card and cost badge describe, which is the real
-// interactive behavior the issue's done-when asks for.
+// - The scrubber's two frames (T47/#110) are not "step 1 of a process" the way
+//   Visualizations' are -- `visualizeReduction` always returns exactly 2 frames, and per
+//   §1.3 they're two DIFFERENT problems' shapes, not a before/after of one: frame 0 is the
+//   source instance's own base rendering (this problem's own first declared visualization,
+//   the same one Visualizations would use), frame 1 is the reduced instance's rendering (the
+//   target problem's own first declared visualization, resolved server-side by
+//   `hooks/useProblemDetail.js`'s `buildReductions` and carried as `targetVisualization` on
+//   each `to` entry -- `Navigation/Reductions` itself names no visualization for either
+//   side, and VISUALIZATION_TYPE_CONTRACTS.md §5 already rejected resolving a universal
+//   type by inspecting a frame's own shape instead of a real backend-declared type). So the
+//   scrubber here toggles which problem's instance is shown, not which step of one instance
+//   -- StepScrubber.js's own header already documents this exact split.
+// - Only frame 0 (source) is ever editable, using the exact same per-type edit apparatus
+//   VisualizationsSection.js uses (data/frameEditOps.js's shared op-appliers,
+//   data/instanceSerializers.js's shared serializers) -- §2.3's "editable only applies to
+//   frames[0]" rule and §2.5's source/target asymmetry turn out to be the same rule once
+//   frame 0 is defined as "the source instance."
+// - `visualizeReduction` requires a certificate for the source instance
+//   (INTERACTIVE_LAYER_DESIGN.md §1.3), which only a completed Solvers run can produce --
+//   `certificate` arrives as a prop from ProblemDetailLayout.js (T53, see that file's
+//   header), and this section renders a "nothing to render yet" state until one exists for
+//   the current instance, rather than erroring.
+// - The source pane's Run button bumps the same shared `runToken` Solvers/Visualizations
+//   use (§2.1.1). Because producing a fresh certificate is itself asynchronous (a `/solve`
+//   call Solvers' own effect performs), this section can't fetch the reduction the moment
+//   `runToken` changes -- it also watches `certificate` itself and fetches as soon as one
+//   lands that matches the current instance, whichever of the three sections' Run buttons
+//   triggered it.
 
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyCircuitOp,
+  applyGraphOp,
+  cloneCircuitForEdit,
+  cloneGraphForEdit,
+  SAT3_MAX_LITERALS_PER_CLAUSE,
+} from "../../data/frameEditOps";
+import {
+  serializeBooleanSatisfiabilityInstance,
+  serializeGraphInstance,
+  serializeRecursiveSetInstance,
+} from "../../data/instanceSerializers";
 import { TAXONOMY } from "../../data/taxonomy";
+import { VISUALIZATION_TYPE_MAP } from "../../data/visualizationTypes";
+import {
+  COMPUTE_CANCELLED,
+  COMPUTE_DONE,
+  COMPUTE_FAILED,
+  COMPUTE_RUNNING,
+  useComputeRequest,
+} from "../../hooks/useComputeRequest";
+import { REDUX_API_BASE_URL, requestReducedInstance } from "../../lib/redux";
 import { getFacetAccentColor, thinScrollbarSx } from "../theme";
+import ComputeStatus from "./ComputeStatus";
 import SectionShell from "./SectionShell";
 import StepScrubber from "./StepScrubber";
+import VisualizationCanvas from "./visualizations/VisualizationCanvas";
 
 // #71: fixed list height so a problem with many declared reduction targets
 // scrolls inside the list instead of stretching the section indefinitely.
 const REDUCES_TO_MAX_HEIGHT = 220;
+
+// A reduction is structurally a 2-frame case (INTERACTIVE_LAYER_DESIGN.md §1.3) -- see this
+// file's header for what the two frames actually are.
+const FRAME_COUNT = 2;
+const SOURCE_STEP = 0;
+const REDUCED_STEP = 1;
+
+// One prefix for every id ComputeStatus renders inside this section (ground rule 4).
+const RUN_ID_PREFIX = "reductions-run";
 
 const REDUCTION_COST_FACET = TAXONOMY.find((facet) => facet.key === "reductionCost");
 const REDUCTION_COST_LABELS = new Map(
@@ -73,44 +125,42 @@ function CostBadge({ costKey }) {
   );
 }
 
-function CanvasCard({ title }) {
-  return (
-    <Paper
-      variant="outlined"
-      sx={{ p: 2, borderRadius: 2, display: "flex", flexDirection: "column", gap: 1 }}
-    >
-      <Typography variant="overline" sx={{ color: "text.secondary" }}>
-        {title}
-      </Typography>
-      <Box
-        sx={{
-          height: 140,
-          borderRadius: 1,
-          border: "1px dashed",
-          borderColor: "divider",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          Static preview — live diagrams are a later phase.
-        </Typography>
-      </Box>
-    </Paper>
-  );
+function formatSeconds(milliseconds) {
+  return `${(milliseconds / 1000).toFixed(2)}s`;
 }
 
 /**
  * @param {Object} props
  * @param {Object} props.problem A data/fixtures.js-shaped FixtureProblem.
+ * @param {string} [props.instanceValue] The shared problem instance, owned by
+ *   components/ProblemDetailLayout.js (T35/#93). The source pane renders and edits this
+ *   same value.
+ * @param {(next: string) => void} [props.onInstanceChange] Called with new text when the
+ *   source pane's diagram edit is serialized just before Run (§2.1.2).
+ * @param {number} [props.runToken] The shared Run trigger (T48/#111).
+ * @param {() => void} [props.onRunRequest] Bumps `runToken`. Called by this section's own
+ *   Run button instead of fetching directly.
+ * @param {{value: string, instance: string}|null} [props.certificate] The certificate for
+ *   `instance`, produced by Solvers' own Run (T53/#116, see ProblemDetailLayout.js's
+ *   header). `null` until a solve has completed at least once. Stale (a certificate for a
+ *   since-edited instance) is detected by comparing `certificate.instance` to
+ *   `instanceValue`, the same pattern SolversSection.js's own `instanceChangedSinceRun`
+ *   uses.
  * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
  *   Forwarded straight through to SectionShell — see T18 (#27).
  */
-export default function ReductionsSection({ problem, dragHandleProps }) {
+export default function ReductionsSection({
+  problem,
+  instanceValue = "",
+  onInstanceChange,
+  runToken,
+  onRunRequest,
+  certificate,
+  dragHandleProps,
+}) {
   const { to, from } = problem.reductions;
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [currentStep, setCurrentStep] = useState(0);
+  const [currentStep, setCurrentStep] = useState(SOURCE_STEP);
   const [fromExpanded, setFromExpanded] = useState(true);
 
   const hasTo = to.length > 0;
@@ -118,14 +168,228 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
   const hasAny = hasTo || hasFrom;
   const selected = hasTo ? to[Math.min(selectedIndex, to.length - 1)] : null;
 
-  // Selecting a different reduction target starts its base/reduced toggle
-  // over rather than carrying a step index across to an unrelated pair.
-  // Render-time state adjustment (React's documented pattern for this, not
-  // a useEffect) so it doesn't cost an extra committed render.
+  const reduce = useComputeRequest({ subject: "instance" });
+
+  const trimmedInstance = instanceValue.trim();
+  const canRun = Boolean(selected?.className) && trimmedInstance !== "";
+  const hasCurrentCertificate =
+    Boolean(certificate?.value) && certificate.instance === instanceValue;
+
+  // A rendered frame pair is only ever shown next to the reduction that produced it -- same
+  // guard VisualizationsSection.js/SolversSection.js use for their own live results.
+  const liveFrames =
+    reduce.status === COMPUTE_DONE && reduce.result?.reductionClassName === selected?.className
+      ? reduce.result
+      : null;
+  const instanceChangedSinceRun = Boolean(liveFrames) && liveFrames.instance !== instanceValue;
+
+  // The source pane renders as this problem's own first declared visualization would
+  // (same "always take the first" convention hooks/useProblemDetail.js's buildVerifier
+  // already uses) -- see this file's header for why frame 0 is the source's own shape, not
+  // the reduction's.
+  const sourceVisualization = problem.visualizations?.[0] ?? null;
+  const sourceUniversalType = VISUALIZATION_TYPE_MAP[sourceVisualization?.backendType] ?? null;
+  const isBooleanSatisfiability = sourceUniversalType === "booleanSatisfiability";
+  const isGraph = sourceUniversalType === "graph";
+  const isRecursiveSet = sourceUniversalType === "recursiveSet";
+  const isQuantumCircuit = sourceUniversalType === "quantumCircuit";
+  const isEditableType = isBooleanSatisfiability || isGraph || isRecursiveSet || isQuantumCircuit;
+  const maxLiteralsPerClause =
+    isBooleanSatisfiability && problem.name === "3SAT" ? SAT3_MAX_LITERALS_PER_CLAUSE : undefined;
+
+  // Local-preview-only edit state (INTERACTIVE_LAYER_DESIGN.md §2.1.2/§2.3), source pane
+  // only -- mirrors VisualizationsSection.js's identical state, kept as its own copy here
+  // since the two sections can have independent pending edits open at once.
+  const [editedClauses, setEditedClauses] = useState(null);
+  const [editedGraph, setEditedGraph] = useState(null);
+  const [graphNodeOps, setGraphNodeOps] = useState([]);
+  const [graphHasEdgeEdits, setGraphHasEdgeEdits] = useState(false);
+  const [editedRecursiveData, setEditedRecursiveData] = useState(null);
+  const [editedCircuit, setEditedCircuit] = useState(null);
+  const [serializeError, setSerializeError] = useState(null);
+
+  const sourceFrame = liveFrames?.frames?.[SOURCE_STEP] ?? null;
+  const reducedFrame = liveFrames?.frames?.[REDUCED_STEP] ?? null;
+
+  if (isGraph && currentStep === SOURCE_STEP && sourceFrame && editedGraph === null) {
+    setEditedGraph(cloneGraphForEdit(sourceFrame));
+  }
+
+  function handleClausesChange(updater) {
+    setEditedClauses((current) => updater(current ?? sourceFrame?.clauses ?? []));
+  }
+
+  function applyGraphEdit(op) {
+    setEditedGraph((current) => applyGraphOp(current ?? cloneGraphForEdit(sourceFrame), op));
+    if (op.type === "addNode" || op.type === "removeNode" || op.type === "renameNode") {
+      setGraphNodeOps((ops) => [...ops, op]);
+    } else {
+      setGraphHasEdgeEdits(true);
+    }
+  }
+
+  function applyCircuitEdit(op) {
+    setEditedCircuit((current) =>
+      applyCircuitOp(current ?? cloneCircuitForEdit(sourceFrame.d3), op),
+    );
+  }
+
+  function handleDataChange(updater) {
+    setEditedRecursiveData((current) => updater(current ?? sourceFrame.data));
+  }
+
+  function resetEdits() {
+    setEditedClauses(null);
+    setEditedGraph(null);
+    setGraphNodeOps([]);
+    setGraphHasEdgeEdits(false);
+    setEditedRecursiveData(null);
+    setEditedCircuit(null);
+    setSerializeError(null);
+  }
+
+  function handleSelectReduction(index) {
+    if (index === selectedIndex) return;
+    // Drops any in-flight request and clears the pane, so nothing from the previous
+    // reduction target survives the switch.
+    reduce.reset();
+    setSelectedIndex(index);
+    resetEdits();
+  }
+
+  const { start: startReduce } = reduce;
+  const canReduceNow = canRun && hasCurrentCertificate;
+  const handleReduce = useCallback(() => {
+    if (!canReduceNow) return;
+    const reduction = selected;
+    const instanceAtRun = instanceValue;
+    const solutionAtRun = certificate.value;
+    startReduce(async (signal) => {
+      const frames = await requestReducedInstance(
+        REDUX_API_BASE_URL,
+        reduction.className,
+        instanceAtRun,
+        solutionAtRun,
+        signal,
+      );
+      return {
+        frames: Array.isArray(frames) ? frames : [],
+        reductionClassName: reduction.className,
+        target: reduction.target,
+        instance: instanceAtRun,
+      };
+    });
+  }, [canReduceNow, selected, instanceValue, certificate, startReduce]);
+
+  // The Run affordance's onClick, not `onRunRequest` directly -- a pending sendable source
+  // edit must be serialized into the shared instance *before* Run fires, exactly the same
+  // ordering VisualizationsSection.js's own handleRunClick uses and for the same reason
+  // (onInstanceChange and onRunRequest are both setters on ProblemDetailLayout.js, batched
+  // into one re-render).
+  function handleRunClick() {
+    setSerializeError(null);
+    if (isBooleanSatisfiability && editedClauses !== null) {
+      onInstanceChange?.(serializeBooleanSatisfiabilityInstance(editedClauses));
+    } else if (isGraph && graphNodeOps.length > 0 && sourceFrame) {
+      const baseNodeIds = sourceFrame.nodes.map((node) => node.id);
+      const result = serializeGraphInstance(instanceValue, baseNodeIds, graphNodeOps);
+      if ("error" in result) {
+        setSerializeError(result.error);
+        return;
+      }
+      onInstanceChange?.(result.instanceText);
+    } else if (isRecursiveSet && editedRecursiveData !== null) {
+      onInstanceChange?.(serializeRecursiveSetInstance(editedRecursiveData));
+    }
+    if (onRunRequest) {
+      onRunRequest();
+    } else {
+      handleReduce();
+    }
+  }
+
+  // Reacts to the shared Run trigger (T48/#111). A fresh certificate for the current
+  // instance may not exist yet the instant this fires -- `canReduceNow` no-ops `handleReduce`
+  // until one does, and the effect below picks it up once Solvers' own `/solve` resolves.
+  const previousRunTokenRef = useRef(runToken);
+  useEffect(() => {
+    if (runToken === undefined || runToken === previousRunTokenRef.current) return;
+    previousRunTokenRef.current = runToken;
+    handleReduce();
+  }, [runToken, handleReduce]);
+
+  // Reacts to a certificate arriving or changing (ProblemDetailLayout.js, T53/#116) --
+  // this is what actually fires the fetch when Run was pressed before Solvers' own solve
+  // had resolved, and also what refreshes this pane automatically if the visitor solves
+  // again from the Solvers section directly without touching this one at all.
+  const previousCertificateRef = useRef(certificate);
+  useEffect(() => {
+    if (certificate === previousCertificateRef.current) return;
+    previousCertificateRef.current = certificate;
+    handleReduce();
+  }, [certificate, handleReduce]);
+
+  // Independent render-time resets (React's documented "adjust state" pattern): selecting a
+  // different reduction target starts its source/reduced toggle over; a freshly-completed
+  // fetch replaces the frames currently shown, which resets the step position and drops any
+  // pending edit (§2.1.2).
   const [stepResetKey, setStepResetKey] = useState(selectedIndex);
   if (stepResetKey !== selectedIndex) {
     setStepResetKey(selectedIndex);
-    setCurrentStep(0);
+    setCurrentStep(SOURCE_STEP);
+  }
+  const [lastReduceResult, setLastReduceResult] = useState(reduce.result);
+  if (lastReduceResult !== reduce.result) {
+    setLastReduceResult(reduce.result);
+    setCurrentStep(SOURCE_STEP);
+    if (editedClauses !== null) setEditedClauses(null);
+    if (editedGraph !== null) setEditedGraph(null);
+    if (graphNodeOps.length > 0) setGraphNodeOps([]);
+    if (graphHasEdgeEdits) setGraphHasEdgeEdits(false);
+    if (editedRecursiveData !== null) setEditedRecursiveData(null);
+    if (editedCircuit !== null) setEditedCircuit(null);
+  }
+
+  const isEditingSource = currentStep === SOURCE_STEP && isEditableType;
+  const fetchedFrame = currentStep === SOURCE_STEP ? sourceFrame : reducedFrame;
+  let currentFrame = fetchedFrame;
+  if (isEditingSource && fetchedFrame) {
+    if (isBooleanSatisfiability && editedClauses !== null) {
+      currentFrame = { clauses: editedClauses };
+    } else if (isGraph && editedGraph) {
+      currentFrame = { nodes: editedGraph.nodes, links: editedGraph.links };
+    } else if (isRecursiveSet && editedRecursiveData !== null) {
+      currentFrame = { data: editedRecursiveData };
+    } else if (isQuantumCircuit && editedCircuit) {
+      currentFrame = { ...fetchedFrame, d3: { ...fetchedFrame.d3, ...editedCircuit } };
+    }
+  }
+
+  const hasPendingEdit =
+    (isBooleanSatisfiability && editedClauses !== null) ||
+    (isGraph && (graphNodeOps.length > 0 || graphHasEdgeEdits)) ||
+    (isRecursiveSet && editedRecursiveData !== null) ||
+    (isQuantumCircuit && editedCircuit !== null);
+
+  const currentBackendType =
+    currentStep === SOURCE_STEP
+      ? sourceVisualization?.backendType
+      : selected?.targetVisualization?.backendType;
+  const paneLabel =
+    currentStep === SOURCE_STEP
+      ? `${problem.name.toUpperCase()} INSTANCE — SOURCE`
+      : `${(selected?.target ?? "").toUpperCase()} INSTANCE — REDUCED`;
+
+  const targetName = selected?.target ?? "this problem";
+  let announcement = "";
+  if (reduce.status === COMPUTE_RUNNING) {
+    announcement = `Rendering the reduction to ${targetName}. This can take up to a minute.`;
+  } else if (reduce.status === COMPUTE_DONE) {
+    announcement = `Reduction to ${targetName} rendered in ${formatSeconds(reduce.elapsedMs)}.`;
+  } else if (reduce.status === COMPUTE_FAILED) {
+    announcement = `The reduction to ${targetName} did not render. ${reduce.failure?.headline ?? ""}`;
+  } else if (reduce.status === COMPUTE_CANCELLED) {
+    announcement = "Run cancelled.";
   }
 
   const total = to.length + from.length;
@@ -148,39 +412,123 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
       )}
 
       {hasTo && (
-        <Box sx={{ mb: 2 }}>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mb: 3 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+            <Button
+              id="reductions-run-button"
+              variant="outlined"
+              size="small"
+              disabled={!canRun || reduce.isRunning}
+              onClick={handleRunClick}
+            >
+              Run
+            </Button>
+            {!canRun && (
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                Add a problem instance above to render this reduction.
+              </Typography>
+            )}
+          </Box>
+
           <StepScrubber
             idPrefix="reductions-scrubber"
-            frameCount={2}
+            frameCount={FRAME_COUNT}
             currentStep={currentStep}
             onStepChange={setCurrentStep}
             frameNoun="Frame"
           />
-          <Typography variant="body2" sx={{ color: "text.secondary", mt: 1, fontStyle: "italic" }}>
+          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
             A reduction is a single mapping, not a stepped process — this toggles between the source
-            instance and the reduced instance, with no intermediate steps.
+            instance and the {costLabel(selected.cost).toLowerCase()} reduction&apos;s result, with
+            no intermediate steps.
           </Typography>
-        </Box>
-      )}
 
-      {hasTo && (
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 3 }}>
-          <CanvasCard title={`${problem.name.toUpperCase()} INSTANCE — SOURCE`} />
-          <Box
-            sx={(theme) => ({
-              alignSelf: "center",
-              px: 1.5,
-              py: 0.5,
-              borderRadius: 999,
-              backgroundColor: alpha(theme.palette.primary.main, 0.15),
-              color: "primary.light",
-              fontSize: "0.8125rem",
-              fontWeight: 700,
-            })}
-          >
-            ↓ {costLabel(selected.cost)} reduction
-          </Box>
-          <CanvasCard title={`${selected.target.toUpperCase()} INSTANCE — REDUCED`} />
+          <ComputeStatus
+            idPrefix={RUN_ID_PREFIX}
+            status={reduce.status}
+            announcement={announcement}
+            failure={reduce.failure}
+            onCancel={reduce.cancel}
+            busyLabel={`Rendering the reduction to ${targetName}`}
+          />
+
+          {!hasCurrentCertificate && !liveFrames && reduce.status !== COMPUTE_RUNNING && (
+            <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+              Nothing to render yet. A reduction needs a solved certificate for the source instance
+              first — press Run to solve it and render this reduction together.
+            </Typography>
+          )}
+
+          {liveFrames ? (
+            <Paper
+              variant="outlined"
+              sx={{ p: 2, borderRadius: 2, display: "flex", flexDirection: "column", gap: 1 }}
+            >
+              <Typography variant="overline" sx={{ color: "text.secondary" }}>
+                {paneLabel}
+              </Typography>
+              <Box
+                sx={{
+                  minHeight: 220,
+                  borderRadius: 1,
+                  border: "1px solid",
+                  borderColor: "divider",
+                }}
+              >
+                <VisualizationCanvas
+                  idPrefix="reductions-canvas"
+                  instanceName={currentStep === SOURCE_STEP ? problem.name : targetName}
+                  backendType={currentBackendType}
+                  frame={currentFrame}
+                  editable={isEditingSource}
+                  onClausesChange={isEditingSource ? handleClausesChange : undefined}
+                  maxLiteralsPerClause={maxLiteralsPerClause}
+                  onGraphEdit={isEditingSource ? applyGraphEdit : undefined}
+                  onDataChange={isEditingSource ? handleDataChange : undefined}
+                  onCircuitEdit={isEditingSource ? applyCircuitEdit : undefined}
+                />
+              </Box>
+              {serializeError && (
+                <Typography variant="body2" sx={{ color: "error.light" }}>
+                  {serializeError}
+                </Typography>
+              )}
+              {hasPendingEdit && (
+                <Typography variant="body2" sx={{ color: "warning.light" }}>
+                  {isQuantumCircuit
+                    ? "This diagram has unsaved edits. They preview here but can't be sent to Run yet for this visualization type."
+                    : "This diagram has unsaved edits. Press Run to send them to the backend."}
+                </Typography>
+              )}
+              {instanceChangedSinceRun && (
+                <Typography variant="body2" sx={{ color: "warning.light" }}>
+                  The instance has been edited since this ran. Run again to render the reduction for
+                  the instance currently in the box.
+                </Typography>
+              )}
+            </Paper>
+          ) : (
+            hasCurrentCertificate &&
+            reduce.status !== COMPUTE_RUNNING &&
+            reduce.status !== COMPUTE_FAILED && (
+              <Box
+                sx={{
+                  minHeight: 220,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  borderRadius: 2,
+                  border: "1px solid",
+                  borderColor: "divider",
+                  color: "text.secondary",
+                }}
+              >
+                <Typography variant="body2" sx={{ fontStyle: "italic" }}>
+                  Not yet run.
+                </Typography>
+              </Box>
+            )
+          )}
 
           <Typography variant="overline" sx={{ color: "text.secondary", mt: 1 }}>
             Reduces to
@@ -207,7 +555,7 @@ export default function ReductionsSection({ problem, dragHandleProps }) {
                   type="button"
                   role="option"
                   aria-selected={isSelected}
-                  onClick={() => setSelectedIndex(index)}
+                  onClick={() => handleSelectReduction(index)}
                   sx={(theme) => ({
                     display: "flex",
                     alignItems: "center",

--- a/components/detail/SolversSection.js
+++ b/components/detail/SolversSection.js
@@ -151,6 +151,12 @@ function formatSeconds(milliseconds) {
  *   Run was pressed somewhere -- this section or another `usesRun` one.
  * @param {() => void} [props.onRunRequest] Bumps `runToken`. Called by this
  *   section's own Run button instead of solving directly.
+ * @param {(certificate: {value: string, instance: string}) => void} [props.onCertificateChange]
+ *   Called with the solved instance and the instance it was solved from every time a solve
+ *   completes successfully (T53/#116). ProblemDetailLayout.js holds the one shared copy so
+ *   ReductionsSection can use it as the certificate `ProblemProvider/visualizeReduction`
+ *   requires -- see that file's header for why this lives here rather than being lifted
+ *   into a shared Run action outright.
  * @param {{attributes: Object, listeners: Object}} [props.dragHandleProps]
  *   Forwarded straight through to SectionShell — see T18 (#27).
  */
@@ -160,6 +166,7 @@ export default function SolversSection({
   onInstanceChange,
   runToken,
   onRunRequest,
+  onCertificateChange,
   dragHandleProps,
 }) {
   const solvers = problem.solvers ?? [];
@@ -206,6 +213,9 @@ export default function SolversSection({
         instanceAtRun,
         signal,
       );
+      // T53 (#116): reported up regardless of which solver produced it -- Reductions only
+      // needs *a* certificate for the current instance, not one from any particular solver.
+      onCertificateChange?.({ value: output, instance: instanceAtRun });
       return {
         output,
         solverClassName: solver.className,
@@ -213,7 +223,7 @@ export default function SolversSection({
         instance: instanceAtRun,
       };
     });
-  }, [canRun, selected, instanceValue, startRun]);
+  }, [canRun, selected, instanceValue, startRun, onCertificateChange]);
 
   // Reacts to the shared Run trigger (T48/#111, see file header) rather than
   // performing the solve inline in the button's onClick -- that way it fires

--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -49,6 +49,13 @@ import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  applyCircuitOp,
+  applyGraphOp,
+  cloneCircuitForEdit,
+  cloneGraphForEdit,
+  SAT3_MAX_LITERALS_PER_CLAUSE,
+} from "../../data/frameEditOps";
+import {
   serializeBooleanSatisfiabilityInstance,
   serializeGraphInstance,
   serializeRecursiveSetInstance,
@@ -70,177 +77,6 @@ import StepScrubber from "./StepScrubber";
 import VisualizationCanvas from "./visualizations/VisualizationCanvas";
 
 const VISUALIZATION_TYPE_FACET = TAXONOMY.find((facet) => facet.key === "visualizationType");
-
-// SAT3's literal-per-clause cap (VISUALIZATION_TYPE_CONTRACTS.md §3.3, T52/#115's own
-// issue body) -- SAT itself has no cap. "3SAT" is the real backend `problemName` (per
-// data/supplementalTags.js's own header note: code "SAT3" -> problemName "3SAT"), not the
-// visualization/solver class-name spelling, so this checks the problem, not the
-// visualization, since the cap is a property of the problem's grammar, not of any one
-// visualization instance.
-const SAT3_MAX_LITERALS_PER_CLAUSE = 3;
-
-// Ids assigned to a newly-added edge/gate within one editing session only need to be
-// unique within that session (React keys, DOM ids) -- a module-level counter is enough.
-let editIdCounter = 0;
-function nextEditId(prefix) {
-  editIdCounter += 1;
-  return `${prefix}-${editIdCounter}`;
-}
-
-function cloneGraphForEdit(frame) {
-  return {
-    nodes: frame.nodes.map((node) => ({ ...node, _key: node.id })),
-    links: frame.links.map((link) => ({ ...link, _key: link.id })),
-  };
-}
-
-// Applies one GraphRenderer edit descriptor to a cloned {nodes, links} structure.
-// Referential integrity for node removal/rename (an edge can't be left dangling, per
-// T46's finding that SPADE itself won't catch this) is handled locally here the same way
-// data/spadeInstanceText.js's `removeLeafEverywhere`/`renameLeafEverywhere` handle it in
-// the text -- the two are independent implementations of the same rule, one over the
-// in-memory structure for the local preview, one over the parsed text for Run.
-function applyGraphOp(current, op) {
-  switch (op.type) {
-    case "addNode": {
-      if (current.nodes.some((node) => node.id === op.id)) return current;
-      return {
-        ...current,
-        nodes: [
-          ...current.nodes,
-          {
-            id: op.id,
-            name: op.id,
-            color: "",
-            outline: "",
-            delay: "",
-            dashed: "",
-            additional: "",
-            _key: op.id,
-          },
-        ],
-      };
-    }
-    case "removeNode":
-      return {
-        nodes: current.nodes.filter((node) => node.id !== op.id),
-        links: current.links.filter((link) => link.source !== op.id && link.target !== op.id),
-      };
-    case "renameNode": {
-      if (op.from === op.to || current.nodes.some((node) => node.id === op.to)) return current;
-      return {
-        nodes: current.nodes.map((node) =>
-          node.id === op.from ? { ...node, id: op.to, name: op.to } : node,
-        ),
-        links: current.links.map((link) => ({
-          ...link,
-          source: link.source === op.from ? op.to : link.source,
-          target: link.target === op.from ? op.to : link.target,
-        })),
-      };
-    }
-    case "addEdge": {
-      if (op.source === op.target) return current;
-      const alreadyExists = current.links.some(
-        (link) =>
-          (link.source === op.source && link.target === op.target) ||
-          (link.source === op.target && link.target === op.source),
-      );
-      if (alreadyExists) return current;
-      return {
-        ...current,
-        links: [
-          ...current.links,
-          {
-            id: nextEditId("edge"),
-            _key: nextEditId("edge-key"),
-            source: op.source,
-            target: op.target,
-            color: "",
-            dashed: "",
-            delay: "",
-            weight: "",
-            weighted: false,
-            directed: false,
-            attribute1: "",
-            attribute2: "",
-          },
-        ],
-      };
-    }
-    case "removeEdge":
-      return { ...current, links: current.links.filter((link) => link.id !== op.id) };
-    default:
-      return current;
-  }
-}
-
-function cloneCircuitForEdit(d3) {
-  return {
-    qubits: [...d3.qubits],
-    classical: [...(d3.classical ?? [])],
-    gates: (d3.gates ?? []).map((gate) => ({ ...gate, targets: [...gate.targets] })),
-    overlays: d3.overlays ?? [],
-    metadata: d3.metadata ?? null,
-  };
-}
-
-// Local-preview-only (data/instanceSerializers.js has no `quantumCircuit` serializer --
-// see that file's header) -- so unlike `applyGraphOp`, nothing here needs to track a
-// separate op log for Run.
-function applyCircuitOp(current, op) {
-  switch (op.type) {
-    case "addQubit":
-      if (current.qubits.includes(op.id)) return current;
-      return { ...current, qubits: [...current.qubits, op.id] };
-    case "removeQubit":
-      return {
-        ...current,
-        qubits: current.qubits.filter((qubit) => qubit !== op.id),
-        gates: current.gates.filter((gate) => !gate.targets.includes(op.id)),
-      };
-    case "renameQubit": {
-      if (op.from === op.to || current.qubits.includes(op.to)) return current;
-      return {
-        ...current,
-        qubits: current.qubits.map((qubit) => (qubit === op.from ? op.to : qubit)),
-        gates: current.gates.map((gate) => ({
-          ...gate,
-          targets: gate.targets.map((target) => (target === op.from ? op.to : target)),
-        })),
-      };
-    }
-    case "addGate": {
-      const maxTime = current.gates.reduce((max, gate) => Math.max(max, gate.time ?? 0), -1);
-      return {
-        ...current,
-        gates: [
-          ...current.gates,
-          {
-            id: nextEditId("gate"),
-            type: op.gateType,
-            targets: [op.target],
-            classical: null,
-            params: null,
-            label: null,
-            time: maxTime + 1,
-          },
-        ],
-      };
-    }
-    case "removeGate":
-      return { ...current, gates: current.gates.filter((gate) => gate.id !== op.id) };
-    case "relabelGate":
-      return {
-        ...current,
-        gates: current.gates.map((gate) =>
-          gate.id === op.id ? { ...gate, type: op.gateType } : gate,
-        ),
-      };
-    default:
-      return current;
-  }
-}
 
 // #71: fixed rail height so a problem with many declared visualizations
 // scrolls inside the rail instead of stretching the section indefinitely.

--- a/data/frameEditOps.js
+++ b/data/frameEditOps.js
@@ -1,0 +1,183 @@
+// data/frameEditOps.js
+//
+// Pure, framework-free helpers for applying a local structural edit to an in-memory
+// `graph`/`quantumCircuit` frame (INTERACTIVE_LAYER_DESIGN.md §2.1.2's local preview).
+// Originally written inline in components/detail/VisualizationsSection.js by T51/T52
+// (#114/#115); pulled out here by T53 (#116) once components/detail/ReductionsSection.js
+// needed the exact same op-applying logic for its own source pane -- moving already-generic
+// pure functions to their second real call site, not a speculative abstraction.
+//
+// SAT3_MAX_LITERALS_PER_CLAUSE lives here for the same reason: both sections need the same
+// cap and neither owns it more than the other.
+
+// SAT3's literal-per-clause cap (VISUALIZATION_TYPE_CONTRACTS.md §3.3, T52/#115's own
+// issue body) -- SAT itself has no cap. "3SAT" is the real backend `problemName` (per
+// data/supplementalTags.js's own header note: code "SAT3" -> problemName "3SAT"), not the
+// visualization/solver class-name spelling, so callers check the problem, not the
+// visualization, since the cap is a property of the problem's grammar, not of any one
+// visualization instance.
+export const SAT3_MAX_LITERALS_PER_CLAUSE = 3;
+
+// Ids assigned to a newly-added edge/gate within one editing session only need to be
+// unique within that session (React keys, DOM ids) -- a module-level counter is enough,
+// shared across every caller so two sections editing at once can never collide.
+let editIdCounter = 0;
+export function nextEditId(prefix) {
+  editIdCounter += 1;
+  return `${prefix}-${editIdCounter}`;
+}
+
+export function cloneGraphForEdit(frame) {
+  return {
+    nodes: frame.nodes.map((node) => ({ ...node, _key: node.id })),
+    links: frame.links.map((link) => ({ ...link, _key: link.id })),
+  };
+}
+
+// Applies one GraphRenderer edit descriptor to a cloned {nodes, links} structure.
+// Referential integrity for node removal/rename (an edge can't be left dangling, per
+// T46's finding that SPADE itself won't catch this) is handled locally here the same way
+// data/spadeInstanceText.js's `removeLeafEverywhere`/`renameLeafEverywhere` handle it in
+// the text -- the two are independent implementations of the same rule, one over the
+// in-memory structure for the local preview, one over the parsed text for Run.
+export function applyGraphOp(current, op) {
+  switch (op.type) {
+    case "addNode": {
+      if (current.nodes.some((node) => node.id === op.id)) return current;
+      return {
+        ...current,
+        nodes: [
+          ...current.nodes,
+          {
+            id: op.id,
+            name: op.id,
+            color: "",
+            outline: "",
+            delay: "",
+            dashed: "",
+            additional: "",
+            _key: op.id,
+          },
+        ],
+      };
+    }
+    case "removeNode":
+      return {
+        nodes: current.nodes.filter((node) => node.id !== op.id),
+        links: current.links.filter((link) => link.source !== op.id && link.target !== op.id),
+      };
+    case "renameNode": {
+      if (op.from === op.to || current.nodes.some((node) => node.id === op.to)) return current;
+      return {
+        nodes: current.nodes.map((node) =>
+          node.id === op.from ? { ...node, id: op.to, name: op.to } : node,
+        ),
+        links: current.links.map((link) => ({
+          ...link,
+          source: link.source === op.from ? op.to : link.source,
+          target: link.target === op.from ? op.to : link.target,
+        })),
+      };
+    }
+    case "addEdge": {
+      if (op.source === op.target) return current;
+      const alreadyExists = current.links.some(
+        (link) =>
+          (link.source === op.source && link.target === op.target) ||
+          (link.source === op.target && link.target === op.source),
+      );
+      if (alreadyExists) return current;
+      return {
+        ...current,
+        links: [
+          ...current.links,
+          {
+            id: nextEditId("edge"),
+            _key: nextEditId("edge-key"),
+            source: op.source,
+            target: op.target,
+            color: "",
+            dashed: "",
+            delay: "",
+            weight: "",
+            weighted: false,
+            directed: false,
+            attribute1: "",
+            attribute2: "",
+          },
+        ],
+      };
+    }
+    case "removeEdge":
+      return { ...current, links: current.links.filter((link) => link.id !== op.id) };
+    default:
+      return current;
+  }
+}
+
+export function cloneCircuitForEdit(d3) {
+  return {
+    qubits: [...d3.qubits],
+    classical: [...(d3.classical ?? [])],
+    gates: (d3.gates ?? []).map((gate) => ({ ...gate, targets: [...gate.targets] })),
+    overlays: d3.overlays ?? [],
+    metadata: d3.metadata ?? null,
+  };
+}
+
+// Local-preview-only (data/instanceSerializers.js has no `quantumCircuit` serializer --
+// see that file's header) -- so unlike `applyGraphOp`, nothing here needs to track a
+// separate op log for Run.
+export function applyCircuitOp(current, op) {
+  switch (op.type) {
+    case "addQubit":
+      if (current.qubits.includes(op.id)) return current;
+      return { ...current, qubits: [...current.qubits, op.id] };
+    case "removeQubit":
+      return {
+        ...current,
+        qubits: current.qubits.filter((qubit) => qubit !== op.id),
+        gates: current.gates.filter((gate) => !gate.targets.includes(op.id)),
+      };
+    case "renameQubit": {
+      if (op.from === op.to || current.qubits.includes(op.to)) return current;
+      return {
+        ...current,
+        qubits: current.qubits.map((qubit) => (qubit === op.from ? op.to : qubit)),
+        gates: current.gates.map((gate) => ({
+          ...gate,
+          targets: gate.targets.map((target) => (target === op.from ? op.to : target)),
+        })),
+      };
+    }
+    case "addGate": {
+      const maxTime = current.gates.reduce((max, gate) => Math.max(max, gate.time ?? 0), -1);
+      return {
+        ...current,
+        gates: [
+          ...current.gates,
+          {
+            id: nextEditId("gate"),
+            type: op.gateType,
+            targets: [op.target],
+            classical: null,
+            params: null,
+            label: null,
+            time: maxTime + 1,
+          },
+        ],
+      };
+    }
+    case "removeGate":
+      return { ...current, gates: current.gates.filter((gate) => gate.id !== op.id) };
+    case "relabelGate":
+      return {
+        ...current,
+        gates: current.gates.map((gate) =>
+          gate.id === op.id ? { ...gate, type: op.gateType } : gate,
+        ),
+      };
+    default:
+      return current;
+  }
+}

--- a/data/instanceSerializers.js
+++ b/data/instanceSerializers.js
@@ -59,9 +59,11 @@ export function serializeBooleanSatisfiabilityInstance(clauses) {
  * @param {string[]} baseNodeIds The `graph` frame's node ids as of that same fetch, before
  *   any of `nodeOps` were applied -- the "known identity" this module's location step
  *   matches against (see data/spadeInstanceText.js's header).
- * @param {Array<{type: "add"|"remove"|"rename", id?: string, from?: string, to?: string}>} nodeOps
- *   Ordered edit log: `{type: "add", id}`, `{type: "remove", id}`, or
- *   `{type: "rename", from, to}`. Edge edits never appear here -- see below.
+ * @param {Array<{type: "addNode"|"removeNode"|"renameNode", id?: string, from?: string, to?: string}>} nodeOps
+ *   Ordered edit log: `{type: "addNode", id}`, `{type: "removeNode", id}`, or
+ *   `{type: "renameNode", from, to}` -- the same vocabulary `applyGraphOp`
+ *   (data/frameEditOps.js) and GraphRenderer.js's `onGraphEdit` calls use. Edge edits never
+ *   appear here -- see below.
  * @returns {{instanceText: string} | {error: string}} `error` when the current instance
  *   text can't be parsed under the generic bracket grammar at all, or when an `add` can't
  *   find a matching node-id set to add into (both real, surfaceable failures, not silent
@@ -105,10 +107,21 @@ export function serializeGraphInstance(originalInstanceText, baseNodeIds, nodeOp
 
   let currentIds = [...baseNodeIds];
   for (const op of nodeOps) {
-    if (op.type === "rename") {
+    // T53 (#116) fix: these three op-type strings previously read "rename"/"remove"/"add",
+    // which never matched anything a caller actually sends -- GraphRenderer.js's
+    // `onGraphEdit` calls (and components/detail/VisualizationsSection.js's/
+    // ReductionsSection.js's own `graphNodeOps` tracking) have always used "renameNode"/
+    // "removeNode"/"addNode" (see applyGraphOp in data/frameEditOps.js). With the old
+    // strings, every branch below was silently unreachable: the loop fell through with no
+    // `else`, `tree` and `currentIds` never changed, and this function quietly returned the
+    // original text back as if nothing were wrong -- so a node edit's own local preview
+    // looked correct while Run sent the *unedited* instance to the backend. Caught by
+    // testing T53's own source-pane Run round trip end to end, not something T53 changed on
+    // purpose.
+    if (op.type === "renameNode") {
       tree = renameLeafEverywhere(tree, op.from, op.to);
       currentIds = currentIds.map((id) => (id === op.from ? op.to : id));
-    } else if (op.type === "remove") {
+    } else if (op.type === "removeNode") {
       // The located node-id set is passed as the protected subtree so it always shrinks
       // by one, never gets collapsed by the pair-removal heuristic that also runs in this
       // same pass -- see removeLeafEverywhere's own doc comment for why a plain two-node
@@ -116,7 +129,7 @@ export function serializeGraphInstance(originalInstanceText, baseNodeIds, nodeOp
       const protectedNode = findExactLeafSetNode(tree, currentIds);
       tree = removeLeafEverywhere(tree, op.id, protectedNode);
       currentIds = currentIds.filter((id) => id !== op.id);
-    } else if (op.type === "add") {
+    } else if (op.type === "addNode") {
       const next = addLeafToMatchingSet(tree, currentIds, op.id);
       if (next === tree) {
         return {

--- a/hooks/useProblemDetail.js
+++ b/hooks/useProblemDetail.js
@@ -131,7 +131,28 @@ function buildVerifier(verifierClassNames, info, problemInfo) {
   };
 }
 
-function buildReductions(problemCode, reductionGraph, codeToName) {
+// T53 (#116): `to` entries carry two things T18-era `buildReductions` never needed --
+// `className` (the reduction's own class name, e.g. "KarpVertexCoverToSetCover", what
+// `ProblemProvider/visualizeReduction?reduction=` takes -- confirmed directly against a
+// local Redux backend) and `targetVisualization` (the reduced problem's own default
+// visualization, resolved through the exact same `buildVisualizations` this file already
+// uses for the current problem). The reduced pane needs a `backendType` to pick a renderer
+// the same way the current problem's own visualizations do (VisualizationCanvas ->
+// resolveVisualizationType), and `Navigation/Reductions` itself carries no type field for
+// either side of a reduction -- VISUALIZATION_TYPE_CONTRACTS.md §5 already rejected
+// resolving a universal type by inspecting a frame's own shape ("duck-typing... this
+// project would rather have one static, readable map than six inline heuristics"), so this
+// resolves the target's type the same static-map way, not by sniffing the fetched frame.
+// `from` entries get neither: they're informational only, never selectable
+// (ReductionsSection.js), so nothing ever renders a diagram for one.
+function buildReductions(
+  problemCode,
+  reductionGraph,
+  codeToName,
+  visualizationsByProblem,
+  info,
+  visualizationTypesByInstance,
+) {
   const to = [];
   const from = [];
 
@@ -139,10 +160,17 @@ function buildReductions(problemCode, reductionGraph, codeToName) {
     for (const [toCode, edges] of Object.entries(toMap)) {
       for (const edge of edges) {
         if (fromCode === problemCode) {
+          const [targetVisualization] = buildVisualizations(
+            visualizationsByProblem[toCode],
+            info,
+            visualizationTypesByInstance,
+          );
           to.push({
             target: codeToName.get(toCode) ?? toCode,
             cost: REDUCTION_COST_MAP[edge.cost],
             type: REDUCTION_TYPE_MAP[edge.reductionType],
+            className: edge.className,
+            targetVisualization: targetVisualization ?? null,
           });
         }
         if (toCode === problemCode) {
@@ -211,7 +239,14 @@ function buildProblem(problemCode, info, batches, codeToName) {
       visualizationTypesByInstance,
     ),
     verifier: buildVerifier(verifiersByProblem[problemCode], info, problemInfo),
-    reductions: buildReductions(problemCode, reductionGraph, codeToName),
+    reductions: buildReductions(
+      problemCode,
+      reductionGraph,
+      codeToName,
+      visualizationsByProblem,
+      info,
+      visualizationTypesByInstance,
+    ),
   };
 }
 

--- a/lib/redux/index.js
+++ b/lib/redux/index.js
@@ -360,3 +360,35 @@ export async function requestVisualizedInstance(url, visualization, instance, si
     signal,
   );
 }
+
+/**
+ * Renders the source-then-reduced frame pair for one reduction, applied to a source
+ * problem instance.
+ *
+ * T53 (#116) is the first caller. Checked directly against a local Redux backend: posting
+ * with neither query parameter returns HTTP 400 naming `reduction` and `solution` as the
+ * two required fields (matching `ai_documentation/INTERACTIVE_LAYER_DESIGN.md` §1.3's read
+ * of `AdditionalControllers/ProblemProvider.cs:290-313`) -- the same query-string-plus-
+ * bare-body shape `requestVisualizedInstance` above already uses, just with a second query
+ * parameter. The response is the same bare JSON frame array `requestVisualizedInstance`
+ * returns, always exactly 2 entries (base, then solved/reduced) per that same source.
+ *
+ * @param {string} url Base URL of the Redux API.
+ * @param {string} reduction Reduction class name, e.g. "KarpVertexCoverToSetCover" -- the
+ * `className` field `Navigation/Reductions` lists for this reduction edge.
+ * @param {string} instance The source problem instance being reduced.
+ * @param {string} solution A certificate for `instance`, produced by a prior `/solve`
+ * call -- this endpoint has no way to derive the reduced instance without one
+ * (INTERACTIVE_LAYER_DESIGN.md §1.3).
+ * @param {AbortSignal} [signal] Optional, same caveat as `requestSolvedInstance`.
+ * @returns the ordered frame array (source base, then reduced/solved).
+ * @throws {ReduxRequestError} if the request fails.
+ */
+export async function requestReducedInstance(url, reduction, instance, solution, signal) {
+  return await fetchPostJson(
+    `${url}ProblemProvider/visualizeReduction?reduction=${encodeURIComponent(reduction)}&solution=${encodeURIComponent(solution)}`,
+    instance,
+    () => `${reduction} VISUALIZE REDUCTION REQUEST FAILED`,
+    signal,
+  );
+}

--- a/pages/api/redux/[...path].js
+++ b/pages/api/redux/[...path].js
@@ -75,8 +75,9 @@ const rateLimitBuckets = new Map();
  * `lib/redux/index.js`. That is a deliberate exception to "the list holds what the site
  * actually uses": Track B's design tasks (T41, #99; T42, #100) need to see real
  * visualization payloads through this app's own proxy, and nothing can render one while
- * the proxy 404s the request first. `ProblemProvider/visualizeReduction` has the same
- * compute profile and is deliberately NOT added yet -- see the comment below.
+ * the proxy 404s the request first. `ProblemProvider/visualizeReduction` had the same
+ * compute profile and was deliberately left out until T53 (#116) gave it a real caller
+ * (`requestReducedInstance`, `lib/redux/index.js`) -- it is allowed below now.
  *
  * Keys are paths relative to `REDUX_BASE_URL`, matched exactly and case-sensitively.
  * Query strings are not part of the match.
@@ -92,11 +93,7 @@ const ALLOWED_ENDPOINTS = new Map([
   ["ProblemProvider/solve", ["POST"]],
   ["ProblemProvider/verify", ["POST"]],
   ["ProblemProvider/visualize", ["POST"]],
-  // ProblemProvider/visualizeReduction is NOT here. It has the same compute profile as
-  // `visualize` above, but nothing calls it yet. Add it, and its COMPUTE_ENDPOINTS entry
-  // below, in whichever task first wires the Reductions section against live data --
-  // not before, per this allowlist's own principle that it holds what the site actually
-  // uses. (T44, #103)
+  ["ProblemProvider/visualizeReduction", ["POST"]],
 ]);
 
 /** Endpoints that run an algorithm rather than returning a stored lookup. */
@@ -104,6 +101,7 @@ const COMPUTE_ENDPOINTS = new Set([
   "ProblemProvider/solve",
   "ProblemProvider/verify",
   "ProblemProvider/visualize",
+  "ProblemProvider/visualizeReduction",
 ]);
 
 export const config = {


### PR DESCRIPTION
Issue:  #116 (T53: Wire Reductions to live data, with the source/target editing asymmetry)
Branch: task/T53-reductions-live-wiring

Changed:
  components/detail/ReductionsSection.js   (rewritten — real rendering via visualizeReduction)
  components/ProblemDetailLayout.js        (shared certificate state; Reductions joins usesRun/usesInstance)
  components/detail/SolversSection.js      (reports its solve output up as the shared certificate)
  components/detail/VisualizationsSection.js (edit-op helpers extracted, no behavior change)
  hooks/useProblemDetail.js                (reduction entries now carry className + the target's own visualization)
  lib/redux/index.js                       (new requestReducedInstance)
  pages/api/redux/[...path].js             (proxy now allows ProblemProvider/visualizeReduction)
  data/instanceSerializers.js              (bug fix, see below)
  data/frameEditOps.js                     (new — shared graph/circuit edit-op appliers)

Done when, met:
  - Selecting a "Reduces to" entry renders the real source and reduced instances via
    visualizeReduction, replacing the static placeholder cards.
  - The source pane is editable (shares the instance with Solvers/Visualizations, including
    the full graph/SAT/recursive-set/quantum-circuit edit apparatus); the target pane is
    view-only.
  - T47's scrubber is wired in, toggling between the two structurally-fixed frames.
  - The section shows a "nothing to render yet" message before a certificate exists for the
    source instance, rather than erroring.
  - The source pane's Run button bumps the same shared runToken Solvers/Visualizations use.

How I verified it: ran the app against the live production Redux backend (local backend on
:27000 wasn't reachable) and drove it with Playwright — confirmed the full chain end to end
on Clique -> Vertex Cover: Run press -> Solvers auto-solves -> certificate lands ->
visualizeReduction fires -> both panes render with correct, independently-resolved
universal types (graph/graph in this case) -> editing a node and pressing Run again
round-trips the edit through /solve.

Bug found and fixed along the way (not introduced by this task):
  data/instanceSerializers.js's serializeGraphInstance checked op.type against "add"/
  "remove"/"rename", but every real caller (GraphRenderer.js, data/frameEditOps.js's
  applyGraphOp) has always emitted "addNode"/"removeNode"/"renameNode". Every branch was
  silently unreachable, so a node edit's local preview looked correct while Run silently
  sent the unedited instance to the backend -- in both VisualizationsSection and this
  section, since both reuse the same function. Caught only because I tested the Reductions
  source pane's Run round trip against real data; fixed by correcting the three string
  literals. Recorded in a code comment at the fix site.

Also found, not fixed (out of scope for this task, pre-existing from T51/T52):
  GraphRenderer.js/QuantumCircuitRenderer.js/RecursiveSetRenderer.js/
  BooleanSatisfiabilityRenderer.js's "add new X" inputs use MUI's `inputProps={{aria-label:
  ...}}`, which this project's MUI v9 no longer special-cases -- it leaks onto the DOM as a
  literal `inputprops` attribute instead of setting the input's accessible name (confirmed
  by the React console warning it throws). Every one of these "new node/qubit/gate/element
  id" inputs across both Visualizations and Reductions has no accessible name right now.
  Fix is mechanical (inputProps -> slotProps={{ htmlInput: {...} }}) but touches four files
  I don't otherwise need to touch for T53, so I left it rather than expanding scope
  unilaterally.

Decisions and assumptions:
  - The two frames visualizeReduction returns are two DIFFERENT problems' own shapes
    (source, then target), not a before/after of one instance -- confirmed by testing
    against the real backend (Clique's own graph on frame 0, Vertex Cover's own graph on
    frame 1, each independently valid). Each pane's universal type is resolved the same
    static backendType-map way the rest of this project already uses (no shape-sniffing,
    per VISUALIZATION_TYPE_CONTRACTS.md §5's explicit rejection of that approach) -- the
    target's type comes from a new `targetVisualization` field I added to buildReductions'
    `to` entries, resolved server-side in the hook using data it already has in scope.
  - The certificate visualizeReduction needs isn't lifted into one fully shared Run action
    the way the design doc's aspirational language suggested -- Solvers still owns its own
    /solve call exactly as before, and now also reports the result up through a new
    onCertificateChange prop. ProblemDetailLayout holds the one shared copy. This was the
    smaller change that still gets the same effective behavior (any Run press, from any
    section, eventually refreshes Reductions once a certificate lands).
  - Editing in the Reductions source pane reuses the exact same op-appliers and serializers
    VisualizationsSection uses (extracted the pure functions into data/frameEditOps.js so
    neither section duplicates ~150 lines of logic), with its own independent local edit
    state -- so the two sections can have unrelated pending edits open at once.

  Closes #116