### PR TITLE
Making Node-Link Visualization Interactive

### DIFF
--- a/components/detail/VisualizationsSection.js
+++ b/components/detail/VisualizationsSection.js
@@ -6,12 +6,13 @@
 //
 // T48 (#111): the canvas is real now, for the `graph` universal type (24 of
 // 48 declared instances, the largest group -- ai_documentation/
-// VISUALIZATION_TYPE_CONTRACTS.md §3.1). Structural editing is still out of
-// scope (T51, gated on T46) -- rendering is read-only, and the earlier "Drag
-// nodes to reposition / Right-click to add" hint text is gone rather than
-// left pointing at an interaction that doesn't exist: it was harmless over
-// a static placeholder box, but would be actively misleading under a real,
-// rendered diagram nothing responds to.
+// VISUALIZATION_TYPE_CONTRACTS.md §3.1).
+//
+// T54 (#125): structural editing for `graph` is drag/right-click directly on the diagram
+// (components/detail/visualizations/GraphRenderer.js), not a side panel -- the "Drag nodes
+// to reposition / Right-click to add" interaction this file's header once said was
+// deliberately removed (T48, when the canvas was still a static read-only placeholder) is
+// back, now backed by a real editable renderer instead of pointing at nothing.
 //
 // Per INTERACTIVE_LAYER_DESIGN.md §0/§2.1/§2.1.1: this section shares
 // `instanceValue`/`onInstanceChange` with Solvers and Verifier (T35/#93) and

--- a/components/detail/visualizations/GraphRenderer.js
+++ b/components/detail/visualizations/GraphRenderer.js
@@ -14,26 +14,29 @@
 //     renderer only uses d3-force's simulation, a pure data computation with no DOM
 //     access at all -- layout math in, `{x, y}` positions out. Everything on screen is
 //     plain React-owned SVG, so nothing here can collide between two mounted instances
-//     of this component (the Reductions section's side-by-side panes, once T53 wires
-//     them to real data).
+//     of this component (the Reductions section's side-by-side panes, T53/#116).
 //
 // The layout is a one-shot force simulation, ticked synchronously to convergence and
-// thrown away -- this is a *static* render (T48's own scope: "static (non-interactive)
-// rendering only"). No drag, no persistent simulation timer, no re-layout on a render
-// that didn't get a new frame.
+// thrown away -- a static starting arrangement, not a persistent physics timer. Dragging a
+// node (T54, below) only ever overrides that starting position; it never restarts or
+// re-ticks the simulation.
 //
-// T51 (#114): structural editing (add/remove/relabel a node; add/remove an edge -- see
-// this component's own scope note below) is gated behind the `editable` prop. Rather than
-// embedding forms inside the SVG (no natural text-flow to hang a labelled input off, and
-// every hover target here is already a small circle), edit controls render in a separate
-// panel below the diagram -- a real, focusable, aria-labelled list of node/edge rows plus
-// add forms, the same keyboard-reachable pattern T52 established for
-// BooleanSatisfiabilityRenderer. The SVG itself stays exactly as before when not editable.
+// T54 (#125): structural editing (add/remove/rename a node; add/remove an edge) is direct
+// manipulation on the canvas itself -- drag a node to move it, drag from a node's outer
+// ring to rubber-band a new edge onto another node, right-click a node/edge/empty canvas
+// for add/rename/delete -- modeled on SARE_2026's AutomatonCanvas.tsx (issue #124's porting
+// notes), replacing the side-panel form T51 originally shipped. This is **mouse-only**, by
+// a deliberate, recorded decision (ai_documentation/INTERACTIVE_LAYER_DESIGN.md §3.1): the
+// shared instance textarea in the Solvers section already gives keyboard-only users a way
+// to edit this same underlying data, so the diagram doesn't duplicate that path. Node/edge
+// position and curvature overrides are pure client-side view state (never serialized --
+// INTERACTIVE_LAYER_DESIGN.md §2.3 is unchanged by this task); only the five structural ops
+// (`addNode`/`removeNode`/`renameNode`/`addEdge`/`removeEdge`) reach `onGraphEdit`.
 //
-// Node/gate position dragging is out of scope everywhere in this contract
-// (INTERACTIVE_LAYER_DESIGN.md §2.3: no position field exists on any type this project's
-// force-directed layout is computed fresh, not read from data) -- nothing here changes
-// that.
+// Edge curvature and self-loop geometry live in ./graphGeometry.js (also ported from
+// SARE_2026, see that file's header) -- shared by both the read-only and editable render
+// paths, so a bidirectional pair (A->B and B->A both present) always renders as two visibly
+// distinct arcs rather than one overlapping line, whether or not editing is active.
 //
 // **Edge edits preview locally but are not sent to Run.** See
 // data/instanceSerializers.js's `serializeGraphInstance` doc comment for the full
@@ -43,19 +46,24 @@
 // summary to the user says this plainly when an edge edit is pending, rather than sending
 // a guess to the backend.
 
-import AddIcon from "@mui/icons-material/Add";
-import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
+import Button from "@mui/material/Button";
+import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation } from "d3-force";
-import { useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+import {
+  computeEdgePath,
+  computeSelfLoopPath,
+  distanceBetween,
+  effectiveCurvature,
+} from "./graphGeometry";
 
 const NODE_RADIUS = 15;
+const INNER_DRAG_RADIUS_RATIO = 0.6; // inside this fraction of the ring: move; outside: create edge
+const EDGE_HANDLE_HIT_RADIUS = 8;
 const LAYOUT_WIDTH = 640;
 const LAYOUT_HEIGHT = 380;
 const LAYOUT_PADDING = NODE_RADIUS * 2;
@@ -93,12 +101,12 @@ function layoutGraph(nodes, links) {
   return { simNodes, simLinks };
 }
 
-function computeViewBox(simNodes) {
-  if (simNodes.length === 0) {
+function computeViewBox(nodes) {
+  if (nodes.length === 0) {
     return `0 0 ${LAYOUT_WIDTH} ${LAYOUT_HEIGHT}`;
   }
-  const xs = simNodes.map((node) => node.x);
-  const ys = simNodes.map((node) => node.y);
+  const xs = nodes.map((node) => node.x);
+  const ys = nodes.map((node) => node.y);
   const minX = Math.min(...xs) - LAYOUT_PADDING;
   const maxX = Math.max(...xs) + LAYOUT_PADDING;
   const minY = Math.min(...ys) - LAYOUT_PADDING;
@@ -106,7 +114,7 @@ function computeViewBox(simNodes) {
   return `${minX} ${minY} ${Math.max(maxX - minX, 1)} ${Math.max(maxY - minY, 1)}`;
 }
 
-function LinkMark({ link, idPrefix, highlighted }) {
+function LinkMark({ link, idPrefix, highlighted, editable }) {
   const source = link.source;
   const target = link.target;
   if (!source || !target || source.x === undefined || target.x === undefined) {
@@ -119,52 +127,53 @@ function LinkMark({ link, idPrefix, highlighted }) {
   const markerEnd = link.directed ? `url(#${idPrefix}-arrow)` : undefined;
   const isSelfLoop = source.id === target.id;
 
-  if (isSelfLoop) {
-    const loopPath = `M ${source.x - NODE_RADIUS * 0.6} ${source.y - NODE_RADIUS} C ${source.x - NODE_RADIUS * 3} ${source.y - NODE_RADIUS * 3}, ${source.x + NODE_RADIUS * 3} ${source.y - NODE_RADIUS * 3}, ${source.x + NODE_RADIUS * 0.6} ${source.y - NODE_RADIUS}`;
-    return (
-      <g>
-        <path
-          d={loopPath}
-          fill="none"
-          stroke={stroke}
-          strokeWidth={strokeWidth}
-          strokeDasharray={strokeDasharray}
-          markerEnd={markerEnd}
-        />
-        {link.weight && (
-          <text
-            x={source.x}
-            y={source.y - NODE_RADIUS * 3.6}
-            textAnchor="middle"
-            fontSize={10}
-            fill={DEFAULT_STROKE}
-          >
-            {link.weight}
-          </text>
-        )}
-      </g>
-    );
-  }
-
-  const midX = (source.x + target.x) / 2;
-  const midY = (source.y + target.y) / 2;
+  const geo = isSelfLoop
+    ? computeSelfLoopPath(source, NODE_RADIUS)
+    : computeEdgePath(source, target, NODE_RADIUS, link.curvature ?? 0);
 
   return (
     <g>
-      <line
-        x1={source.x}
-        y1={source.y}
-        x2={target.x}
-        y2={target.y}
+      {editable && (
+        <path
+          d={geo.path}
+          fill="none"
+          stroke="transparent"
+          strokeWidth={16}
+          style={{ cursor: "context-menu" }}
+          onContextMenu={link.onContextMenu}
+        />
+      )}
+      <path
+        d={geo.path}
+        fill="none"
         stroke={stroke}
         strokeWidth={strokeWidth}
         strokeDasharray={strokeDasharray}
         markerEnd={markerEnd}
+        style={{ pointerEvents: "none" }}
       />
       {link.weight && (
-        <text x={midX} y={midY - 4} textAnchor="middle" fontSize={10} fill={DEFAULT_STROKE}>
+        <text
+          x={geo.labelX}
+          y={geo.labelY - (isSelfLoop ? 0 : 4)}
+          textAnchor="middle"
+          fontSize={10}
+          fill={DEFAULT_STROKE}
+          style={{ pointerEvents: "none" }}
+        >
           {link.weight}
         </text>
+      )}
+      {editable && !isSelfLoop && (
+        <circle
+          cx={geo.handleX}
+          cy={geo.handleY}
+          r={4}
+          fill="rgba(255,255,255,0.15)"
+          stroke={DEFAULT_STROKE}
+          strokeWidth={1}
+          style={{ cursor: "grab" }}
+        />
       )}
     </g>
   );
@@ -216,196 +225,29 @@ function GraphNodeMark({ node, highlighted, onEnter, onLeave }) {
   );
 }
 
-// Node/edge rows are keyed by `_key`, a stable identifier VisualizationsSection.js
-// assigns once when local edit state is created (see that file's header) and never
-// changes even when the node's own `id` is renamed -- keying by `node.id` directly would
-// remount (and drop focus from) the very text field the user is typing a rename into,
-// since React treats a changed `key` as a different element. `id` is still what's shown,
-// edited, and referenced by edges; `_key` only exists for this reason.
-function GraphEditPanel({ idPrefix, nodes, links, onGraphEdit }) {
-  const [newNodeId, setNewNodeId] = useState("");
-  const [newEdgeSource, setNewEdgeSource] = useState(nodes[0]?.id ?? "");
-  const [newEdgeTarget, setNewEdgeTarget] = useState(nodes[1]?.id ?? nodes[0]?.id ?? "");
-
-  const sourceValue = nodes.some((node) => node.id === newEdgeSource)
-    ? newEdgeSource
-    : (nodes[0]?.id ?? "");
-  const targetValue = nodes.some((node) => node.id === newEdgeTarget)
-    ? newEdgeTarget
-    : (nodes[1]?.id ?? nodes[0]?.id ?? "");
-
-  function handleAddNode(event) {
-    event.preventDefault();
-    const trimmed = newNodeId.trim();
-    if (!trimmed || nodes.some((node) => node.id === trimmed)) return;
-    onGraphEdit({ type: "addNode", id: trimmed });
-    setNewNodeId("");
-  }
-
-  function handleAddEdge(event) {
-    event.preventDefault();
-    if (!sourceValue || !targetValue) return;
-    onGraphEdit({ type: "addEdge", source: sourceValue, target: targetValue });
-  }
-
+// Fixed-position floating popup, positioned at the screen point a right-click or drag-end
+// happened -- SARE_2026's AutomatonCanvas.tsx menu pattern (issue #124). Lives as a sibling
+// of the <svg> in the DOM, not inside it, so a click inside the menu never reaches the
+// canvas's own mousedown/contextmenu handlers.
+function FloatingMenu({ menuRef, x, y, children }) {
   return (
-    <Box
+    <Paper
+      ref={menuRef}
+      elevation={8}
       sx={{
+        position: "fixed",
+        left: x + 4,
+        top: y + 4,
+        p: 1.5,
+        zIndex: 20,
+        minWidth: 200,
         display: "flex",
         flexDirection: "column",
         gap: 1,
-        mt: 1,
-        p: 1.5,
-        border: "1px dashed",
-        borderColor: "divider",
-        borderRadius: 1,
       }}
     >
-      <Typography variant="overline" sx={{ color: "text.secondary" }}>
-        Edit nodes
-      </Typography>
-      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-        {nodes.map((node) => (
-          <Box key={node._key} sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
-            <Box
-              component="label"
-              htmlFor={`${idPrefix}-node-${node._key}`}
-              sx={{ display: "none" }}
-            >
-              Rename node {node.id}
-            </Box>
-            <TextField
-              id={`${idPrefix}-node-${node._key}`}
-              size="small"
-              variant="standard"
-              value={node.id}
-              onChange={(event) =>
-                onGraphEdit({ type: "renameNode", from: node.id, to: event.target.value })
-              }
-              sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
-              inputProps={{ "aria-label": `Rename node ${node.id}` }}
-            />
-            <IconButton
-              id={`${idPrefix}-node-${node._key}-remove`}
-              size="small"
-              aria-label={`Remove node ${node.id}`}
-              onClick={() => onGraphEdit({ type: "removeNode", id: node.id })}
-              sx={{ p: 0.375 }}
-            >
-              <CloseIcon sx={{ fontSize: "0.875rem" }} />
-            </IconButton>
-          </Box>
-        ))}
-      </Box>
-      <Box
-        component="form"
-        onSubmit={handleAddNode}
-        sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
-      >
-        <Box component="label" htmlFor={`${idPrefix}-add-node`} sx={{ display: "none" }}>
-          New node id
-        </Box>
-        <TextField
-          id={`${idPrefix}-add-node`}
-          size="small"
-          variant="outlined"
-          placeholder="new node id"
-          value={newNodeId}
-          onChange={(event) => setNewNodeId(event.target.value)}
-          sx={{ width: 120, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
-          inputProps={{ "aria-label": "New node id" }}
-        />
-        <IconButton
-          id={`${idPrefix}-add-node-submit`}
-          type="submit"
-          size="small"
-          disabled={!newNodeId.trim() || nodes.some((node) => node.id === newNodeId.trim())}
-          aria-label="Add node"
-          sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
-        >
-          <AddIcon sx={{ fontSize: "1rem" }} />
-        </IconButton>
-      </Box>
-
-      <Typography variant="overline" sx={{ color: "text.secondary", mt: 1 }}>
-        Edit edges
-      </Typography>
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-        {links.length === 0 && (
-          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
-            No edges.
-          </Typography>
-        )}
-        {links.map((link) => (
-          <Box key={link._key} sx={{ display: "inline-flex", alignItems: "center", gap: 0.75 }}>
-            <Typography variant="body2" sx={{ fontFamily: "monospace" }}>
-              {link.source} {link.directed ? "->" : "--"} {link.target}
-            </Typography>
-            <IconButton
-              id={`${idPrefix}-edge-${link._key}-remove`}
-              size="small"
-              aria-label={`Remove edge from ${link.source} to ${link.target}`}
-              onClick={() => onGraphEdit({ type: "removeEdge", id: link.id })}
-              sx={{ p: 0.375 }}
-            >
-              <CloseIcon sx={{ fontSize: "0.875rem" }} />
-            </IconButton>
-          </Box>
-        ))}
-      </Box>
-      {nodes.length > 0 && (
-        <Box
-          component="form"
-          onSubmit={handleAddEdge}
-          sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
-        >
-          <Select
-            id={`${idPrefix}-add-edge-source`}
-            size="small"
-            value={sourceValue}
-            onChange={(event) => setNewEdgeSource(event.target.value)}
-            inputProps={{ "aria-label": "New edge source node" }}
-            sx={{ minWidth: 72 }}
-          >
-            {nodes.map((node) => (
-              <MenuItem key={node._key} value={node.id}>
-                {node.id}
-              </MenuItem>
-            ))}
-          </Select>
-          <Typography variant="body2" aria-hidden="true">
-            {"->"}
-          </Typography>
-          <Select
-            id={`${idPrefix}-add-edge-target`}
-            size="small"
-            value={targetValue}
-            onChange={(event) => setNewEdgeTarget(event.target.value)}
-            inputProps={{ "aria-label": "New edge target node" }}
-            sx={{ minWidth: 72 }}
-          >
-            {nodes.map((node) => (
-              <MenuItem key={node._key} value={node.id}>
-                {node.id}
-              </MenuItem>
-            ))}
-          </Select>
-          <IconButton
-            id={`${idPrefix}-add-edge-submit`}
-            type="submit"
-            size="small"
-            aria-label="Add edge"
-            sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
-          >
-            <AddIcon sx={{ fontSize: "1rem" }} />
-          </IconButton>
-        </Box>
-      )}
-      <Typography variant="body2" sx={{ color: "text.secondary" }}>
-        Node changes are sent to Run. Edge changes preview here but can&apos;t be sent to Run yet
-        for this visualization type.
-      </Typography>
-    </Box>
+      {children}
+    </Paper>
   );
 }
 
@@ -416,7 +258,7 @@ function GraphEditPanel({ idPrefix, nodes, links, onGraphEdit }) {
  * @param {string} [props.instanceName] Human-readable visualization name, folded into
  *   the accessible summary when given.
  * @param {{nodes: Array, links: Array}} props.frame One already-validated `graph` frame.
- * @param {boolean} [props.editable] T51 (#114): true only when this frame is the base
+ * @param {boolean} [props.editable] T54 (#125): true only when this frame is the base
  *   frame of a visualization the caller has decided is editable right now -- this
  *   component does not re-derive that gate.
  * @param {(op: Object) => void} [props.onGraphEdit] Called with one edit descriptor per
@@ -433,55 +275,357 @@ export default function GraphRenderer({
 }) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
+  const svgRef = useRef(null);
+  const menuRef = useRef(null);
+
   const [hoveredNodeId, setHoveredNodeId] = useState(null);
+  const [positionOverride, setPositionOverride] = useState({});
+  const [curvatureOverride, setCurvatureOverride] = useState({});
+  const [drag, setDrag] = useState({ kind: "none" });
+  const [rubber, setRubber] = useState(null);
+  const [menu, setMenu] = useState(null); // {kind, x, y, ...} | null -- screen-space x/y
+  const [menuValue, setMenuValue] = useState("");
+  const [menuError, setMenuError] = useState("");
 
+  // Layout is a one-shot simulation keyed only on the frame's own structure -- dragging
+  // (which only ever writes positionOverride/curvatureOverride) never re-triggers it.
   const { simNodes, simLinks } = useMemo(() => layoutGraph(frame.nodes, frame.links), [frame]);
-  const viewBox = useMemo(() => computeViewBox(simNodes), [simNodes]);
 
-  const nodeCount = simNodes.length;
-  const linkCount = simLinks.length;
+  const displayNodes = useMemo(
+    () => simNodes.map((node) => ({ ...node, ...(positionOverride[node.id] ?? {}) })),
+    [simNodes, positionOverride],
+  );
+  const nodeById = useMemo(
+    () => new Map(displayNodes.map((node) => [node.id, node])),
+    [displayNodes],
+  );
+  // d3-force rewrote each link's source/target into references to the *pre-override* node
+  // objects -- remap to the display copies so a dragged node's edges track its new position.
+  const displayLinks = useMemo(
+    () =>
+      simLinks
+        .map((link) => ({
+          ...link,
+          source: nodeById.get(link.source.id),
+          target: nodeById.get(link.target.id),
+        }))
+        .filter((link) => link.source && link.target),
+    [simLinks, nodeById],
+  );
+
+  const viewBox = useMemo(() => computeViewBox(displayNodes), [displayNodes]);
+
+  const closeMenu = useCallback(() => {
+    setMenu(null);
+    setMenuValue("");
+    setMenuError("");
+  }, []);
+
+  // Outside click / Escape closes whatever menu is open -- reads only this component's own
+  // menuRef, not a hardcoded global selector (§4.1).
+  useEffect(() => {
+    if (!menu) return undefined;
+    function handlePointerDown(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        closeMenu();
+      }
+    }
+    function handleKeyDown(event) {
+      if (event.key === "Escape") closeMenu();
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menu, closeMenu]);
+
+  const svgPoint = useCallback((event) => {
+    const svg = svgRef.current;
+    if (!svg) return { x: 0, y: 0 };
+    const point = svg.createSVGPoint();
+    point.x = event.clientX;
+    point.y = event.clientY;
+    const matrix = svg.getScreenCTM();
+    if (!matrix) return { x: 0, y: 0 };
+    const transformed = point.matrixTransform(matrix.inverse());
+    return { x: transformed.x, y: transformed.y };
+  }, []);
+
+  const handleSvgMouseDown = useCallback(
+    (event) => {
+      if (!editable || event.button !== 0) return;
+      const { x, y } = svgPoint(event);
+
+      for (const node of displayNodes) {
+        const r = distanceBetween(x, y, node.x, node.y);
+        if (r <= NODE_RADIUS) {
+          event.preventDefault();
+          if (r <= NODE_RADIUS * INNER_DRAG_RADIUS_RATIO) {
+            setDrag({ kind: "moveNode", id: node.id, offsetX: x - node.x, offsetY: y - node.y });
+          } else {
+            setDrag({ kind: "createEdge", sourceId: node.id });
+            setRubber({ x, y });
+          }
+          return;
+        }
+      }
+
+      for (const link of displayLinks) {
+        if (link.source.id === link.target.id) continue; // self-loops have no curvature handle
+        const distance =
+          distanceBetween(link.source.x, link.source.y, link.target.x, link.target.y) || 1;
+        const curvature = effectiveCurvature(
+          link,
+          displayLinks,
+          curvatureOverride,
+          NODE_RADIUS,
+          distance,
+        );
+        const geo = computeEdgePath(link.source, link.target, NODE_RADIUS, curvature);
+        if (distanceBetween(x, y, geo.handleX, geo.handleY) <= EDGE_HANDLE_HIT_RADIUS) {
+          event.preventDefault();
+          setDrag({ kind: "adjustCurvature", linkKey: `${link.source.id}@@${link.target.id}` });
+          return;
+        }
+      }
+    },
+    [editable, svgPoint, displayNodes, displayLinks, curvatureOverride],
+  );
+
+  const handleSvgMouseMove = useCallback(
+    (event) => {
+      if (drag.kind === "none") return;
+      const { x, y } = svgPoint(event);
+
+      if (drag.kind === "moveNode") {
+        setPositionOverride((current) => ({
+          ...current,
+          [drag.id]: { x: x - drag.offsetX, y: y - drag.offsetY },
+        }));
+      } else if (drag.kind === "createEdge") {
+        setRubber({ x, y });
+      } else if (drag.kind === "adjustCurvature") {
+        const [sourceId, targetId] = drag.linkKey.split("@@");
+        const source = nodeById.get(sourceId);
+        const target = nodeById.get(targetId);
+        if (!source || !target) return;
+        const midX = (source.x + target.x) / 2;
+        const midY = (source.y + target.y) / 2;
+        const dx = target.x - source.x;
+        const dy = target.y - source.y;
+        const distance = distanceBetween(source.x, source.y, target.x, target.y) || 1;
+        const nx = -dy / distance;
+        const ny = dx / distance;
+        const curvature = (x - midX) * nx + (y - midY) * ny;
+        setCurvatureOverride((current) => ({ ...current, [drag.linkKey]: curvature }));
+      }
+    },
+    [drag, svgPoint, nodeById],
+  );
+
+  const handleSvgMouseUp = useCallback(
+    (event) => {
+      if (drag.kind === "createEdge") {
+        const { x, y } = svgPoint(event);
+        const target = displayNodes.find(
+          (node) => distanceBetween(x, y, node.x, node.y) <= NODE_RADIUS,
+        );
+        if (target && target.id !== drag.sourceId) {
+          onGraphEdit?.({ type: "addEdge", source: drag.sourceId, target: target.id });
+        }
+        setRubber(null);
+      }
+      if (drag.kind !== "none") setDrag({ kind: "none" });
+    },
+    [drag, svgPoint, displayNodes, onGraphEdit],
+  );
+
+  const handleSvgContextMenu = useCallback(
+    (event) => {
+      if (!editable) return;
+      event.preventDefault();
+      const { x, y } = svgPoint(event);
+
+      const node = displayNodes.find(
+        (candidate) => distanceBetween(x, y, candidate.x, candidate.y) <= NODE_RADIUS,
+      );
+      if (node) {
+        setMenu({ kind: "editNode", id: node.id, x: event.clientX, y: event.clientY });
+        setMenuValue(node.id);
+        setMenuError("");
+        return;
+      }
+
+      for (const link of displayLinks) {
+        if (link.source.id === link.target.id) continue;
+        const distance =
+          distanceBetween(link.source.x, link.source.y, link.target.x, link.target.y) || 1;
+        const curvature = effectiveCurvature(
+          link,
+          displayLinks,
+          curvatureOverride,
+          NODE_RADIUS,
+          distance,
+        );
+        const geo = computeEdgePath(link.source, link.target, NODE_RADIUS, curvature);
+        if (distanceBetween(x, y, geo.handleX, geo.handleY) <= 16) {
+          setMenu({
+            kind: "editEdge",
+            id: link.id,
+            source: link.source.id,
+            target: link.target.id,
+            x: event.clientX,
+            y: event.clientY,
+          });
+          setMenuError("");
+          return;
+        }
+      }
+
+      setMenu({ kind: "createNode", x: event.clientX, y: event.clientY });
+      setMenuValue("");
+      setMenuError("");
+    },
+    [editable, svgPoint, displayNodes, displayLinks, curvatureOverride],
+  );
+
+  function submitCreateNode() {
+    const trimmed = menuValue.trim();
+    if (!trimmed) {
+      setMenuError("Name is required");
+      return;
+    }
+    if (frame.nodes.some((node) => node.id === trimmed)) {
+      setMenuError("Name already used");
+      return;
+    }
+    onGraphEdit?.({ type: "addNode", id: trimmed });
+    closeMenu();
+  }
+
+  function submitRenameNode() {
+    if (menu?.kind !== "editNode") return;
+    const trimmed = menuValue.trim();
+    if (!trimmed) {
+      setMenuError("Name is required");
+      return;
+    }
+    if (trimmed !== menu.id && frame.nodes.some((node) => node.id === trimmed)) {
+      setMenuError("Name already used");
+      return;
+    }
+    if (trimmed !== menu.id) {
+      onGraphEdit?.({ type: "renameNode", from: menu.id, to: trimmed });
+    }
+    closeMenu();
+  }
+
+  function submitDeleteNode() {
+    if (menu?.kind !== "editNode") return;
+    onGraphEdit?.({ type: "removeNode", id: menu.id });
+    closeMenu();
+  }
+
+  function submitDeleteEdge() {
+    if (menu?.kind !== "editEdge") return;
+    onGraphEdit?.({ type: "removeEdge", id: menu.id });
+    closeMenu();
+  }
+
+  const nodeCount = displayNodes.length;
+  const linkCount = displayLinks.length;
   const summaryBody = `graph with ${nodeCount} node${nodeCount === 1 ? "" : "s"} and ${linkCount} link${linkCount === 1 ? "" : "s"}`;
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
 
   const svg = (
     <svg
+      ref={svgRef}
       id={scopeId}
       role="img"
       aria-label={summary}
       viewBox={viewBox}
       width="100%"
       height="100%"
-      style={{ display: "block" }}
+      style={{ display: "block", cursor: drag.kind === "moveNode" ? "grabbing" : "default" }}
+      onMouseDown={handleSvgMouseDown}
+      onMouseMove={handleSvgMouseMove}
+      onMouseUp={handleSvgMouseUp}
+      onMouseLeave={handleSvgMouseUp}
+      onContextMenu={handleSvgContextMenu}
     >
       <title>{summary}</title>
       <defs>
         <marker
           id={`${scopeId}-arrow`}
-          viewBox="0 0 10 10"
-          refX={NODE_RADIUS + 8}
-          refY={5}
-          markerWidth={6}
+          markerWidth={8}
           markerHeight={6}
+          refX={8}
+          refY={3}
           orient="auto-start-reverse"
         >
-          <path d="M 0 0 L 10 5 L 0 10 z" fill={DEFAULT_STROKE} />
+          <path d="M0,0 L0,6 L8,3 Z" fill={DEFAULT_STROKE} />
         </marker>
       </defs>
       <g>
-        {simLinks.map((link) => (
-          <LinkMark
-            key={link.id}
-            link={link}
-            idPrefix={scopeId}
-            highlighted={
-              hoveredNodeId != null &&
-              (link.source?.id === hoveredNodeId || link.target?.id === hoveredNodeId)
-            }
-          />
-        ))}
+        {displayLinks.map((link) => {
+          const distance =
+            distanceBetween(link.source.x, link.source.y, link.target.x, link.target.y) || 1;
+          const curvature =
+            link.source.id === link.target.id
+              ? 0
+              : effectiveCurvature(link, displayLinks, curvatureOverride, NODE_RADIUS, distance);
+          return (
+            <LinkMark
+              key={link.id}
+              link={{
+                ...link,
+                curvature,
+                onContextMenu: (event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  setMenu({
+                    kind: "editEdge",
+                    id: link.id,
+                    source: link.source.id,
+                    target: link.target.id,
+                    x: event.clientX,
+                    y: event.clientY,
+                  });
+                  setMenuError("");
+                },
+              }}
+              idPrefix={scopeId}
+              editable={editable}
+              highlighted={
+                hoveredNodeId != null &&
+                (link.source?.id === hoveredNodeId || link.target?.id === hoveredNodeId)
+              }
+            />
+          );
+        })}
+        {drag.kind === "createEdge" &&
+          rubber &&
+          (() => {
+            const source = nodeById.get(drag.sourceId);
+            if (!source) return null;
+            return (
+              <line
+                x1={source.x}
+                y1={source.y}
+                x2={rubber.x}
+                y2={rubber.y}
+                stroke={DEFAULT_STROKE}
+                strokeWidth={1.5}
+                strokeDasharray="5,3"
+                style={{ pointerEvents: "none" }}
+              />
+            );
+          })()}
       </g>
       <g>
-        {simNodes.map((node) => (
+        {displayNodes.map((node) => (
           <GraphNodeMark
             key={node.id}
             node={node}
@@ -501,12 +645,89 @@ export default function GraphRenderer({
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
       <Box sx={{ flex: 1, minHeight: 0 }}>{svg}</Box>
-      <GraphEditPanel
-        idPrefix={scopeId}
-        nodes={frame.nodes}
-        links={frame.links}
-        onGraphEdit={onGraphEdit}
-      />
+      <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+        Drag a node to move it, or drag from its outer edge onto another node to connect them.
+        Right-click a node, a connection, or empty space to add, rename, or delete.
+      </Typography>
+
+      {menu?.kind === "createNode" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            New node
+          </Typography>
+          <TextField
+            id={`${scopeId}-new-node`}
+            size="small"
+            autoFocus
+            label="Name"
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitCreateNode()}
+          />
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitCreateNode}>
+              Add
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
+      )}
+
+      {menu?.kind === "editNode" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            Edit node
+          </Typography>
+          <TextField
+            id={`${scopeId}-edit-node`}
+            size="small"
+            autoFocus
+            label="Name"
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitRenameNode()}
+          />
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitRenameNode}>
+              Save
+            </Button>
+            <Button size="small" color="error" onClick={submitDeleteNode}>
+              Delete
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
+      )}
+
+      {menu?.kind === "editEdge" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            {menu.source} {"->"} {menu.target}
+          </Typography>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" color="error" variant="contained" onClick={submitDeleteEdge}>
+              Delete
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
+      )}
     </Box>
   );
 }

--- a/components/detail/visualizations/graphGeometry.js
+++ b/components/detail/visualizations/graphGeometry.js
@@ -1,0 +1,129 @@
+// components/detail/visualizations/graphGeometry.js
+//
+// T54 (#125) -- pure edge/curvature path math for GraphRenderer.js's SVG rendering, ported
+// from SARE_2026's AutomatonCanvas.tsx/GraphCanvas.tsx (see issue #124's porting notes)
+// rather than re-derived: straight edges offset their endpoints along the unit vector by
+// node radius so arrowheads land exactly on the node boundary; curved edges compute a
+// control point from midpoint + perpendicular * offset, with start/end angles taken from
+// the *tangent* to the control point (not the straight line between centers) so an
+// arrowhead still lands cleanly on the boundary when curved; a bidirectional pair (A->B and
+// B->A both present) is auto-assigned symmetric opposite curvature so the two edges render
+// as visibly distinct arcs instead of overlapping into one line -- the straight-line-only
+// renderer T48 shipped had exactly this overlap bug, fixed here as part of pulling in this
+// math anyway. No React/DOM dependency -- every function here is plain math over
+// {x, y} points, shared by GraphRenderer's read-only and editable rendering paths alike.
+
+export function distanceBetween(ax, ay, bx, by) {
+  return Math.sqrt((bx - ax) ** 2 + (by - ay) ** 2);
+}
+
+/**
+ * Straight or quadratic-curved path between two node centers, offset so both ends land on
+ * the node boundary (not the center) regardless of curvature.
+ *
+ * @param {{x: number, y: number}} source
+ * @param {{x: number, y: number}} target
+ * @param {number} radius Node radius (both nodes assumed the same size).
+ * @param {number} curvature Signed perpendicular offset, in the same units as x/y. Under
+ *   0.5 in magnitude renders as a straight line.
+ * @returns {{path: string, labelX: number, labelY: number, handleX: number, handleY: number}}
+ */
+export function computeEdgePath(source, target, radius, curvature) {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const distance = distanceBetween(source.x, source.y, target.x, target.y) || 1;
+
+  if (Math.abs(curvature) < 0.5) {
+    const ux = dx / distance;
+    const uy = dy / distance;
+    const startX = source.x + ux * radius;
+    const startY = source.y + uy * radius;
+    const endX = target.x - ux * radius;
+    const endY = target.y - uy * radius;
+    return {
+      path: `M ${startX} ${startY} L ${endX} ${endY}`,
+      labelX: (startX + endX) / 2,
+      labelY: (startY + endY) / 2,
+      handleX: (startX + endX) / 2,
+      handleY: (startY + endY) / 2,
+    };
+  }
+
+  const midX = (source.x + target.x) / 2;
+  const midY = (source.y + target.y) / 2;
+  const nx = -dy / distance;
+  const ny = dx / distance;
+  const controlX = midX + nx * curvature;
+  const controlY = midY + ny * curvature;
+
+  const startAngle = Math.atan2(controlY - source.y, controlX - source.x);
+  const startX = source.x + radius * Math.cos(startAngle);
+  const startY = source.y + radius * Math.sin(startAngle);
+
+  const endAngle = Math.atan2(target.y - controlY, target.x - controlX);
+  const endX = target.x - radius * Math.cos(endAngle);
+  const endY = target.y - radius * Math.sin(endAngle);
+
+  // Quadratic bezier midpoint at t=0.5, used for both the label and the drag handle.
+  const midpointX = 0.25 * startX + 0.5 * controlX + 0.25 * endX;
+  const midpointY = 0.25 * startY + 0.5 * controlY + 0.25 * endY;
+
+  return {
+    path: `M ${startX} ${startY} Q ${controlX} ${controlY} ${endX} ${endY}`,
+    labelX: midpointX,
+    labelY: midpointY,
+    handleX: midpointX,
+    handleY: midpointY,
+  };
+}
+
+/**
+ * Self-loop path: a fixed bezier hump above the node, sized off its radius.
+ *
+ * @param {{x: number, y: number}} node
+ * @param {number} radius
+ */
+export function computeSelfLoopPath(node, radius) {
+  const startX = node.x - radius * 0.55;
+  const startY = node.y - radius;
+  const endX = node.x + radius * 0.55;
+  const endY = node.y - radius;
+  const control1X = node.x - radius * 1.6;
+  const control1Y = node.y - radius * 3.1;
+  const control2X = node.x + radius * 1.6;
+  const control2Y = node.y - radius * 3.1;
+  return {
+    path: `M ${startX} ${startY} C ${control1X} ${control1Y}, ${control2X} ${control2Y}, ${endX} ${endY}`,
+    labelX: node.x,
+    labelY: node.y - radius * 3.6,
+  };
+}
+
+/**
+ * Default curvature magnitude for an auto-detected bidirectional pair (A->B and B->A both
+ * present), scaled off node radius and edge length -- only applied when neither edge has an
+ * explicit drag-set override.
+ */
+export function defaultReverseCurvature(radius, distance) {
+  return Math.max(radius * 1.4, distance * 0.15);
+}
+
+/**
+ * Resolves the curvature to actually render for one link: an explicit drag-set override
+ * takes precedence; otherwise a bidirectional pair gets automatic opposite curvature;
+ * otherwise the edge is straight.
+ *
+ * @param {{source: {id: string}, target: {id: string}}} link
+ * @param {Array<{source: {id: string}, target: {id: string}}>} allLinks
+ * @param {Record<string, number>} curvatureOverrides Keyed by `${sourceId}@@${targetId}`.
+ * @param {number} radius
+ * @param {number} distance
+ */
+export function effectiveCurvature(link, allLinks, curvatureOverrides, radius, distance) {
+  const key = `${link.source.id}@@${link.target.id}`;
+  if (key in curvatureOverrides) return curvatureOverrides[key];
+  const hasReverse = allLinks.some(
+    (other) => other.source.id === link.target.id && other.target.id === link.source.id,
+  );
+  return hasReverse ? defaultReverseCurvature(radius, distance) : 0;
+}


### PR DESCRIPTION
Issue: T54 (#125): Rework graph-type editing to match SARE_2026's direct-manipulation canvas
Branch: task/T54-graph-mouse-editor

Changed:
components/detail/visualizations/GraphRenderer.js    (rewritten)
components/detail/visualizations/graphGeometry.js    (new)
components/detail/VisualizationsSection.js           (header comment updated)

Done when, met:
- Drag a node's inner region to reposition it (cosmetic only, never serialized)
- Drag from a node's outer ring, release on another node → fires addEdge; release elsewhere is a no-op
- Right-click a node / an edge / empty canvas opens the matching context menu at the click point
- Rename, delete node, delete edge, add node/edge all fire the existing onGraphEdit op vocabulary unchanged — no changes needed to frameEditOps.js, instanceSerializers.js, or the Run/serialization pipeline
- Bidirectional edge pairs (and any two edges between the same node pair) now render as two visibly distinct curves instead of overlapping into one line — pulled in SARE_2026's curvature math (graphGeometry.js) to fix this, since T54 needed that math anyway
- Side-panel form (GraphEditPanel) removed entirely
- ReductionsSection.js's source pane gets the new interaction for free — it already routes through the same GraphRenderer/applyGraphOp path, no changes needed there
- npm run lint, npm run format, npm run build all clean

Decisions recorded:
- Decision correction (mouse-only editing for graph, overriding part of T42's non-drag requirement) recorded in ai_documentation/INTERACTIVE_LAYER_DESIGN.md §3.1 and LIVE_CONTROLS_PLAN.md's task table, plus as comments on #100 and #114 per this project's own decision-recording convention.
- Reference issue #124 is now genuinely applied rather than dangling — the geometry and interaction-model notes it recorded are what this task actually ported.

Not extended (deliberately, not an oversight): booleanSatisfiability, quantumCircuit, recursiveSet keep their existing keyboard-reachable editing UIs. They aren't node-link diagrams, so there's no SARE_2026 interaction to port to them — that's a separate design question, noted but not decided in the §3.1 correction.

Closes #125 