### PR TITLE
Additional Interative Visualizations

### DIFF
--- a/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
+++ b/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
@@ -10,31 +10,63 @@
 //
 // No `d3.selectAll`/`d3.select` against `document` or a hardcoded id (§4.1): this is
 // plain React-owned markup, nothing to scope beyond the one root id `useId()` already
-// makes collision-proof between two mounted instances (Reductions' side-by-side panes,
-// once T53 wires them to real data).
+// makes collision-proof between two mounted instances (Reductions' side-by-side panes).
 //
 // Literal text (`"x1"`, `"!x2"`) is rendered exactly as the backend sends it -- no
 // substituting `!` for a proper negation glyph -- the same "display exactly what the
 // backend returned" call §3.5 already made for stepTable's cell text, extended here on
 // the same reasoning: this is the backend's own data, not this project's UI copy.
 //
-// T52 (#115): editing affordances (add/remove/negate a literal, add/remove a clause) are
-// now here, gated behind the `editable` prop -- exactly the growth this component was
-// structured for. Only ever passed `editable` when the frame being shown is the base
-// frame (frames[0], per INTERACTIVE_LAYER_DESIGN.md §2.3) -- VisualizationsSection.js
-// owns that gate, this component doesn't re-derive it. Every edit control here is a
-// real, focusable, aria-labelled button or text input -- no drag, no right-click -- per
-// §3's keyboard-reachable requirement (same precedent as T18's KeyboardSensor).
+// T55 (#128): editing is right-click context menus (negate/remove a literal; add a
+// literal/remove a clause; add a clause), plus drag-to-reorder for both clauses and
+// literals within a clause -- replacing T52's inline icon-button controls. Reordering
+// never changes what the formula means ("∧"/"∨" are both commutative), and
+// `serializeBooleanSatisfiabilityInstance` already serializes whatever order the
+// `clauses`/`literals` arrays hold, so this carries none of `graph`'s round-trip
+// correctness risk.
+//
+// Unlike `graph` (T54), this keeps a keyboard-reachable path: dragging is built on
+// `@dnd-kit` (already a project dependency; `KeyboardSensor` with
+// `sortableKeyboardCoordinates` is T18/#27's existing precedent in
+// ProblemDetailLayout.js) rather than hand-rolled pointer math, because both reorders
+// here are snap-to-slot -- a clause or literal moves to one of a fixed set of positions
+// -- exactly what `@dnd-kit`'s sortable preset is built for, unlike `graph`'s freeform
+// curve-dragging, which had no cheap keyboard equivalent. Full decision record:
+// ai_documentation/INTERACTIVE_LAYER_DESIGN.md §3.2.
+//
+// One shared `DndContext` covers both reorder levels rather than nesting a `DndContext`
+// per clause -- nesting `DndContext`s is a known-fragile dnd-kit pattern (both would try
+// to claim the same pointer/keyboard events). Sibling `SortableContext`s (one for the
+// clause list, one per clause for its own literals) coexist fine under one `DndContext`;
+// `handleDragEnd` below tells a clause-reorder from a literal-reorder via each draggable
+// item's own `data.current.type`, and a literal drop is ignored outright if it lands on a
+// different clause than it started in (literals never move between clauses this way).
 
-import AddIcon from "@mui/icons-material/Add";
-import CloseIcon from "@mui/icons-material/Close";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  rectSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import IconButton from "@mui/material/IconButton";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { useId, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+import { FloatingMenu, useCloseFloatingMenu } from "./floatingMenu";
 
 const CONJUNCTION = "∧"; // AND, between literals within a clause (T40's finding, see header)
 const DISJUNCTION = "∨"; // OR, between clauses
@@ -61,11 +93,37 @@ function nextEditId(prefix) {
   return `${prefix}-${editIdCounter}`;
 }
 
-function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
+// Human-readable name for a dnd-kit drag/drop announcement -- a literal's own text, or
+// "clause N" (clauses have no shorter display name of their own).
+function describeDragItem(id, type, clauses) {
+  if (type === "clause") {
+    const index = clauses.findIndex((clause) => clause.id === id);
+    return index === -1 ? "a clause" : `clause ${index + 1}`;
+  }
+  for (const clause of clauses) {
+    const literal = clause.literals.find((candidate) => candidate.id === id);
+    if (literal) return literal.literal;
+  }
+  return "an item";
+}
+
+function LiteralMark({
+  id,
+  literal,
+  highlighted,
+  onEnter,
+  onLeave,
+  onContextMenu,
+  dragRef,
+  dragStyle,
+  dragAttributes,
+  dragListeners,
+}) {
   const color = getVisualizationColor(literal.color);
   return (
     <Box
       id={id}
+      ref={dragRef}
       component="span"
       tabIndex={0}
       aria-label={literal.literal}
@@ -73,14 +131,20 @@ function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
       onMouseLeave={onLeave}
       onFocus={onEnter}
       onBlur={onLeave}
+      onContextMenu={onContextMenu}
+      style={dragStyle}
+      {...(dragAttributes ?? {})}
+      {...(dragListeners ?? {})}
       sx={{
+        display: "inline-block",
         fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
         fontSize: "0.9375rem",
         color,
         fontWeight: highlighted ? 700 : 500,
         textDecoration: highlighted ? "underline" : "none",
         borderRadius: 0.5,
-        cursor: "default",
+        px: 0.25,
+        cursor: dragListeners ? "grab" : "default",
       }}
     >
       {literal.literal}
@@ -88,130 +152,134 @@ function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
   );
 }
 
-// The negate toggle and remove button share this compact icon-button style -- kept small
-// enough to sit inline with the clause's literal text without dominating it.
-function EditIconButton({ id, label, pressed, onClick, children }) {
-  return (
-    <IconButton
-      id={id}
-      size="small"
-      aria-label={label}
-      aria-pressed={pressed}
-      onClick={onClick}
-      sx={{ p: 0.375 }}
-    >
-      {children}
-    </IconButton>
-  );
-}
-
-function EditableLiteral({ idPrefix, clauseIndex, literalIndex, literal, canRemove, onEdit }) {
+// One sortable literal -- calls `useSortable` itself (only ever mounted inside the
+// editable tree's DndContext) and hands the resulting drag wiring down to the shared
+// LiteralMark presentational component.
+function SortableLiteral({
+  literal,
+  literalIndex,
+  clauseIndex,
+  clauseId,
+  hoveredVariable,
+  setHoveredVariable,
+  openMenu,
+  idPrefix,
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: literal.id,
+    data: { type: "literal", clauseId },
+  });
   const variable = literalVariable(literal.literal);
-  const negated = isNegated(literal.literal);
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
   return (
-    <Box component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
-      <LiteralMark id={`${idPrefix}-literal-${literal.id}`} literal={literal} />
-      <EditIconButton
-        id={`${idPrefix}-literal-${literal.id}-negate`}
-        label={`${negated ? "Remove negation from" : "Negate"} ${variable} in clause ${clauseIndex + 1}`}
-        pressed={negated}
-        onClick={() =>
-          onEdit((clauses) => {
-            const next = clauses.map((clause) => ({ ...clause, literals: [...clause.literals] }));
-            const target = next[clauseIndex].literals[literalIndex];
-            next[clauseIndex].literals[literalIndex] = {
-              ...target,
-              literal: negated ? variable : `!${variable}`,
-            };
-            return next;
-          })
-        }
-      >
-        <Typography
-          component="span"
-          aria-hidden="true"
-          sx={{ fontSize: "0.75rem", fontWeight: 700 }}
-        >
-          !
-        </Typography>
-      </EditIconButton>
-      {canRemove && (
-        <EditIconButton
-          id={`${idPrefix}-literal-${literal.id}-remove`}
-          label={`Remove ${literal.literal} from clause ${clauseIndex + 1}`}
-          onClick={() =>
-            onEdit((clauses) => {
-              const next = clauses.map((clause) => ({
-                ...clause,
-                literals: [...clause.literals],
-              }));
-              next[clauseIndex].literals.splice(literalIndex, 1);
-              return next;
-            })
-          }
-        >
-          <CloseIcon sx={{ fontSize: "0.875rem" }} />
-        </EditIconButton>
-      )}
-    </Box>
+    <LiteralMark
+      id={`${idPrefix}-literal-${literal.id}`}
+      literal={literal}
+      highlighted={hoveredVariable != null && variable === hoveredVariable}
+      onEnter={() => setHoveredVariable(variable)}
+      onLeave={() => setHoveredVariable((current) => (current === variable ? null : current))}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openMenu({
+          kind: "literal",
+          clauseIndex,
+          literalIndex,
+          x: event.clientX,
+          y: event.clientY,
+        });
+      }}
+      dragRef={setNodeRef}
+      dragStyle={style}
+      dragAttributes={attributes}
+      dragListeners={listeners}
+    />
   );
 }
 
-// Keyboard-reachable "add literal" affordance (§3 of INTERACTIVE_LAYER_DESIGN.md): a real
-// text field plus a submit button, not a drag/right-click gesture. Disabled once the
-// clause is at `maxLiteralsPerClause` (SAT3's 3-literal cap, enforced here rather than
-// left for the backend to reject).
-function AddLiteralForm({ idPrefix, clauseIndex, atCap, onEdit }) {
-  const [value, setValue] = useState("");
-  const fieldId = `${idPrefix}-clause-${clauseIndex}-add-literal`;
-  const isValid = VARIABLE_NAME_PATTERN.test(value.trim());
-
-  function handleSubmit(event) {
-    event.preventDefault();
-    if (!isValid || atCap) return;
-    const variable = value.trim();
-    onEdit((clauses) => {
-      const next = clauses.map((clause) => ({ ...clause, literals: [...clause.literals] }));
-      next[clauseIndex].literals.push({
-        id: nextEditId("literal"),
-        literal: variable,
-        color: "",
-      });
-      return next;
-    });
-    setValue("");
-  }
+// One sortable clause: a drag grip (its own handle, distinct from each literal's own drag
+// handle so the two never fight over the same pointer/keyboard events), its own nested
+// SortableContext for literal reorder, and a right-click target scoped to the clause's own
+// background (literals stop propagation on their own context-menu clicks, so this only
+// fires for a click that wasn't on a literal).
+function SortableClause({
+  clause,
+  clauseIndex,
+  hoveredVariable,
+  setHoveredVariable,
+  openMenu,
+  idPrefix,
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: clause.id,
+    data: { type: "clause" },
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
 
   return (
     <Box
-      component="form"
-      onSubmit={handleSubmit}
-      sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, ml: 0.5 }}
+      ref={setNodeRef}
+      component="span"
+      style={style}
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openMenu({ kind: "clause", clauseIndex, x: event.clientX, y: event.clientY });
+      }}
     >
-      <Box component="label" htmlFor={fieldId} sx={{ display: "none" }}>
-        Variable name to add to clause {clauseIndex + 1}
-      </Box>
-      <TextField
-        id={fieldId}
-        size="small"
-        variant="standard"
-        placeholder="x1"
-        value={value}
-        disabled={atCap}
-        onChange={(event) => setValue(event.target.value)}
-        sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
-        inputProps={{ "aria-label": `Variable name to add to clause ${clauseIndex + 1}` }}
-      />
-      <IconButton
-        id={`${fieldId}-submit`}
-        type="submit"
-        size="small"
-        disabled={atCap || !isValid}
-        aria-label={`Add literal to clause ${clauseIndex + 1}`}
-        sx={{ p: 0.375 }}
+      <Box
+        component="span"
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder clause ${clauseIndex + 1}`}
+        sx={{ display: "inline-flex", cursor: "grab", color: "text.secondary", mr: 0.25 }}
       >
-        <AddIcon sx={{ fontSize: "0.875rem" }} />
-      </IconButton>
+        <DragIndicatorIcon sx={{ fontSize: "0.9375rem" }} />
+      </Box>
+      <Box component="span" sx={{ color: "text.secondary" }}>
+        (
+      </Box>
+      <SortableContext
+        items={clause.literals.map((literal) => literal.id)}
+        strategy={rectSortingStrategy}
+      >
+        {clause.literals.map((literal, literalIndex) => (
+          <Box
+            key={literal.id}
+            component="span"
+            sx={{ display: "inline-flex", alignItems: "center" }}
+          >
+            {literalIndex > 0 && (
+              <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mx: 0.5 }}>
+                {CONJUNCTION}
+              </Box>
+            )}
+            <SortableLiteral
+              literal={literal}
+              literalIndex={literalIndex}
+              clauseIndex={clauseIndex}
+              clauseId={clause.id}
+              hoveredVariable={hoveredVariable}
+              setHoveredVariable={setHoveredVariable}
+              openMenu={openMenu}
+              idPrefix={idPrefix}
+            />
+          </Box>
+        ))}
+      </SortableContext>
+      <Box component="span" sx={{ color: "text.secondary" }}>
+        )
+      </Box>
     </Box>
   );
 }
@@ -224,17 +292,15 @@ function AddLiteralForm({ idPrefix, clauseIndex, atCap, onEdit }) {
  *   the accessible summary when given.
  * @param {{clauses: Array}} props.frame One already-validated `booleanSatisfiability`
  *   frame.
- * @param {boolean} [props.editable] T52 (#115): true only when this frame is the base
+ * @param {boolean} [props.editable] T55 (#128): true only when this frame is the base
  *   frame (frames[0]) of a visualization the caller has decided is editable right now --
- *   this component does not re-derive that gate. Adds add/remove/negate-literal and
- *   add/remove-clause controls when true; renders exactly as before (T49) when false or
- *   omitted, so Reductions' still-static panes (§2.5, T53 not yet built) are unaffected.
+ *   this component does not re-derive that gate. Renders exactly as before (T49) when
+ *   false or omitted.
  * @param {(updater: (clauses: Array) => Array) => void} [props.onClausesChange] Called
- *   with a `(currentClauses) => nextClauses` updater on every structural edit -- the
- *   caller owns whether "currentClauses" is the frame's own `clauses` or an already-
- *   edited copy from an earlier edit in the same session (INTERACTIVE_LAYER_DESIGN.md
- *   §2.1.2: edits preview locally; only Run round-trips through the backend). Required
- *   when `editable` is true.
+ *   with a `(currentClauses) => nextClauses` updater on every structural edit or reorder
+ *   -- the caller owns whether "currentClauses" is the frame's own `clauses` or an
+ *   already-edited copy from an earlier edit in the same session
+ *   (INTERACTIVE_LAYER_DESIGN.md §2.1.2). Required when `editable` is true.
  * @param {number} [props.maxLiteralsPerClause] SAT3's 3-literal-per-clause cap, enforced
  *   in this UI rather than left for the backend to reject. Omitted (no cap) for SAT.
  */
@@ -248,184 +314,446 @@ export default function BooleanSatisfiabilityRenderer({
 }) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
-  // Hovering or focusing one literal highlights every literal for the same variable
-  // (ignoring negation) across the whole formula -- the hover-triggered highlight §4.2
-  // requires stay keyboard-reachable, via the identical onFocus/onBlur pair LiteralMark
-  // already wires to the same mouse handlers. Suppressed in edit mode: EditableLiteral
-  // renders its own negate/remove controls in the same slot instead of a hover target.
   const [hoveredVariable, setHoveredVariable] = useState(null);
-  const addClauseFieldRef = useRef(null);
-  const [newClauseValue, setNewClauseValue] = useState("");
+  const [menu, setMenu] = useState(null);
+  const [menuValue, setMenuValue] = useState("");
+  const [menuError, setMenuError] = useState("");
+  const menuRef = useRef(null);
 
   const clauses = frame.clauses;
   const clauseCount = clauses.length;
   const summaryBody = `boolean formula with ${clauseCount} clause${clauseCount === 1 ? "" : "s"}`;
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
-  const isNewClauseValid = VARIABLE_NAME_PATTERN.test(newClauseValue.trim());
 
-  function handleAddClause(event) {
-    event.preventDefault();
-    if (!isNewClauseValid) return;
-    const variable = newClauseValue.trim();
+  const closeMenu = useCallback(() => {
+    setMenu(null);
+    setMenuValue("");
+    setMenuError("");
+  }, []);
+  useCloseFloatingMenu(menuRef, menu !== null, closeMenu);
+
+  function openMenu(next) {
+    setMenu(next);
+    setMenuValue("");
+    setMenuError("");
+  }
+
+  // PointerSensor covers mouse, TouchSensor adds mobile/tablet support, KeyboardSensor
+  // (arrow keys to move, space to pick up/drop, escape to cancel) is what keeps this
+  // reachable without a mouse -- exactly T18's ProblemDetailLayout.js sensor set.
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  // Overrides @dnd-kit's generic "sortable item was moved" announcements with text naming
+  // the actual literal or clause -- T18's SECTION_ANNOUNCEMENTS pattern. Needs live
+  // `clauses` (unlike T18's static section titles), so this is a memo, not module scope.
+  const announcements = useMemo(
+    () => ({
+      onDragStart({ active }) {
+        const type = active.data.current?.type;
+        const name = describeDragItem(active.id, type, clauses);
+        return type === "clause"
+          ? `Picked up ${name}. Use the arrow keys to move it, space bar to drop, escape to cancel.`
+          : `Picked up literal ${name}. Use the arrow keys to move it within its clause, space bar to drop, escape to cancel.`;
+      },
+      onDragOver({ active, over }) {
+        if (!over || active.id === over.id) return "";
+        const type = active.data.current?.type;
+        return `${describeDragItem(active.id, type, clauses)} was moved next to ${describeDragItem(over.id, type, clauses)}.`;
+      },
+      onDragEnd({ active, over }) {
+        const type = active.data.current?.type;
+        const activeName = describeDragItem(active.id, type, clauses);
+        return over
+          ? `${activeName} was dropped next to ${describeDragItem(over.id, type, clauses)}.`
+          : `${activeName} was dropped.`;
+      },
+      onDragCancel({ active }) {
+        const type = active.data.current?.type;
+        return `Moving ${describeDragItem(active.id, type, clauses)} was cancelled.`;
+      },
+    }),
+    [clauses],
+  );
+
+  const handleDragEnd = useCallback(
+    (event) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const activeType = active.data.current?.type;
+      const overType = over.data.current?.type;
+
+      if (activeType === "clause" && overType === "clause") {
+        onClausesChange?.((current) => {
+          const oldIndex = current.findIndex((clause) => clause.id === active.id);
+          const newIndex = current.findIndex((clause) => clause.id === over.id);
+          if (oldIndex === -1 || newIndex === -1) return current;
+          return arrayMove(current, oldIndex, newIndex);
+        });
+      } else if (activeType === "literal" && overType === "literal") {
+        // Literals only ever reorder within their own clause -- a drop over a literal
+        // belonging to a different clause is silently ignored, not moved.
+        const clauseId = active.data.current.clauseId;
+        if (over.data.current?.clauseId !== clauseId) return;
+        onClausesChange?.((current) => {
+          const clauseIndex = current.findIndex((clause) => clause.id === clauseId);
+          if (clauseIndex === -1) return current;
+          const literals = current[clauseIndex].literals;
+          const oldIndex = literals.findIndex((literal) => literal.id === active.id);
+          const newIndex = literals.findIndex((literal) => literal.id === over.id);
+          if (oldIndex === -1 || newIndex === -1) return current;
+          const next = [...current];
+          next[clauseIndex] = {
+            ...next[clauseIndex],
+            literals: arrayMove(literals, oldIndex, newIndex),
+          };
+          return next;
+        });
+      }
+    },
+    [onClausesChange],
+  );
+
+  function submitToggleNegate() {
+    if (menu?.kind !== "literal") return;
+    onClausesChange?.((current) => {
+      const next = current.map((clause) => ({ ...clause, literals: [...clause.literals] }));
+      const target = next[menu.clauseIndex]?.literals[menu.literalIndex];
+      if (!target) return current;
+      const variable = literalVariable(target.literal);
+      next[menu.clauseIndex].literals[menu.literalIndex] = {
+        ...target,
+        literal: isNegated(target.literal) ? variable : `!${variable}`,
+      };
+      return next;
+    });
+    closeMenu();
+  }
+
+  function submitRemoveLiteral() {
+    if (menu?.kind !== "literal") return;
+    onClausesChange?.((current) => {
+      const next = current.map((clause) => ({ ...clause, literals: [...clause.literals] }));
+      if (!next[menu.clauseIndex] || next[menu.clauseIndex].literals.length <= 1) return current;
+      next[menu.clauseIndex].literals.splice(menu.literalIndex, 1);
+      return next;
+    });
+    closeMenu();
+  }
+
+  function submitAddLiteralToClause() {
+    if (menu?.kind !== "clause") return;
+    const trimmed = menuValue.trim();
+    if (!VARIABLE_NAME_PATTERN.test(trimmed)) {
+      setMenuError("Enter a variable name, e.g. x1");
+      return;
+    }
+    const clause = clauses[menu.clauseIndex];
+    if (
+      clause &&
+      typeof maxLiteralsPerClause === "number" &&
+      clause.literals.length >= maxLiteralsPerClause
+    ) {
+      setMenuError(`Up to ${maxLiteralsPerClause} literals per clause`);
+      return;
+    }
+    onClausesChange?.((current) => {
+      const next = current.map((candidate) => ({
+        ...candidate,
+        literals: [...candidate.literals],
+      }));
+      if (!next[menu.clauseIndex]) return current;
+      next[menu.clauseIndex].literals.push({
+        id: nextEditId("literal"),
+        literal: trimmed,
+        color: "",
+      });
+      return next;
+    });
+    closeMenu();
+  }
+
+  function submitRemoveClause() {
+    if (menu?.kind !== "clause") return;
+    onClausesChange?.((current) =>
+      current.filter((_candidate, index) => index !== menu.clauseIndex),
+    );
+    closeMenu();
+  }
+
+  function submitCreateClause() {
+    if (menu?.kind !== "createClause") return;
+    const trimmed = menuValue.trim();
+    if (!VARIABLE_NAME_PATTERN.test(trimmed)) {
+      setMenuError("Enter a variable name, e.g. x1");
+      return;
+    }
     onClausesChange?.((current) => [
       ...current,
       {
         id: nextEditId("clause"),
-        literals: [{ id: nextEditId("literal"), literal: variable, color: "" }],
+        literals: [{ id: nextEditId("literal"), literal: trimmed, color: "" }],
       },
     ]);
-    setNewClauseValue("");
-    addClauseFieldRef.current?.focus();
+    closeMenu();
   }
 
-  return (
-    <Box
-      id={scopeId}
-      role="img"
-      aria-label={summary}
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 1.5,
-        p: 2,
-        minHeight: "100%",
-        boxSizing: "border-box",
-      }}
-    >
-      <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1 }}>
+  if (!editable) {
+    return (
+      <Box
+        id={scopeId}
+        role="img"
+        aria-label={summary}
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 1,
+          p: 2,
+          minHeight: "100%",
+          boxSizing: "border-box",
+        }}
+      >
         {clauseCount === 0 ? (
           <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
             No clauses.
           </Box>
         ) : (
-          clauses.map((clause, clauseIndex) => {
-            const atCap =
-              typeof maxLiteralsPerClause === "number" &&
-              clause.literals.length >= maxLiteralsPerClause;
-            return (
-              <Box
-                key={clause.id}
-                component="span"
-                sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
-              >
-                {clauseIndex > 0 && (
-                  <Box
-                    component="span"
-                    aria-hidden="true"
-                    sx={{ color: "text.secondary", mx: 0.5 }}
-                  >
-                    {DISJUNCTION}
-                  </Box>
-                )}
-                <Box component="span" sx={{ color: "text.secondary" }}>
-                  (
+          clauses.map((clause, clauseIndex) => (
+            <Box
+              key={clause.id}
+              component="span"
+              sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+            >
+              {clauseIndex > 0 && (
+                <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mx: 0.5 }}>
+                  {DISJUNCTION}
                 </Box>
-                {clause.literals.map((literal, literalIndex) => {
-                  const variable = literalVariable(literal.literal);
-                  return (
-                    <Box
-                      key={literal.id}
-                      component="span"
-                      sx={{ display: "inline-flex", alignItems: "center" }}
-                    >
-                      {literalIndex > 0 && (
-                        <Box
-                          component="span"
-                          aria-hidden="true"
-                          sx={{ color: "text.secondary", mx: 0.5 }}
-                        >
-                          {CONJUNCTION}
-                        </Box>
-                      )}
-                      {editable ? (
-                        <EditableLiteral
-                          idPrefix={scopeId}
-                          clauseIndex={clauseIndex}
-                          literalIndex={literalIndex}
-                          literal={literal}
-                          canRemove={clause.literals.length > 1}
-                          onEdit={onClausesChange}
-                        />
-                      ) : (
-                        <LiteralMark
-                          id={`${scopeId}-literal-${literal.id}`}
-                          literal={literal}
-                          highlighted={hoveredVariable != null && variable === hoveredVariable}
-                          onEnter={() => setHoveredVariable(variable)}
-                          onLeave={() =>
-                            setHoveredVariable((current) => (current === variable ? null : current))
-                          }
-                        />
-                      )}
-                    </Box>
-                  );
-                })}
-                <Box component="span" sx={{ color: "text.secondary" }}>
-                  )
-                </Box>
-                {editable && (
-                  <>
-                    <AddLiteralForm
-                      idPrefix={scopeId}
-                      clauseIndex={clauseIndex}
-                      atCap={atCap}
-                      onEdit={onClausesChange}
-                    />
-                    <EditIconButton
-                      id={`${scopeId}-clause-${clause.id}-remove`}
-                      label={`Remove clause ${clauseIndex + 1}`}
-                      onClick={() =>
-                        onClausesChange?.((current) =>
-                          current.filter((_candidate, index) => index !== clauseIndex),
-                        )
-                      }
-                    >
-                      <CloseIcon sx={{ fontSize: "0.875rem" }} />
-                    </EditIconButton>
-                  </>
-                )}
+              )}
+              <Box component="span" sx={{ color: "text.secondary" }}>
+                (
               </Box>
-            );
-          })
+              {clause.literals.map((literal, literalIndex) => {
+                const variable = literalVariable(literal.literal);
+                return (
+                  <Box
+                    key={literal.id}
+                    component="span"
+                    sx={{ display: "inline-flex", alignItems: "center" }}
+                  >
+                    {literalIndex > 0 && (
+                      <Box
+                        component="span"
+                        aria-hidden="true"
+                        sx={{ color: "text.secondary", mx: 0.5 }}
+                      >
+                        {CONJUNCTION}
+                      </Box>
+                    )}
+                    <LiteralMark
+                      id={`${scopeId}-literal-${literal.id}`}
+                      literal={literal}
+                      highlighted={hoveredVariable != null && variable === hoveredVariable}
+                      onEnter={() => setHoveredVariable(variable)}
+                      onLeave={() =>
+                        setHoveredVariable((current) => (current === variable ? null : current))
+                      }
+                    />
+                  </Box>
+                );
+              })}
+              <Box component="span" sx={{ color: "text.secondary" }}>
+                )
+              </Box>
+            </Box>
+          ))
         )}
       </Box>
+    );
+  }
 
-      {editable && (
-        <Box
-          component="form"
-          onSubmit={handleAddClause}
-          sx={{ display: "flex", alignItems: "center", gap: 0.75 }}
-        >
-          <Box component="label" htmlFor={`${scopeId}-add-clause`} sx={{ display: "none" }}>
-            First variable for the new clause
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        accessibility={{ announcements }}
+      >
+        <SortableContext items={clauses.map((clause) => clause.id)} strategy={rectSortingStrategy}>
+          <Box
+            id={scopeId}
+            role="img"
+            aria-label={summary}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              openMenu({ kind: "createClause", x: event.clientX, y: event.clientY });
+            }}
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              alignItems: "center",
+              gap: 1,
+              p: 2,
+              minHeight: 120,
+              boxSizing: "border-box",
+            }}
+          >
+            {clauseCount === 0 ? (
+              <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+                No clauses. Right-click to add one.
+              </Box>
+            ) : (
+              clauses.map((clause, clauseIndex) => (
+                <Box
+                  key={clause.id}
+                  component="span"
+                  sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+                >
+                  {clauseIndex > 0 && (
+                    <Box
+                      component="span"
+                      aria-hidden="true"
+                      sx={{ color: "text.secondary", mx: 0.5 }}
+                    >
+                      {DISJUNCTION}
+                    </Box>
+                  )}
+                  <SortableClause
+                    clause={clause}
+                    clauseIndex={clauseIndex}
+                    hoveredVariable={hoveredVariable}
+                    setHoveredVariable={setHoveredVariable}
+                    openMenu={openMenu}
+                    idPrefix={scopeId}
+                  />
+                </Box>
+              ))
+            )}
           </Box>
+        </SortableContext>
+      </DndContext>
+
+      <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+        Drag the grip to reorder clauses, or drag a literal to reorder it within its clause.
+        Right-click a literal, a clause, or empty space to add, negate, or remove.
+      </Typography>
+
+      {menu?.kind === "literal" &&
+        (() => {
+          const clause = clauses[menu.clauseIndex];
+          const literal = clause?.literals[menu.literalIndex];
+          if (!literal) return null;
+          const canRemove = clause.literals.length > 1;
+          const negated = isNegated(literal.literal);
+          return (
+            <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+              <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+                {literal.literal}
+              </Typography>
+              <Box sx={{ display: "flex", gap: 1 }}>
+                <Button size="small" variant="outlined" onClick={submitToggleNegate}>
+                  {negated ? "Remove negation" : "Negate"}
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  variant="outlined"
+                  disabled={!canRemove}
+                  onClick={submitRemoveLiteral}
+                >
+                  Remove
+                </Button>
+              </Box>
+            </FloatingMenu>
+          );
+        })()}
+
+      {menu?.kind === "clause" &&
+        (() => {
+          const clause = clauses[menu.clauseIndex];
+          if (!clause) return null;
+          const atCap =
+            typeof maxLiteralsPerClause === "number" &&
+            clause.literals.length >= maxLiteralsPerClause;
+          return (
+            <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+              <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+                Clause {menu.clauseIndex + 1}
+              </Typography>
+              <TextField
+                id={`${scopeId}-add-literal`}
+                size="small"
+                autoFocus
+                label="Add variable"
+                placeholder="x1"
+                value={menuValue}
+                disabled={atCap}
+                onChange={(event) => setMenuValue(event.target.value)}
+                onKeyDown={(event) => event.key === "Enter" && submitAddLiteralToClause()}
+              />
+              {atCap && (
+                <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                  Up to {maxLiteralsPerClause} literals per clause.
+                </Typography>
+              )}
+              {menuError && (
+                <Typography variant="caption" color="error">
+                  {menuError}
+                </Typography>
+              )}
+              <Box sx={{ display: "flex", gap: 1 }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={atCap}
+                  onClick={submitAddLiteralToClause}
+                >
+                  Add literal
+                </Button>
+                <Button size="small" color="error" variant="outlined" onClick={submitRemoveClause}>
+                  Remove clause
+                </Button>
+                <Button size="small" onClick={closeMenu}>
+                  Cancel
+                </Button>
+              </Box>
+            </FloatingMenu>
+          );
+        })()}
+
+      {menu?.kind === "createClause" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            New clause
+          </Typography>
           <TextField
             id={`${scopeId}-add-clause`}
-            inputRef={addClauseFieldRef}
             size="small"
-            variant="outlined"
+            autoFocus
+            label="First variable"
             placeholder="x1"
-            value={newClauseValue}
-            onChange={(event) => setNewClauseValue(event.target.value)}
-            sx={{ width: 88, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
-            inputProps={{ "aria-label": "First variable for the new clause" }}
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitCreateClause()}
           />
-          <Button
-            id={`${scopeId}-add-clause-submit`}
-            type="submit"
-            size="small"
-            variant="outlined"
-            disabled={!isNewClauseValid}
-            startIcon={<AddIcon sx={{ fontSize: "1rem" }} />}
-          >
-            Add clause
-          </Button>
-          {typeof maxLiteralsPerClause === "number" && (
-            <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              Up to {maxLiteralsPerClause} literals per clause.
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
             </Typography>
           )}
-        </Box>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitCreateClause}>
+              Add clause
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
       )}
     </Box>
   );

--- a/components/detail/visualizations/GraphRenderer.js
+++ b/components/detail/visualizations/GraphRenderer.js
@@ -48,12 +48,12 @@
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation } from "d3-force";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+import { FloatingMenu, useCloseFloatingMenu } from "./floatingMenu";
 import {
   computeEdgePath,
   computeSelfLoopPath,
@@ -225,31 +225,8 @@ function GraphNodeMark({ node, highlighted, onEnter, onLeave }) {
   );
 }
 
-// Fixed-position floating popup, positioned at the screen point a right-click or drag-end
-// happened -- SARE_2026's AutomatonCanvas.tsx menu pattern (issue #124). Lives as a sibling
-// of the <svg> in the DOM, not inside it, so a click inside the menu never reaches the
-// canvas's own mousedown/contextmenu handlers.
-function FloatingMenu({ menuRef, x, y, children }) {
-  return (
-    <Paper
-      ref={menuRef}
-      elevation={8}
-      sx={{
-        position: "fixed",
-        left: x + 4,
-        top: y + 4,
-        p: 1.5,
-        zIndex: 20,
-        minWidth: 200,
-        display: "flex",
-        flexDirection: "column",
-        gap: 1,
-      }}
-    >
-      {children}
-    </Paper>
-  );
-}
+// FloatingMenu and its outside-click/Escape handling now live in ./floatingMenu.js -- pulled
+// out once BooleanSatisfiabilityRenderer.js (T55/#128) needed the identical pattern.
 
 /**
  * @param {Object} props
@@ -321,25 +298,7 @@ export default function GraphRenderer({
     setMenuError("");
   }, []);
 
-  // Outside click / Escape closes whatever menu is open -- reads only this component's own
-  // menuRef, not a hardcoded global selector (§4.1).
-  useEffect(() => {
-    if (!menu) return undefined;
-    function handlePointerDown(event) {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        closeMenu();
-      }
-    }
-    function handleKeyDown(event) {
-      if (event.key === "Escape") closeMenu();
-    }
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [menu, closeMenu]);
+  useCloseFloatingMenu(menuRef, menu !== null, closeMenu);
 
   const svgPoint = useCallback((event) => {
     const svg = svgRef.current;
@@ -432,7 +391,9 @@ export default function GraphRenderer({
         const target = displayNodes.find(
           (node) => distanceBetween(x, y, node.x, node.y) <= NODE_RADIUS,
         );
-        if (target && target.id !== drag.sourceId) {
+        // #127: releasing back on the origin node creates a self-loop -- applyGraphOp's
+        // addEdge no longer rejects source === target.
+        if (target) {
           onGraphEdit?.({ type: "addEdge", source: drag.sourceId, target: target.id });
         }
         setRubber(null);

--- a/components/detail/visualizations/floatingMenu.js
+++ b/components/detail/visualizations/floatingMenu.js
@@ -1,0 +1,65 @@
+// components/detail/visualizations/floatingMenu.js
+//
+// Shared floating context-menu chrome for the diagram editors that use right-click menus
+// positioned at the click point (GraphRenderer.js/T54, BooleanSatisfiabilityRenderer.js/T55)
+// -- extracted once a second renderer needed the identical pattern, rather than duplicated a
+// second time. A menu is a DOM sibling of whatever it floats over (never inside an SVG or a
+// dnd-kit draggable subtree), positioned with `position: fixed` at the screen point a
+// right-click happened, so a click inside the menu never reaches the canvas's own
+// pointerdown/contextmenu handlers underneath it.
+
+import Paper from "@mui/material/Paper";
+import { useEffect } from "react";
+
+/**
+ * Closes `onClose` on an outside click or Escape, while a menu is open. Reads only the given
+ * ref, not a hardcoded global selector (§4.1).
+ *
+ * @param {React.RefObject} menuRef
+ * @param {boolean} isOpen
+ * @param {() => void} onClose
+ */
+export function useCloseFloatingMenu(menuRef, isOpen, onClose) {
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    function handlePointerDown(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        onClose();
+      }
+    }
+    function handleKeyDown(event) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+    // menuRef is a ref object -- stable across renders, but it arrives as a parameter here
+    // (not a `useRef()` call in this function body), so eslint's exhaustive-deps special
+    // case for refs doesn't apply and it's listed explicitly instead.
+  }, [isOpen, onClose, menuRef]);
+}
+
+export function FloatingMenu({ menuRef, x, y, children }) {
+  return (
+    <Paper
+      ref={menuRef}
+      elevation={8}
+      sx={{
+        position: "fixed",
+        left: x + 4,
+        top: y + 4,
+        p: 1.5,
+        zIndex: 20,
+        minWidth: 200,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}

--- a/data/frameEditOps.js
+++ b/data/frameEditOps.js
@@ -80,7 +80,9 @@ export function applyGraphOp(current, op) {
       };
     }
     case "addEdge": {
-      if (op.source === op.target) return current;
+      // #127: self-loops (op.source === op.target) are allowed -- DFA/NFA instances need
+      // them routinely (a state transitioning to itself), and they already render fine
+      // (graphGeometry.js's computeSelfLoopPath) when present in loaded instance data.
       const alreadyExists = current.links.some(
         (link) =>
           (link.source === op.source && link.target === op.target) ||


### PR DESCRIPTION
Issue: T55 (#128): Rework booleanSatisfiability editing: right-click menus + drag-to-reorder
Branch: task/T55-sat-dnd-editor

Changed:
components/detail/visualizations/BooleanSatisfiabilityRenderer.js   (rewritten)
components/detail/visualizations/floatingMenu.js                    (new, shared)
components/detail/visualizations/GraphRenderer.js                   (refactored to use the shared module)

Done when, met:
- Right-click on a literal, a clause, and empty space each open the correct context menu
- Negate/remove-literal, add/remove-clause all work through the menus via the existing onClausesChange updater contract — no changes to VisualizationsSection.js or the serializer
- Drag (mouse, touch, or keyboard via @dnd-kit's KeyboardSensor) reorders clauses among each other, and reorders literals within one clause; a literal dropped on a different clause is silently ignored rather than moved
- Screen-reader announcements name the actual literal/clause being moved, not @dnd-kit's generic defaults
- Old inline icon-button controls and forms removed entirely

Bonus cleanup: pulled the floating-menu chrome (positioning, outside-click/Escape close) out of GraphRenderer.js into a shared module once this was the second renderer that needed it — GraphRenderer.js's own behavior is unchanged, just de-duplicated.

Closes #128 