### PR TITLE
Task/t56 quantum dnd editor

### DIFF
--- a/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
+++ b/components/detail/visualizations/BooleanSatisfiabilityRenderer.js
@@ -10,31 +10,63 @@
 //
 // No `d3.selectAll`/`d3.select` against `document` or a hardcoded id (§4.1): this is
 // plain React-owned markup, nothing to scope beyond the one root id `useId()` already
-// makes collision-proof between two mounted instances (Reductions' side-by-side panes,
-// once T53 wires them to real data).
+// makes collision-proof between two mounted instances (Reductions' side-by-side panes).
 //
 // Literal text (`"x1"`, `"!x2"`) is rendered exactly as the backend sends it -- no
 // substituting `!` for a proper negation glyph -- the same "display exactly what the
 // backend returned" call §3.5 already made for stepTable's cell text, extended here on
 // the same reasoning: this is the backend's own data, not this project's UI copy.
 //
-// T52 (#115): editing affordances (add/remove/negate a literal, add/remove a clause) are
-// now here, gated behind the `editable` prop -- exactly the growth this component was
-// structured for. Only ever passed `editable` when the frame being shown is the base
-// frame (frames[0], per INTERACTIVE_LAYER_DESIGN.md §2.3) -- VisualizationsSection.js
-// owns that gate, this component doesn't re-derive it. Every edit control here is a
-// real, focusable, aria-labelled button or text input -- no drag, no right-click -- per
-// §3's keyboard-reachable requirement (same precedent as T18's KeyboardSensor).
+// T55 (#128): editing is right-click context menus (negate/remove a literal; add a
+// literal/remove a clause; add a clause), plus drag-to-reorder for both clauses and
+// literals within a clause -- replacing T52's inline icon-button controls. Reordering
+// never changes what the formula means ("∧"/"∨" are both commutative), and
+// `serializeBooleanSatisfiabilityInstance` already serializes whatever order the
+// `clauses`/`literals` arrays hold, so this carries none of `graph`'s round-trip
+// correctness risk.
+//
+// Unlike `graph` (T54), this keeps a keyboard-reachable path: dragging is built on
+// `@dnd-kit` (already a project dependency; `KeyboardSensor` with
+// `sortableKeyboardCoordinates` is T18/#27's existing precedent in
+// ProblemDetailLayout.js) rather than hand-rolled pointer math, because both reorders
+// here are snap-to-slot -- a clause or literal moves to one of a fixed set of positions
+// -- exactly what `@dnd-kit`'s sortable preset is built for, unlike `graph`'s freeform
+// curve-dragging, which had no cheap keyboard equivalent. Full decision record:
+// ai_documentation/INTERACTIVE_LAYER_DESIGN.md §3.2.
+//
+// One shared `DndContext` covers both reorder levels rather than nesting a `DndContext`
+// per clause -- nesting `DndContext`s is a known-fragile dnd-kit pattern (both would try
+// to claim the same pointer/keyboard events). Sibling `SortableContext`s (one for the
+// clause list, one per clause for its own literals) coexist fine under one `DndContext`;
+// `handleDragEnd` below tells a clause-reorder from a literal-reorder via each draggable
+// item's own `data.current.type`, and a literal drop is ignored outright if it lands on a
+// different clause than it started in (literals never move between clauses this way).
 
-import AddIcon from "@mui/icons-material/Add";
-import CloseIcon from "@mui/icons-material/Close";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  rectSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import IconButton from "@mui/material/IconButton";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { useId, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+import { FloatingMenu, useCloseFloatingMenu } from "./floatingMenu";
 
 const CONJUNCTION = "∧"; // AND, between literals within a clause (T40's finding, see header)
 const DISJUNCTION = "∨"; // OR, between clauses
@@ -61,11 +93,37 @@ function nextEditId(prefix) {
   return `${prefix}-${editIdCounter}`;
 }
 
-function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
+// Human-readable name for a dnd-kit drag/drop announcement -- a literal's own text, or
+// "clause N" (clauses have no shorter display name of their own).
+function describeDragItem(id, type, clauses) {
+  if (type === "clause") {
+    const index = clauses.findIndex((clause) => clause.id === id);
+    return index === -1 ? "a clause" : `clause ${index + 1}`;
+  }
+  for (const clause of clauses) {
+    const literal = clause.literals.find((candidate) => candidate.id === id);
+    if (literal) return literal.literal;
+  }
+  return "an item";
+}
+
+function LiteralMark({
+  id,
+  literal,
+  highlighted,
+  onEnter,
+  onLeave,
+  onContextMenu,
+  dragRef,
+  dragStyle,
+  dragAttributes,
+  dragListeners,
+}) {
   const color = getVisualizationColor(literal.color);
   return (
     <Box
       id={id}
+      ref={dragRef}
       component="span"
       tabIndex={0}
       aria-label={literal.literal}
@@ -73,14 +131,20 @@ function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
       onMouseLeave={onLeave}
       onFocus={onEnter}
       onBlur={onLeave}
+      onContextMenu={onContextMenu}
+      style={dragStyle}
+      {...(dragAttributes ?? {})}
+      {...(dragListeners ?? {})}
       sx={{
+        display: "inline-block",
         fontFamily: '"JetBrains Mono", "Fira Code", Consolas, monospace',
         fontSize: "0.9375rem",
         color,
         fontWeight: highlighted ? 700 : 500,
         textDecoration: highlighted ? "underline" : "none",
         borderRadius: 0.5,
-        cursor: "default",
+        px: 0.25,
+        cursor: dragListeners ? "grab" : "default",
       }}
     >
       {literal.literal}
@@ -88,130 +152,134 @@ function LiteralMark({ id, literal, highlighted, onEnter, onLeave }) {
   );
 }
 
-// The negate toggle and remove button share this compact icon-button style -- kept small
-// enough to sit inline with the clause's literal text without dominating it.
-function EditIconButton({ id, label, pressed, onClick, children }) {
-  return (
-    <IconButton
-      id={id}
-      size="small"
-      aria-label={label}
-      aria-pressed={pressed}
-      onClick={onClick}
-      sx={{ p: 0.375 }}
-    >
-      {children}
-    </IconButton>
-  );
-}
-
-function EditableLiteral({ idPrefix, clauseIndex, literalIndex, literal, canRemove, onEdit }) {
+// One sortable literal -- calls `useSortable` itself (only ever mounted inside the
+// editable tree's DndContext) and hands the resulting drag wiring down to the shared
+// LiteralMark presentational component.
+function SortableLiteral({
+  literal,
+  literalIndex,
+  clauseIndex,
+  clauseId,
+  hoveredVariable,
+  setHoveredVariable,
+  openMenu,
+  idPrefix,
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: literal.id,
+    data: { type: "literal", clauseId },
+  });
   const variable = literalVariable(literal.literal);
-  const negated = isNegated(literal.literal);
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
   return (
-    <Box component="span" sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
-      <LiteralMark id={`${idPrefix}-literal-${literal.id}`} literal={literal} />
-      <EditIconButton
-        id={`${idPrefix}-literal-${literal.id}-negate`}
-        label={`${negated ? "Remove negation from" : "Negate"} ${variable} in clause ${clauseIndex + 1}`}
-        pressed={negated}
-        onClick={() =>
-          onEdit((clauses) => {
-            const next = clauses.map((clause) => ({ ...clause, literals: [...clause.literals] }));
-            const target = next[clauseIndex].literals[literalIndex];
-            next[clauseIndex].literals[literalIndex] = {
-              ...target,
-              literal: negated ? variable : `!${variable}`,
-            };
-            return next;
-          })
-        }
-      >
-        <Typography
-          component="span"
-          aria-hidden="true"
-          sx={{ fontSize: "0.75rem", fontWeight: 700 }}
-        >
-          !
-        </Typography>
-      </EditIconButton>
-      {canRemove && (
-        <EditIconButton
-          id={`${idPrefix}-literal-${literal.id}-remove`}
-          label={`Remove ${literal.literal} from clause ${clauseIndex + 1}`}
-          onClick={() =>
-            onEdit((clauses) => {
-              const next = clauses.map((clause) => ({
-                ...clause,
-                literals: [...clause.literals],
-              }));
-              next[clauseIndex].literals.splice(literalIndex, 1);
-              return next;
-            })
-          }
-        >
-          <CloseIcon sx={{ fontSize: "0.875rem" }} />
-        </EditIconButton>
-      )}
-    </Box>
+    <LiteralMark
+      id={`${idPrefix}-literal-${literal.id}`}
+      literal={literal}
+      highlighted={hoveredVariable != null && variable === hoveredVariable}
+      onEnter={() => setHoveredVariable(variable)}
+      onLeave={() => setHoveredVariable((current) => (current === variable ? null : current))}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openMenu({
+          kind: "literal",
+          clauseIndex,
+          literalIndex,
+          x: event.clientX,
+          y: event.clientY,
+        });
+      }}
+      dragRef={setNodeRef}
+      dragStyle={style}
+      dragAttributes={attributes}
+      dragListeners={listeners}
+    />
   );
 }
 
-// Keyboard-reachable "add literal" affordance (§3 of INTERACTIVE_LAYER_DESIGN.md): a real
-// text field plus a submit button, not a drag/right-click gesture. Disabled once the
-// clause is at `maxLiteralsPerClause` (SAT3's 3-literal cap, enforced here rather than
-// left for the backend to reject).
-function AddLiteralForm({ idPrefix, clauseIndex, atCap, onEdit }) {
-  const [value, setValue] = useState("");
-  const fieldId = `${idPrefix}-clause-${clauseIndex}-add-literal`;
-  const isValid = VARIABLE_NAME_PATTERN.test(value.trim());
-
-  function handleSubmit(event) {
-    event.preventDefault();
-    if (!isValid || atCap) return;
-    const variable = value.trim();
-    onEdit((clauses) => {
-      const next = clauses.map((clause) => ({ ...clause, literals: [...clause.literals] }));
-      next[clauseIndex].literals.push({
-        id: nextEditId("literal"),
-        literal: variable,
-        color: "",
-      });
-      return next;
-    });
-    setValue("");
-  }
+// One sortable clause: a drag grip (its own handle, distinct from each literal's own drag
+// handle so the two never fight over the same pointer/keyboard events), its own nested
+// SortableContext for literal reorder, and a right-click target scoped to the clause's own
+// background (literals stop propagation on their own context-menu clicks, so this only
+// fires for a click that wasn't on a literal).
+function SortableClause({
+  clause,
+  clauseIndex,
+  hoveredVariable,
+  setHoveredVariable,
+  openMenu,
+  idPrefix,
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: clause.id,
+    data: { type: "clause" },
+  });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
 
   return (
     <Box
-      component="form"
-      onSubmit={handleSubmit}
-      sx={{ display: "inline-flex", alignItems: "center", gap: 0.5, ml: 0.5 }}
+      ref={setNodeRef}
+      component="span"
+      style={style}
+      sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        openMenu({ kind: "clause", clauseIndex, x: event.clientX, y: event.clientY });
+      }}
     >
-      <Box component="label" htmlFor={fieldId} sx={{ display: "none" }}>
-        Variable name to add to clause {clauseIndex + 1}
-      </Box>
-      <TextField
-        id={fieldId}
-        size="small"
-        variant="standard"
-        placeholder="x1"
-        value={value}
-        disabled={atCap}
-        onChange={(event) => setValue(event.target.value)}
-        sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
-        inputProps={{ "aria-label": `Variable name to add to clause ${clauseIndex + 1}` }}
-      />
-      <IconButton
-        id={`${fieldId}-submit`}
-        type="submit"
-        size="small"
-        disabled={atCap || !isValid}
-        aria-label={`Add literal to clause ${clauseIndex + 1}`}
-        sx={{ p: 0.375 }}
+      <Box
+        component="span"
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder clause ${clauseIndex + 1}`}
+        sx={{ display: "inline-flex", cursor: "grab", color: "text.secondary", mr: 0.25 }}
       >
-        <AddIcon sx={{ fontSize: "0.875rem" }} />
-      </IconButton>
+        <DragIndicatorIcon sx={{ fontSize: "0.9375rem" }} />
+      </Box>
+      <Box component="span" sx={{ color: "text.secondary" }}>
+        (
+      </Box>
+      <SortableContext
+        items={clause.literals.map((literal) => literal.id)}
+        strategy={rectSortingStrategy}
+      >
+        {clause.literals.map((literal, literalIndex) => (
+          <Box
+            key={literal.id}
+            component="span"
+            sx={{ display: "inline-flex", alignItems: "center" }}
+          >
+            {literalIndex > 0 && (
+              <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mx: 0.5 }}>
+                {CONJUNCTION}
+              </Box>
+            )}
+            <SortableLiteral
+              literal={literal}
+              literalIndex={literalIndex}
+              clauseIndex={clauseIndex}
+              clauseId={clause.id}
+              hoveredVariable={hoveredVariable}
+              setHoveredVariable={setHoveredVariable}
+              openMenu={openMenu}
+              idPrefix={idPrefix}
+            />
+          </Box>
+        ))}
+      </SortableContext>
+      <Box component="span" sx={{ color: "text.secondary" }}>
+        )
+      </Box>
     </Box>
   );
 }
@@ -224,17 +292,15 @@ function AddLiteralForm({ idPrefix, clauseIndex, atCap, onEdit }) {
  *   the accessible summary when given.
  * @param {{clauses: Array}} props.frame One already-validated `booleanSatisfiability`
  *   frame.
- * @param {boolean} [props.editable] T52 (#115): true only when this frame is the base
+ * @param {boolean} [props.editable] T55 (#128): true only when this frame is the base
  *   frame (frames[0]) of a visualization the caller has decided is editable right now --
- *   this component does not re-derive that gate. Adds add/remove/negate-literal and
- *   add/remove-clause controls when true; renders exactly as before (T49) when false or
- *   omitted, so Reductions' still-static panes (§2.5, T53 not yet built) are unaffected.
+ *   this component does not re-derive that gate. Renders exactly as before (T49) when
+ *   false or omitted.
  * @param {(updater: (clauses: Array) => Array) => void} [props.onClausesChange] Called
- *   with a `(currentClauses) => nextClauses` updater on every structural edit -- the
- *   caller owns whether "currentClauses" is the frame's own `clauses` or an already-
- *   edited copy from an earlier edit in the same session (INTERACTIVE_LAYER_DESIGN.md
- *   §2.1.2: edits preview locally; only Run round-trips through the backend). Required
- *   when `editable` is true.
+ *   with a `(currentClauses) => nextClauses` updater on every structural edit or reorder
+ *   -- the caller owns whether "currentClauses" is the frame's own `clauses` or an
+ *   already-edited copy from an earlier edit in the same session
+ *   (INTERACTIVE_LAYER_DESIGN.md §2.1.2). Required when `editable` is true.
  * @param {number} [props.maxLiteralsPerClause] SAT3's 3-literal-per-clause cap, enforced
  *   in this UI rather than left for the backend to reject. Omitted (no cap) for SAT.
  */
@@ -248,184 +314,446 @@ export default function BooleanSatisfiabilityRenderer({
 }) {
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
-  // Hovering or focusing one literal highlights every literal for the same variable
-  // (ignoring negation) across the whole formula -- the hover-triggered highlight §4.2
-  // requires stay keyboard-reachable, via the identical onFocus/onBlur pair LiteralMark
-  // already wires to the same mouse handlers. Suppressed in edit mode: EditableLiteral
-  // renders its own negate/remove controls in the same slot instead of a hover target.
   const [hoveredVariable, setHoveredVariable] = useState(null);
-  const addClauseFieldRef = useRef(null);
-  const [newClauseValue, setNewClauseValue] = useState("");
+  const [menu, setMenu] = useState(null);
+  const [menuValue, setMenuValue] = useState("");
+  const [menuError, setMenuError] = useState("");
+  const menuRef = useRef(null);
 
   const clauses = frame.clauses;
   const clauseCount = clauses.length;
   const summaryBody = `boolean formula with ${clauseCount} clause${clauseCount === 1 ? "" : "s"}`;
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
-  const isNewClauseValid = VARIABLE_NAME_PATTERN.test(newClauseValue.trim());
 
-  function handleAddClause(event) {
-    event.preventDefault();
-    if (!isNewClauseValid) return;
-    const variable = newClauseValue.trim();
+  const closeMenu = useCallback(() => {
+    setMenu(null);
+    setMenuValue("");
+    setMenuError("");
+  }, []);
+  useCloseFloatingMenu(menuRef, menu !== null, closeMenu);
+
+  function openMenu(next) {
+    setMenu(next);
+    setMenuValue("");
+    setMenuError("");
+  }
+
+  // PointerSensor covers mouse, TouchSensor adds mobile/tablet support, KeyboardSensor
+  // (arrow keys to move, space to pick up/drop, escape to cancel) is what keeps this
+  // reachable without a mouse -- exactly T18's ProblemDetailLayout.js sensor set.
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  // Overrides @dnd-kit's generic "sortable item was moved" announcements with text naming
+  // the actual literal or clause -- T18's SECTION_ANNOUNCEMENTS pattern. Needs live
+  // `clauses` (unlike T18's static section titles), so this is a memo, not module scope.
+  const announcements = useMemo(
+    () => ({
+      onDragStart({ active }) {
+        const type = active.data.current?.type;
+        const name = describeDragItem(active.id, type, clauses);
+        return type === "clause"
+          ? `Picked up ${name}. Use the arrow keys to move it, space bar to drop, escape to cancel.`
+          : `Picked up literal ${name}. Use the arrow keys to move it within its clause, space bar to drop, escape to cancel.`;
+      },
+      onDragOver({ active, over }) {
+        if (!over || active.id === over.id) return "";
+        const type = active.data.current?.type;
+        return `${describeDragItem(active.id, type, clauses)} was moved next to ${describeDragItem(over.id, type, clauses)}.`;
+      },
+      onDragEnd({ active, over }) {
+        const type = active.data.current?.type;
+        const activeName = describeDragItem(active.id, type, clauses);
+        return over
+          ? `${activeName} was dropped next to ${describeDragItem(over.id, type, clauses)}.`
+          : `${activeName} was dropped.`;
+      },
+      onDragCancel({ active }) {
+        const type = active.data.current?.type;
+        return `Moving ${describeDragItem(active.id, type, clauses)} was cancelled.`;
+      },
+    }),
+    [clauses],
+  );
+
+  const handleDragEnd = useCallback(
+    (event) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const activeType = active.data.current?.type;
+      const overType = over.data.current?.type;
+
+      if (activeType === "clause" && overType === "clause") {
+        onClausesChange?.((current) => {
+          const oldIndex = current.findIndex((clause) => clause.id === active.id);
+          const newIndex = current.findIndex((clause) => clause.id === over.id);
+          if (oldIndex === -1 || newIndex === -1) return current;
+          return arrayMove(current, oldIndex, newIndex);
+        });
+      } else if (activeType === "literal" && overType === "literal") {
+        // Literals only ever reorder within their own clause -- a drop over a literal
+        // belonging to a different clause is silently ignored, not moved.
+        const clauseId = active.data.current.clauseId;
+        if (over.data.current?.clauseId !== clauseId) return;
+        onClausesChange?.((current) => {
+          const clauseIndex = current.findIndex((clause) => clause.id === clauseId);
+          if (clauseIndex === -1) return current;
+          const literals = current[clauseIndex].literals;
+          const oldIndex = literals.findIndex((literal) => literal.id === active.id);
+          const newIndex = literals.findIndex((literal) => literal.id === over.id);
+          if (oldIndex === -1 || newIndex === -1) return current;
+          const next = [...current];
+          next[clauseIndex] = {
+            ...next[clauseIndex],
+            literals: arrayMove(literals, oldIndex, newIndex),
+          };
+          return next;
+        });
+      }
+    },
+    [onClausesChange],
+  );
+
+  function submitToggleNegate() {
+    if (menu?.kind !== "literal") return;
+    onClausesChange?.((current) => {
+      const next = current.map((clause) => ({ ...clause, literals: [...clause.literals] }));
+      const target = next[menu.clauseIndex]?.literals[menu.literalIndex];
+      if (!target) return current;
+      const variable = literalVariable(target.literal);
+      next[menu.clauseIndex].literals[menu.literalIndex] = {
+        ...target,
+        literal: isNegated(target.literal) ? variable : `!${variable}`,
+      };
+      return next;
+    });
+    closeMenu();
+  }
+
+  function submitRemoveLiteral() {
+    if (menu?.kind !== "literal") return;
+    onClausesChange?.((current) => {
+      const next = current.map((clause) => ({ ...clause, literals: [...clause.literals] }));
+      if (!next[menu.clauseIndex] || next[menu.clauseIndex].literals.length <= 1) return current;
+      next[menu.clauseIndex].literals.splice(menu.literalIndex, 1);
+      return next;
+    });
+    closeMenu();
+  }
+
+  function submitAddLiteralToClause() {
+    if (menu?.kind !== "clause") return;
+    const trimmed = menuValue.trim();
+    if (!VARIABLE_NAME_PATTERN.test(trimmed)) {
+      setMenuError("Enter a variable name, e.g. x1");
+      return;
+    }
+    const clause = clauses[menu.clauseIndex];
+    if (
+      clause &&
+      typeof maxLiteralsPerClause === "number" &&
+      clause.literals.length >= maxLiteralsPerClause
+    ) {
+      setMenuError(`Up to ${maxLiteralsPerClause} literals per clause`);
+      return;
+    }
+    onClausesChange?.((current) => {
+      const next = current.map((candidate) => ({
+        ...candidate,
+        literals: [...candidate.literals],
+      }));
+      if (!next[menu.clauseIndex]) return current;
+      next[menu.clauseIndex].literals.push({
+        id: nextEditId("literal"),
+        literal: trimmed,
+        color: "",
+      });
+      return next;
+    });
+    closeMenu();
+  }
+
+  function submitRemoveClause() {
+    if (menu?.kind !== "clause") return;
+    onClausesChange?.((current) =>
+      current.filter((_candidate, index) => index !== menu.clauseIndex),
+    );
+    closeMenu();
+  }
+
+  function submitCreateClause() {
+    if (menu?.kind !== "createClause") return;
+    const trimmed = menuValue.trim();
+    if (!VARIABLE_NAME_PATTERN.test(trimmed)) {
+      setMenuError("Enter a variable name, e.g. x1");
+      return;
+    }
     onClausesChange?.((current) => [
       ...current,
       {
         id: nextEditId("clause"),
-        literals: [{ id: nextEditId("literal"), literal: variable, color: "" }],
+        literals: [{ id: nextEditId("literal"), literal: trimmed, color: "" }],
       },
     ]);
-    setNewClauseValue("");
-    addClauseFieldRef.current?.focus();
+    closeMenu();
   }
 
-  return (
-    <Box
-      id={scopeId}
-      role="img"
-      aria-label={summary}
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 1.5,
-        p: 2,
-        minHeight: "100%",
-        boxSizing: "border-box",
-      }}
-    >
-      <Box sx={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 1 }}>
+  if (!editable) {
+    return (
+      <Box
+        id={scopeId}
+        role="img"
+        aria-label={summary}
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 1,
+          p: 2,
+          minHeight: "100%",
+          boxSizing: "border-box",
+        }}
+      >
         {clauseCount === 0 ? (
           <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
             No clauses.
           </Box>
         ) : (
-          clauses.map((clause, clauseIndex) => {
-            const atCap =
-              typeof maxLiteralsPerClause === "number" &&
-              clause.literals.length >= maxLiteralsPerClause;
-            return (
-              <Box
-                key={clause.id}
-                component="span"
-                sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
-              >
-                {clauseIndex > 0 && (
-                  <Box
-                    component="span"
-                    aria-hidden="true"
-                    sx={{ color: "text.secondary", mx: 0.5 }}
-                  >
-                    {DISJUNCTION}
-                  </Box>
-                )}
-                <Box component="span" sx={{ color: "text.secondary" }}>
-                  (
+          clauses.map((clause, clauseIndex) => (
+            <Box
+              key={clause.id}
+              component="span"
+              sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+            >
+              {clauseIndex > 0 && (
+                <Box component="span" aria-hidden="true" sx={{ color: "text.secondary", mx: 0.5 }}>
+                  {DISJUNCTION}
                 </Box>
-                {clause.literals.map((literal, literalIndex) => {
-                  const variable = literalVariable(literal.literal);
-                  return (
-                    <Box
-                      key={literal.id}
-                      component="span"
-                      sx={{ display: "inline-flex", alignItems: "center" }}
-                    >
-                      {literalIndex > 0 && (
-                        <Box
-                          component="span"
-                          aria-hidden="true"
-                          sx={{ color: "text.secondary", mx: 0.5 }}
-                        >
-                          {CONJUNCTION}
-                        </Box>
-                      )}
-                      {editable ? (
-                        <EditableLiteral
-                          idPrefix={scopeId}
-                          clauseIndex={clauseIndex}
-                          literalIndex={literalIndex}
-                          literal={literal}
-                          canRemove={clause.literals.length > 1}
-                          onEdit={onClausesChange}
-                        />
-                      ) : (
-                        <LiteralMark
-                          id={`${scopeId}-literal-${literal.id}`}
-                          literal={literal}
-                          highlighted={hoveredVariable != null && variable === hoveredVariable}
-                          onEnter={() => setHoveredVariable(variable)}
-                          onLeave={() =>
-                            setHoveredVariable((current) => (current === variable ? null : current))
-                          }
-                        />
-                      )}
-                    </Box>
-                  );
-                })}
-                <Box component="span" sx={{ color: "text.secondary" }}>
-                  )
-                </Box>
-                {editable && (
-                  <>
-                    <AddLiteralForm
-                      idPrefix={scopeId}
-                      clauseIndex={clauseIndex}
-                      atCap={atCap}
-                      onEdit={onClausesChange}
-                    />
-                    <EditIconButton
-                      id={`${scopeId}-clause-${clause.id}-remove`}
-                      label={`Remove clause ${clauseIndex + 1}`}
-                      onClick={() =>
-                        onClausesChange?.((current) =>
-                          current.filter((_candidate, index) => index !== clauseIndex),
-                        )
-                      }
-                    >
-                      <CloseIcon sx={{ fontSize: "0.875rem" }} />
-                    </EditIconButton>
-                  </>
-                )}
+              )}
+              <Box component="span" sx={{ color: "text.secondary" }}>
+                (
               </Box>
-            );
-          })
+              {clause.literals.map((literal, literalIndex) => {
+                const variable = literalVariable(literal.literal);
+                return (
+                  <Box
+                    key={literal.id}
+                    component="span"
+                    sx={{ display: "inline-flex", alignItems: "center" }}
+                  >
+                    {literalIndex > 0 && (
+                      <Box
+                        component="span"
+                        aria-hidden="true"
+                        sx={{ color: "text.secondary", mx: 0.5 }}
+                      >
+                        {CONJUNCTION}
+                      </Box>
+                    )}
+                    <LiteralMark
+                      id={`${scopeId}-literal-${literal.id}`}
+                      literal={literal}
+                      highlighted={hoveredVariable != null && variable === hoveredVariable}
+                      onEnter={() => setHoveredVariable(variable)}
+                      onLeave={() =>
+                        setHoveredVariable((current) => (current === variable ? null : current))
+                      }
+                    />
+                  </Box>
+                );
+              })}
+              <Box component="span" sx={{ color: "text.secondary" }}>
+                )
+              </Box>
+            </Box>
+          ))
         )}
       </Box>
+    );
+  }
 
-      {editable && (
-        <Box
-          component="form"
-          onSubmit={handleAddClause}
-          sx={{ display: "flex", alignItems: "center", gap: 0.75 }}
-        >
-          <Box component="label" htmlFor={`${scopeId}-add-clause`} sx={{ display: "none" }}>
-            First variable for the new clause
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        accessibility={{ announcements }}
+      >
+        <SortableContext items={clauses.map((clause) => clause.id)} strategy={rectSortingStrategy}>
+          <Box
+            id={scopeId}
+            role="img"
+            aria-label={summary}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              openMenu({ kind: "createClause", x: event.clientX, y: event.clientY });
+            }}
+            sx={{
+              display: "flex",
+              flexWrap: "wrap",
+              alignItems: "center",
+              gap: 1,
+              p: 2,
+              minHeight: 120,
+              boxSizing: "border-box",
+            }}
+          >
+            {clauseCount === 0 ? (
+              <Box component="span" sx={{ color: "text.secondary", fontStyle: "italic" }}>
+                No clauses. Right-click to add one.
+              </Box>
+            ) : (
+              clauses.map((clause, clauseIndex) => (
+                <Box
+                  key={clause.id}
+                  component="span"
+                  sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}
+                >
+                  {clauseIndex > 0 && (
+                    <Box
+                      component="span"
+                      aria-hidden="true"
+                      sx={{ color: "text.secondary", mx: 0.5 }}
+                    >
+                      {DISJUNCTION}
+                    </Box>
+                  )}
+                  <SortableClause
+                    clause={clause}
+                    clauseIndex={clauseIndex}
+                    hoveredVariable={hoveredVariable}
+                    setHoveredVariable={setHoveredVariable}
+                    openMenu={openMenu}
+                    idPrefix={scopeId}
+                  />
+                </Box>
+              ))
+            )}
           </Box>
+        </SortableContext>
+      </DndContext>
+
+      <Typography variant="body2" sx={{ color: "text.secondary", mt: 0.5 }}>
+        Drag the grip to reorder clauses, or drag a literal to reorder it within its clause.
+        Right-click a literal, a clause, or empty space to add, negate, or remove.
+      </Typography>
+
+      {menu?.kind === "literal" &&
+        (() => {
+          const clause = clauses[menu.clauseIndex];
+          const literal = clause?.literals[menu.literalIndex];
+          if (!literal) return null;
+          const canRemove = clause.literals.length > 1;
+          const negated = isNegated(literal.literal);
+          return (
+            <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+              <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+                {literal.literal}
+              </Typography>
+              <Box sx={{ display: "flex", gap: 1 }}>
+                <Button size="small" variant="outlined" onClick={submitToggleNegate}>
+                  {negated ? "Remove negation" : "Negate"}
+                </Button>
+                <Button
+                  size="small"
+                  color="error"
+                  variant="outlined"
+                  disabled={!canRemove}
+                  onClick={submitRemoveLiteral}
+                >
+                  Remove
+                </Button>
+              </Box>
+            </FloatingMenu>
+          );
+        })()}
+
+      {menu?.kind === "clause" &&
+        (() => {
+          const clause = clauses[menu.clauseIndex];
+          if (!clause) return null;
+          const atCap =
+            typeof maxLiteralsPerClause === "number" &&
+            clause.literals.length >= maxLiteralsPerClause;
+          return (
+            <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+              <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+                Clause {menu.clauseIndex + 1}
+              </Typography>
+              <TextField
+                id={`${scopeId}-add-literal`}
+                size="small"
+                autoFocus
+                label="Add variable"
+                placeholder="x1"
+                value={menuValue}
+                disabled={atCap}
+                onChange={(event) => setMenuValue(event.target.value)}
+                onKeyDown={(event) => event.key === "Enter" && submitAddLiteralToClause()}
+              />
+              {atCap && (
+                <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                  Up to {maxLiteralsPerClause} literals per clause.
+                </Typography>
+              )}
+              {menuError && (
+                <Typography variant="caption" color="error">
+                  {menuError}
+                </Typography>
+              )}
+              <Box sx={{ display: "flex", gap: 1 }}>
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={atCap}
+                  onClick={submitAddLiteralToClause}
+                >
+                  Add literal
+                </Button>
+                <Button size="small" color="error" variant="outlined" onClick={submitRemoveClause}>
+                  Remove clause
+                </Button>
+                <Button size="small" onClick={closeMenu}>
+                  Cancel
+                </Button>
+              </Box>
+            </FloatingMenu>
+          );
+        })()}
+
+      {menu?.kind === "createClause" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            New clause
+          </Typography>
           <TextField
             id={`${scopeId}-add-clause`}
-            inputRef={addClauseFieldRef}
             size="small"
-            variant="outlined"
+            autoFocus
+            label="First variable"
             placeholder="x1"
-            value={newClauseValue}
-            onChange={(event) => setNewClauseValue(event.target.value)}
-            sx={{ width: 88, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
-            inputProps={{ "aria-label": "First variable for the new clause" }}
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitCreateClause()}
           />
-          <Button
-            id={`${scopeId}-add-clause-submit`}
-            type="submit"
-            size="small"
-            variant="outlined"
-            disabled={!isNewClauseValid}
-            startIcon={<AddIcon sx={{ fontSize: "1rem" }} />}
-          >
-            Add clause
-          </Button>
-          {typeof maxLiteralsPerClause === "number" && (
-            <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              Up to {maxLiteralsPerClause} literals per clause.
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
             </Typography>
           )}
-        </Box>
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitCreateClause}>
+              Add clause
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
       )}
     </Box>
   );

--- a/components/detail/visualizations/GraphRenderer.js
+++ b/components/detail/visualizations/GraphRenderer.js
@@ -48,12 +48,12 @@
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Paper from "@mui/material/Paper";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation } from "d3-force";
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+import { FloatingMenu, useCloseFloatingMenu } from "./floatingMenu";
 import {
   computeEdgePath,
   computeSelfLoopPath,
@@ -225,31 +225,8 @@ function GraphNodeMark({ node, highlighted, onEnter, onLeave }) {
   );
 }
 
-// Fixed-position floating popup, positioned at the screen point a right-click or drag-end
-// happened -- SARE_2026's AutomatonCanvas.tsx menu pattern (issue #124). Lives as a sibling
-// of the <svg> in the DOM, not inside it, so a click inside the menu never reaches the
-// canvas's own mousedown/contextmenu handlers.
-function FloatingMenu({ menuRef, x, y, children }) {
-  return (
-    <Paper
-      ref={menuRef}
-      elevation={8}
-      sx={{
-        position: "fixed",
-        left: x + 4,
-        top: y + 4,
-        p: 1.5,
-        zIndex: 20,
-        minWidth: 200,
-        display: "flex",
-        flexDirection: "column",
-        gap: 1,
-      }}
-    >
-      {children}
-    </Paper>
-  );
-}
+// FloatingMenu and its outside-click/Escape handling now live in ./floatingMenu.js -- pulled
+// out once BooleanSatisfiabilityRenderer.js (T55/#128) needed the identical pattern.
 
 /**
  * @param {Object} props
@@ -321,25 +298,7 @@ export default function GraphRenderer({
     setMenuError("");
   }, []);
 
-  // Outside click / Escape closes whatever menu is open -- reads only this component's own
-  // menuRef, not a hardcoded global selector (§4.1).
-  useEffect(() => {
-    if (!menu) return undefined;
-    function handlePointerDown(event) {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        closeMenu();
-      }
-    }
-    function handleKeyDown(event) {
-      if (event.key === "Escape") closeMenu();
-    }
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [menu, closeMenu]);
+  useCloseFloatingMenu(menuRef, menu !== null, closeMenu);
 
   const svgPoint = useCallback((event) => {
     const svg = svgRef.current;
@@ -432,7 +391,9 @@ export default function GraphRenderer({
         const target = displayNodes.find(
           (node) => distanceBetween(x, y, node.x, node.y) <= NODE_RADIUS,
         );
-        if (target && target.id !== drag.sourceId) {
+        // #127: releasing back on the origin node creates a self-loop -- applyGraphOp's
+        // addEdge no longer rejects source === target.
+        if (target) {
           onGraphEdit?.({ type: "addEdge", source: drag.sourceId, target: target.id });
         }
         setRubber(null);

--- a/components/detail/visualizations/QuantumCircuitRenderer.js
+++ b/components/detail/visualizations/QuantumCircuitRenderer.js
@@ -504,17 +504,18 @@ export default function QuantumCircuitRenderer({
       const { gateId, targetIndex } = active.data.current ?? {};
       const { wireId, columnIndex } = over.data.current ?? {};
       if (!gateId || wireId == null || columnIndex == null) return;
-      const nextGates = moveGateToCell(
+      const result = moveGateToCell(
         gates,
+        overlays,
         gateId,
         targetIndex,
         wireId,
         columnIndex,
         sortedTimes,
       );
-      onCircuitEdit?.({ type: "replaceGates", gates: nextGates });
+      onCircuitEdit?.({ type: "replaceGates", gates: result.gates, overlays: result.overlays });
     },
-    [gates, sortedTimes, onCircuitEdit],
+    [gates, overlays, sortedTimes, onCircuitEdit],
   );
 
   function openGateMenu(gate, event) {
@@ -606,8 +607,15 @@ export default function QuantumCircuitRenderer({
       setMenuError("Gate type is required");
       return;
     }
-    const result = addGateAtCell(gates, trimmed, menu.wireId, menu.columnIndex, sortedTimes);
-    onCircuitEdit?.({ type: "replaceGates", gates: result.gates });
+    const result = addGateAtCell(
+      gates,
+      overlays,
+      trimmed,
+      menu.wireId,
+      menu.columnIndex,
+      sortedTimes,
+    );
+    onCircuitEdit?.({ type: "replaceGates", gates: result.gates, overlays: result.overlays });
     closeMenu();
   }
 

--- a/components/detail/visualizations/QuantumCircuitRenderer.js
+++ b/components/detail/visualizations/QuantumCircuitRenderer.js
@@ -20,34 +20,53 @@
 // wires/gates/overlays, not `metadata`'s free-form contents, and T50's own
 // scope is rendering the frame, not a metadata inspector.
 //
-// --- T51 (#114): editing UI ships; the diagram-to-text serializer does not -------------
-// Add/remove qubit and add/remove/relabel gate are wired here, gated behind `editable`,
-// and update the local preview immediately (INTERACTIVE_LAYER_DESIGN.md §2.1.2) exactly
-// like the `graph` and `recursiveSet` editors on this same task. What's deliberately
-// missing is a serializer to send an edit through Run: T46 (#109) verified SPADE
-// round-tripping against Clique and DFA, a set-of-nodes-plus-edges grammar and an
-// automaton grammar -- neither is a gate-sequence grammar, and nothing this project has
-// checked says whether a quantum-circuit instance's text encodes gates by literal type
-// tokens, by position, or some other shape entirely, or whether gate `id` (which this
-// contract's payload appears to synthesize during parsing, unlike a graph node's `id`,
-// which is plausibly the literal grammar token) has any textual counterpart at all.
-// Writing a serializer against an unverified guess risks producing instance text that
-// looks plausible and silently means something else -- worse than leaving the gap
-// visible. VisualizationsSection.js declines to serialize a pending `quantumCircuit`
-// edit and says why, rather than guessing. See data/instanceSerializers.js's own header
-// for the parallel note. This is this task's one explicitly left-open item -- see its
-// handback summary.
+// --- T56 (#129): direct-manipulation editing, replacing T51's side-panel form ---------
+// Editing is now on the diagram itself: drag a gate's box or one of its connector dots
+// onto a grid cell to retime/retarget it (see components/detail/visualizations/
+// quantumCircuitGrid.js for the "reuse an existing time column, or insert one and shift
+// everything after it" math -- decided as a global shift across every wire, not just the
+// one dropped on, on issue #125's thread); right-click a qubit label to rename/remove it,
+// empty grid space to add a gate there, or a gate to relabel/delete it.
+//
+// Built on `@dnd-kit`'s raw `useDraggable`/`useDroppable` (not its sortable preset) --
+// unlike `booleanSatisfiability`'s flat/nested lists (T55), this is a genuine 2D grid where
+// one gate can occupy multiple rows at once (a multi-qubit gate's box and dots), which the
+// sortable preset's "each item belongs to exactly one container" model doesn't fit. Keeps
+// keyboard access anyway: `@dnd-kit/core`'s `KeyboardSensor` works with raw draggable/
+// droppable directly (arrow keys nudge the drag by a fixed step, not "jump to next list
+// item" -- that's the sortable preset's `sortableKeyboardCoordinates`, not used here since
+// there's no sortable list). Full decision record: ai_documentation/
+// INTERACTIVE_LAYER_DESIGN.md §3.2.
+//
+// --- The diagram-to-text serializer still does not exist ------------------------------
+// Unchanged from T51: T46 (#109) verified SPADE round-tripping against a set-of-nodes-plus-
+// edges grammar and an automaton grammar, neither of which is a gate-sequence grammar, and
+// nothing this project has checked says whether a quantum-circuit instance's text encodes
+// gates by literal type tokens, by position, or some other shape entirely. Writing a
+// serializer against an unverified guess risks producing instance text that looks
+// plausible and silently means something else. VisualizationsSection.js declines to
+// serialize a pending `quantumCircuit` edit and says why, rather than guessing.
 
-import AddIcon from "@mui/icons-material/Add";
-import CloseIcon from "@mui/icons-material/Close";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
-import MenuItem from "@mui/material/MenuItem";
-import Select from "@mui/material/Select";
+import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
-import { useId, useMemo, useState } from "react";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { getVisualizationColor } from "../../theme";
+import { FloatingMenu, useCloseFloatingMenu } from "./floatingMenu";
+import { addGateAtCell, moveGateToCell } from "./quantumCircuitGrid";
 
 const GATE_WIDTH = 44;
 const GATE_HEIGHT = 26;
@@ -78,20 +97,40 @@ function buildLayout(d3) {
   });
   const sortedTimes = Array.from(times).sort((a, b) => a - b);
   const columnIndex = new Map(sortedTimes.map((time, index) => [time, index]));
-  const xForTime = (time) => MARGIN.left + (columnIndex.get(time) ?? 0) * COLUMN_SPACING;
+  const xForColumnIndex = (index) => MARGIN.left + index * COLUMN_SPACING;
+  const xForTime = (time) => xForColumnIndex(columnIndex.get(time) ?? 0);
 
   const qubitRowY = new Map(qubits.map((id, index) => [id, MARGIN.top + index * ROW_SPACING]));
   const lastQubitY =
     qubits.length > 0 ? MARGIN.top + (qubits.length - 1) * ROW_SPACING : MARGIN.top;
   const classicalRowY = classical.length > 0 ? lastQubitY + CLASSICAL_GAP : null;
 
-  const maxColumn = Math.max(sortedTimes.length - 1, 0);
-  const width = MARGIN.left + MARGIN.right + Math.max(maxColumn, 1) * COLUMN_SPACING + GATE_WIDTH;
-  const height = (classicalRowY ?? lastQubitY) + MARGIN.bottom;
+  // One extra column's worth of width so the trailing "append a new step" drop zone
+  // (T56/#129) has room past the last real column.
+  const maxColumn = Math.max(sortedTimes.length, 1);
+  const width = MARGIN.left + MARGIN.right + maxColumn * COLUMN_SPACING + GATE_WIDTH;
+  const height = (classicalRowY ?? lastQubitY) + MARGIN.bottom + ROW_SPACING;
 
-  return { qubits, classical, gates, overlays, xForTime, qubitRowY, classicalRowY, width, height };
+  return {
+    qubits,
+    classical,
+    gates,
+    overlays,
+    sortedTimes,
+    xForTime,
+    xForColumnIndex,
+    qubitRowY,
+    lastQubitY,
+    classicalRowY,
+    width,
+    height,
+  };
 }
 
+// Read-only rendering -- unchanged from T50/T51. Only used on the non-editable path;
+// EditableGateMark (below) is the editable path's own version, since it needs to know
+// *which* `gate.targets` array index each handle represents (for drag-to-retarget),
+// something this simpler version was never handed.
 function GateMark({ idPrefix, gate, x, targetYs, classicalY, highlighted, onEnter, onLeave }) {
   if (targetYs.length === 0) return null;
 
@@ -200,197 +239,188 @@ function OverlayBand({ idPrefix, overlay, overlayIndex, x0, x1, yMin, yMax }) {
   );
 }
 
-// `qubits` is `d3.qubits` straight from the contract -- a plain `string[]` (§3.2), not
-// objects, unlike `graph`'s nodes. Rows are keyed by array index rather than value: a
-// qubit's position in the array is stable across a rename (renaming mutates the string at
-// the same index, it doesn't reorder), so indexing avoids the same remount-during-rename
-// problem GraphEditPanel solves with a synthetic `_key` -- without needing one here, since
-// the contract gives this type no per-qubit object to hang one off. `gates` don't need
-// this treatment at all: `gate.id` (§3.2) is independent of `gate.type`, the field being
-// relabeled, so it's already a stable key on its own.
-function QuantumCircuitEditPanel({ idPrefix, qubits, gates, onCircuitEdit }) {
-  const [newQubitId, setNewQubitId] = useState("");
-  const [newGateType, setNewGateType] = useState("");
-  const [newGateTarget, setNewGateTarget] = useState(qubits[0] ?? "");
-  const targetValue = qubits.includes(newGateTarget) ? newGateTarget : (qubits[0] ?? "");
+// One drag handle: a gate's box (its last/highest-sorted target -- the wire it "acts on")
+// or one of its connector dots (an earlier target -- a wire it "depends on"). Each is its
+// own `useDraggable` so the two kinds of handle never fight over the same pointer/keyboard
+// events, and so dropping one only ever changes the one `gate.targets` position it
+// represents (`data.targetIndex`) plus the whole gate's shared `time` (§ file header).
+function DraggableHandle({
+  gateId,
+  targetIndex,
+  cx,
+  cy,
+  isBox,
+  label,
+  highlighted,
+  stroke,
+  onContextMenu,
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `${gateId}::${targetIndex}`,
+    data: { type: "gateHandle", gateId, targetIndex },
+  });
+  const dragStyle = {
+    transform: transform ? CSS.Translate.toString(transform) : undefined,
+    opacity: isDragging ? 0.4 : 1,
+    cursor: "grab",
+  };
 
-  function handleAddQubit(event) {
-    event.preventDefault();
-    const trimmed = newQubitId.trim();
-    if (!trimmed || qubits.includes(trimmed)) return;
-    onCircuitEdit({ type: "addQubit", id: trimmed });
-    setNewQubitId("");
-  }
-
-  function handleAddGate(event) {
-    event.preventDefault();
-    const trimmed = newGateType.trim();
-    if (!trimmed || !targetValue) return;
-    onCircuitEdit({ type: "addGate", gateType: trimmed, target: targetValue });
-    setNewGateType("");
+  if (isBox) {
+    return (
+      <g
+        ref={setNodeRef}
+        style={dragStyle}
+        {...attributes}
+        {...listeners}
+        onContextMenu={onContextMenu}
+      >
+        <rect
+          x={cx - GATE_WIDTH / 2}
+          y={cy - GATE_HEIGHT / 2}
+          width={GATE_WIDTH}
+          height={GATE_HEIGHT}
+          rx={5}
+          ry={5}
+          fill={GATE_FILL}
+          stroke={highlighted ? "#FFFFFF" : stroke}
+          strokeWidth={highlighted ? 2 : 1.5}
+        />
+        <text
+          x={cx}
+          y={cy + 4}
+          textAnchor="middle"
+          fontSize={11}
+          fontWeight={700}
+          fill={LABEL_COLOR}
+          style={{ pointerEvents: "none" }}
+        >
+          {String(label).toUpperCase()}
+        </text>
+      </g>
+    );
   }
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 1,
-        mt: 1,
-        p: 1.5,
-        border: "1px dashed",
-        borderColor: "divider",
-        borderRadius: 1,
-      }}
-    >
-      <Typography variant="overline" sx={{ color: "text.secondary" }}>
-        Edit qubits
-      </Typography>
-      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-        {qubits.map((qubitId, index) => (
-          <Box key={index} sx={{ display: "inline-flex", alignItems: "center", gap: 0.25 }}>
-            <Box component="label" htmlFor={`${idPrefix}-qubit-${index}`} sx={{ display: "none" }}>
-              Rename qubit {qubitId}
-            </Box>
-            <TextField
-              id={`${idPrefix}-qubit-${index}`}
-              size="small"
-              variant="standard"
-              value={qubitId}
-              onChange={(event) =>
-                onCircuitEdit({ type: "renameQubit", from: qubitId, to: event.target.value })
-              }
-              sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
-              inputProps={{ "aria-label": `Rename qubit ${qubitId}` }}
-            />
-            <IconButton
-              id={`${idPrefix}-qubit-${index}-remove`}
-              size="small"
-              aria-label={`Remove qubit ${qubitId}`}
-              onClick={() => onCircuitEdit({ type: "removeQubit", id: qubitId })}
-              sx={{ p: 0.375 }}
-            >
-              <CloseIcon sx={{ fontSize: "0.875rem" }} />
-            </IconButton>
-          </Box>
-        ))}
-      </Box>
-      <Box
-        component="form"
-        onSubmit={handleAddQubit}
-        sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
-      >
-        <Box component="label" htmlFor={`${idPrefix}-add-qubit`} sx={{ display: "none" }}>
-          New qubit id
-        </Box>
-        <TextField
-          id={`${idPrefix}-add-qubit`}
-          size="small"
-          variant="outlined"
-          placeholder="new qubit id"
-          value={newQubitId}
-          onChange={(event) => setNewQubitId(event.target.value)}
-          sx={{ width: 120, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
-          inputProps={{ "aria-label": "New qubit id" }}
-        />
-        <IconButton
-          id={`${idPrefix}-add-qubit-submit`}
-          type="submit"
-          size="small"
-          disabled={!newQubitId.trim() || qubits.includes(newQubitId.trim())}
-          aria-label="Add qubit"
-          sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
-        >
-          <AddIcon sx={{ fontSize: "1rem" }} />
-        </IconButton>
-      </Box>
+    <circle
+      ref={setNodeRef}
+      style={dragStyle}
+      {...attributes}
+      {...listeners}
+      onContextMenu={onContextMenu}
+      cx={cx}
+      cy={cy}
+      r={5}
+      fill={stroke}
+    />
+  );
+}
 
-      <Typography variant="overline" sx={{ color: "text.secondary", mt: 1 }}>
-        Edit gates
-      </Typography>
-      <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-        {gates.length === 0 && (
-          <Typography variant="body2" sx={{ color: "text.secondary", fontStyle: "italic" }}>
-            No gates.
-          </Typography>
-        )}
-        {gates.map((gate) => (
-          <Box key={gate.id} sx={{ display: "inline-flex", alignItems: "center", gap: 0.5 }}>
-            <Box component="label" htmlFor={`${idPrefix}-gate-${gate.id}`} sx={{ display: "none" }}>
-              Relabel gate on {gate.targets?.join(", ")}
-            </Box>
-            <TextField
-              id={`${idPrefix}-gate-${gate.id}`}
-              size="small"
-              variant="standard"
-              value={gate.type ?? ""}
-              onChange={(event) =>
-                onCircuitEdit({ type: "relabelGate", id: gate.id, gateType: event.target.value })
-              }
-              sx={{ width: 56, "& input": { fontSize: "0.8125rem", py: 0.25 } }}
-              inputProps={{ "aria-label": `Relabel gate on ${gate.targets?.join(", ")}` }}
-            />
-            <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              on {gate.targets?.join(", ")}
-            </Typography>
-            <IconButton
-              id={`${idPrefix}-gate-${gate.id}-remove`}
-              size="small"
-              aria-label={`Remove gate on ${gate.targets?.join(", ")}`}
-              onClick={() => onCircuitEdit({ type: "removeGate", id: gate.id })}
-              sx={{ p: 0.375 }}
-            >
-              <CloseIcon sx={{ fontSize: "0.875rem" }} />
-            </IconButton>
-          </Box>
-        ))}
-      </Box>
-      {qubits.length > 0 && (
-        <Box
-          component="form"
-          onSubmit={handleAddGate}
-          sx={{ display: "inline-flex", gap: 0.5, alignItems: "center" }}
-        >
-          <TextField
-            id={`${idPrefix}-add-gate-type`}
-            size="small"
-            variant="outlined"
-            placeholder="gate type"
-            value={newGateType}
-            onChange={(event) => setNewGateType(event.target.value)}
-            sx={{ width: 100, "& input": { fontSize: "0.8125rem", py: 0.5 } }}
-            inputProps={{ "aria-label": "New gate type" }}
-          />
-          <Select
-            id={`${idPrefix}-add-gate-target`}
-            size="small"
-            value={targetValue}
-            onChange={(event) => setNewGateTarget(event.target.value)}
-            inputProps={{ "aria-label": "New gate target qubit" }}
-            sx={{ minWidth: 72 }}
-          >
-            {qubits.map((qubitId) => (
-              <MenuItem key={qubitId} value={qubitId}>
-                {qubitId}
-              </MenuItem>
-            ))}
-          </Select>
-          <IconButton
-            id={`${idPrefix}-add-gate-submit`}
-            type="submit"
-            size="small"
-            disabled={!newGateType.trim()}
-            aria-label="Add gate"
-            sx={{ p: 0.5, border: "1px solid", borderColor: "divider", borderRadius: 1 }}
-          >
-            <AddIcon sx={{ fontSize: "1rem" }} />
-          </IconButton>
-        </Box>
+// Editable path's gate renderer -- unlike the read-only GateMark, this is handed the raw
+// `gate.targets` array (not pre-stripped Y positions) so each handle can carry its own
+// array index for drag-to-retarget.
+function EditableGateMark({
+  gate,
+  x,
+  qubitRowY,
+  classicalY,
+  highlighted,
+  onEnter,
+  onLeave,
+  onGateContextMenu,
+}) {
+  const entries = gate.targets
+    .map((targetId, index) => ({ index, y: qubitRowY.get(targetId) }))
+    .filter((entry) => entry.y != null);
+  if (entries.length === 0) return null;
+
+  const sorted = [...entries].sort((a, b) => a.y - b.y);
+  const boxEntry = sorted[sorted.length - 1];
+  const dotEntries = sorted.slice(0, -1);
+  const label = gate.label ?? gate.type ?? "?";
+  const hasClassicalLink =
+    classicalY != null && Array.isArray(gate.classical) && gate.classical.length > 0;
+  const stroke = highlighted ? GATE_FILL : WIRE_COLOR;
+
+  function handleContextMenu(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    onGateContextMenu(gate, event);
+  }
+
+  return (
+    <g onMouseEnter={onEnter} onMouseLeave={onLeave}>
+      {sorted.length > 1 && (
+        <line
+          x1={x}
+          x2={x}
+          y1={sorted[0].y}
+          y2={boxEntry.y}
+          stroke={stroke}
+          strokeWidth={highlighted ? 2.5 : 1.5}
+          style={{ pointerEvents: "none" }}
+        />
       )}
-      <Typography variant="body2" sx={{ color: "text.secondary" }}>
-        These changes preview here, but can&apos;t be sent to Run yet for this visualization type.
-      </Typography>
-    </Box>
+      {hasClassicalLink && (
+        <g style={{ pointerEvents: "none" }}>
+          <line
+            x1={x}
+            x2={x}
+            y1={boxEntry.y}
+            y2={classicalY}
+            stroke={WIRE_COLOR}
+            strokeWidth={1.5}
+            strokeDasharray="3 2"
+          />
+          <circle cx={x} cy={classicalY} r={4} fill={WIRE_COLOR} />
+        </g>
+      )}
+      {dotEntries.map((entry) => (
+        <DraggableHandle
+          key={entry.index}
+          gateId={gate.id}
+          targetIndex={entry.index}
+          cx={x}
+          cy={entry.y}
+          isBox={false}
+          stroke={stroke}
+          onContextMenu={handleContextMenu}
+        />
+      ))}
+      <DraggableHandle
+        gateId={gate.id}
+        targetIndex={boxEntry.index}
+        cx={x}
+        cy={boxEntry.y}
+        isBox
+        label={label}
+        highlighted={highlighted}
+        stroke={stroke}
+        onContextMenu={handleContextMenu}
+      />
+    </g>
+  );
+}
+
+// One droppable grid cell -- a (wire, column) position a dragged handle can land on.
+// `columnIndex === sortedTimes.length` is the trailing "append a new step" zone past the
+// last existing column.
+function GridCell({ wireId, columnIndex, x, y, onContextMenu }) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `cell::${wireId}::${columnIndex}`,
+    data: { type: "gridCell", wireId, columnIndex },
+  });
+  return (
+    <rect
+      ref={setNodeRef}
+      x={x - COLUMN_SPACING / 2}
+      y={y - ROW_SPACING / 2}
+      width={COLUMN_SPACING}
+      height={ROW_SPACING}
+      fill={isOver ? "rgba(255,255,255,0.08)" : "transparent"}
+      stroke={isOver ? WIRE_COLOR : "none"}
+      strokeDasharray="3 2"
+      onContextMenu={onContextMenu}
+    />
   );
 }
 
@@ -404,15 +434,18 @@ function QuantumCircuitEditPanel({ idPrefix, qubits, gates, onCircuitEdit }) {
  * @param {{d3: Object}} props.frame One already-validated `quantumCircuit`
  *   frame (the `d3` arm -- resolveVisualizationType only reaches this
  *   renderer when `format === 1` and `d3` is present, per §3.2).
- * @param {boolean} [props.editable] T51 (#114): true only when this frame is
+ * @param {boolean} [props.editable] T56 (#129): true only when this frame is
  *   the base frame of a visualization the caller has decided is editable
  *   right now. See this file's header for why edits here preview locally
  *   but are never sent to Run.
  * @param {(op: Object) => void} [props.onCircuitEdit] Called with one edit
  *   descriptor per structural edit -- `{type: "addQubit", id}`,
  *   `{type: "removeQubit", id}`, `{type: "renameQubit", from, to}`,
- *   `{type: "addGate", gateType, target}`, `{type: "removeGate", id}`, or
- *   `{type: "relabelGate", id, gateType}`. Required when `editable` is true.
+ *   `{type: "relabelGate", id, gateType}`, `{type: "removeGate", id}`, or
+ *   `{type: "replaceGates", gates}` (a drag-to-retime/retarget or an "add
+ *   gate at this cell", both computed via
+ *   components/detail/visualizations/quantumCircuitGrid.js). Required when
+ *   `editable` is true.
  */
 export default function QuantumCircuitRenderer({
   idPrefix,
@@ -424,113 +457,490 @@ export default function QuantumCircuitRenderer({
   const reactId = useId().replace(/:/g, "");
   const scopeId = `${idPrefix}-${reactId}`;
   const [hoveredGateId, setHoveredGateId] = useState(null);
+  const [menu, setMenu] = useState(null);
+  const [menuValue, setMenuValue] = useState("");
+  const [menuError, setMenuError] = useState("");
+  const menuRef = useRef(null);
 
   const layout = useMemo(() => buildLayout(frame.d3), [frame]);
-  const { qubits, classical, gates, overlays, xForTime, qubitRowY, classicalRowY, width, height } =
-    layout;
+  const {
+    qubits,
+    classical,
+    gates,
+    overlays,
+    sortedTimes,
+    xForTime,
+    xForColumnIndex,
+    qubitRowY,
+    lastQubitY,
+    classicalRowY,
+    width,
+    height,
+  } = layout;
 
   const summaryBody = `quantum circuit with ${qubits.length} qubit${qubits.length === 1 ? "" : "s"} and ${gates.length} gate${gates.length === 1 ? "" : "s"}`;
   const summary = instanceName ? `${instanceName}: ${summaryBody}` : summaryBody;
 
+  const closeMenu = useCallback(() => {
+    setMenu(null);
+    setMenuValue("");
+    setMenuError("");
+  }, []);
+  useCloseFloatingMenu(menuRef, menu !== null, closeMenu);
+
+  // KeyboardSensor's default coordinate getter (no `coordinateGetter` override) nudges the
+  // drag by a fixed step per arrow key -- the sortable preset's `sortableKeyboardCoordinates`
+  // ("jump to the next list item") doesn't apply here since this isn't a SortableContext.
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(TouchSensor),
+    useSensor(KeyboardSensor),
+  );
+
+  const handleDragEnd = useCallback(
+    (event) => {
+      const { active, over } = event;
+      if (!over) return;
+      const { gateId, targetIndex } = active.data.current ?? {};
+      const { wireId, columnIndex } = over.data.current ?? {};
+      if (!gateId || wireId == null || columnIndex == null) return;
+      const nextGates = moveGateToCell(
+        gates,
+        gateId,
+        targetIndex,
+        wireId,
+        columnIndex,
+        sortedTimes,
+      );
+      onCircuitEdit?.({ type: "replaceGates", gates: nextGates });
+    },
+    [gates, sortedTimes, onCircuitEdit],
+  );
+
+  function openGateMenu(gate, event) {
+    setMenu({ kind: "gate", gateId: gate.id, x: event.clientX, y: event.clientY });
+    setMenuValue(gate.type ?? "");
+    setMenuError("");
+  }
+
+  function openCellMenu(wireId, columnIndex, event) {
+    event.preventDefault();
+    setMenu({ kind: "cell", wireId, columnIndex, x: event.clientX, y: event.clientY });
+    setMenuValue("");
+    setMenuError("");
+  }
+
+  function openQubitMenu(wireId, event) {
+    event.preventDefault();
+    setMenu({ kind: "qubit", wireId, x: event.clientX, y: event.clientY });
+    setMenuValue(wireId);
+    setMenuError("");
+  }
+
+  function openAddQubitMenu(event) {
+    event.preventDefault();
+    setMenu({ kind: "addQubit", x: event.clientX, y: event.clientY });
+    setMenuValue("");
+    setMenuError("");
+  }
+
+  function submitRenameQubit() {
+    if (menu?.kind !== "qubit") return;
+    const trimmed = menuValue.trim();
+    if (!trimmed) {
+      setMenuError("Name is required");
+      return;
+    }
+    if (trimmed !== menu.wireId && qubits.includes(trimmed)) {
+      setMenuError("Name already used");
+      return;
+    }
+    if (trimmed !== menu.wireId) {
+      onCircuitEdit?.({ type: "renameQubit", from: menu.wireId, to: trimmed });
+    }
+    closeMenu();
+  }
+
+  function submitRemoveQubit() {
+    if (menu?.kind !== "qubit") return;
+    onCircuitEdit?.({ type: "removeQubit", id: menu.wireId });
+    closeMenu();
+  }
+
+  function submitAddQubit() {
+    if (menu?.kind !== "addQubit") return;
+    const trimmed = menuValue.trim();
+    if (!trimmed) {
+      setMenuError("Name is required");
+      return;
+    }
+    if (qubits.includes(trimmed)) {
+      setMenuError("Name already used");
+      return;
+    }
+    onCircuitEdit?.({ type: "addQubit", id: trimmed });
+    closeMenu();
+  }
+
+  function submitRelabelGate() {
+    if (menu?.kind !== "gate") return;
+    const trimmed = menuValue.trim();
+    if (!trimmed) {
+      setMenuError("Gate type is required");
+      return;
+    }
+    onCircuitEdit?.({ type: "relabelGate", id: menu.gateId, gateType: trimmed });
+    closeMenu();
+  }
+
+  function submitRemoveGate() {
+    if (menu?.kind !== "gate") return;
+    onCircuitEdit?.({ type: "removeGate", id: menu.gateId });
+    closeMenu();
+  }
+
+  function submitAddGate() {
+    if (menu?.kind !== "cell") return;
+    const trimmed = menuValue.trim();
+    if (!trimmed) {
+      setMenuError("Gate type is required");
+      return;
+    }
+    const result = addGateAtCell(gates, trimmed, menu.wireId, menu.columnIndex, sortedTimes);
+    onCircuitEdit?.({ type: "replaceGates", gates: result.gates });
+    closeMenu();
+  }
+
+  const svgCommon = (
+    <>
+      <title>{summary}</title>
+
+      {classicalRowY != null && (
+        <g>
+          <text
+            x={MARGIN.left - 10}
+            y={classicalRowY - 8}
+            textAnchor="end"
+            fontSize={11}
+            fill={WIRE_COLOR}
+          >
+            {classical.length === 1 ? classical[0] : `c (${classical.length})`}
+          </text>
+          <line
+            x1={MARGIN.left}
+            x2={width - MARGIN.right}
+            y1={classicalRowY}
+            y2={classicalRowY}
+            stroke={WIRE_COLOR}
+            strokeWidth={2}
+          />
+        </g>
+      )}
+
+      {overlays.map((overlay, overlayIndex) => {
+        const targetYs = (overlay.targets ?? [])
+          .map((targetId) => qubitRowY.get(targetId))
+          .filter((y) => y != null);
+        if (targetYs.length === 0) return null;
+        const x0 = xForTime(overlay.timeStart) - COLUMN_SPACING / 2 + GATE_WIDTH / 2;
+        const x1 = xForTime(overlay.timeEnd) + COLUMN_SPACING / 2 - GATE_WIDTH / 2;
+        return (
+          <OverlayBand
+            key={overlay.id || overlayIndex}
+            idPrefix={scopeId}
+            overlay={overlay}
+            overlayIndex={overlayIndex}
+            x0={x0}
+            x1={x1}
+            yMin={Math.min(...targetYs)}
+            yMax={Math.max(...targetYs)}
+          />
+        );
+      })}
+    </>
+  );
+
+  if (!editable) {
+    return (
+      <Box sx={{ width: "100%", height: "100%", overflow: "auto" }}>
+        <svg
+          id={scopeId}
+          role="img"
+          aria-label={summary}
+          viewBox={`0 0 ${width} ${height}`}
+          width={width}
+          height={height}
+          style={{ display: "block" }}
+        >
+          {svgCommon}
+          {qubits.map((qubitId) => {
+            const y = qubitRowY.get(qubitId);
+            return (
+              <g key={qubitId}>
+                <text
+                  x={MARGIN.left - 10}
+                  y={y + 4}
+                  textAnchor="end"
+                  fontSize={11}
+                  fill={WIRE_COLOR}
+                >
+                  {qubitId}
+                </text>
+                <line
+                  x1={MARGIN.left}
+                  x2={width - MARGIN.right}
+                  y1={y}
+                  y2={y}
+                  stroke={WIRE_COLOR}
+                />
+              </g>
+            );
+          })}
+          {gates.map((gate) => {
+            const x = xForTime(gate.time);
+            const targetYs = (gate.targets ?? [])
+              .map((targetId) => qubitRowY.get(targetId))
+              .filter((y) => y != null);
+            return (
+              <GateMark
+                key={gate.id}
+                idPrefix={scopeId}
+                gate={gate}
+                x={x}
+                targetYs={targetYs}
+                classicalY={classicalRowY}
+                highlighted={hoveredGateId === gate.id}
+                onEnter={() => setHoveredGateId(gate.id)}
+                onLeave={() =>
+                  setHoveredGateId((current) => (current === gate.id ? null : current))
+                }
+              />
+            );
+          })}
+        </svg>
+      </Box>
+    );
+  }
+
+  const addQubitZoneTop = (classicalRowY ?? lastQubitY) + ROW_SPACING / 2;
+
   return (
-    <Box sx={{ width: "100%", height: editable ? "auto" : "100%", overflow: "auto" }}>
-      <svg
-        id={scopeId}
-        role="img"
-        aria-label={summary}
-        viewBox={`0 0 ${width} ${height}`}
-        width={width}
-        height={height}
-        style={{ display: "block" }}
-      >
-        <title>{summary}</title>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <Box sx={{ width: "100%", overflow: "auto" }}>
+          <svg
+            id={scopeId}
+            role="img"
+            aria-label={summary}
+            viewBox={`0 0 ${width} ${height}`}
+            width={width}
+            height={height}
+            style={{ display: "block" }}
+          >
+            {svgCommon}
 
-        {qubits.map((qubitId) => {
-          const y = qubitRowY.get(qubitId);
-          return (
-            <g key={qubitId}>
-              <text x={MARGIN.left - 10} y={y + 4} textAnchor="end" fontSize={11} fill={WIRE_COLOR}>
-                {qubitId}
-              </text>
-              <line x1={MARGIN.left} x2={width - MARGIN.right} y1={y} y2={y} stroke={WIRE_COLOR} />
-            </g>
-          );
-        })}
+            {/* Grid cells first, so gates painted afterward sit on top and win hit-testing */}
+            {qubits.map((qubitId) => {
+              const y = qubitRowY.get(qubitId);
+              return Array.from({ length: sortedTimes.length + 1 }, (_, columnIndex) => (
+                <GridCell
+                  key={`${qubitId}-${columnIndex}`}
+                  wireId={qubitId}
+                  columnIndex={columnIndex}
+                  x={xForColumnIndex(columnIndex)}
+                  y={y}
+                  onContextMenu={(event) => openCellMenu(qubitId, columnIndex, event)}
+                />
+              ));
+            })}
 
-        {classicalRowY != null && (
-          <g>
-            <text
-              x={MARGIN.left - 10}
-              y={classicalRowY - 8}
-              textAnchor="end"
-              fontSize={11}
-              fill={WIRE_COLOR}
-            >
-              {classical.length === 1 ? classical[0] : `c (${classical.length})`}
-            </text>
-            <line
-              x1={MARGIN.left}
-              x2={width - MARGIN.right}
-              y1={classicalRowY}
-              y2={classicalRowY}
-              stroke={WIRE_COLOR}
-              strokeWidth={2}
+            {qubits.map((qubitId) => {
+              const y = qubitRowY.get(qubitId);
+              return (
+                <g key={qubitId}>
+                  <text
+                    x={MARGIN.left - 10}
+                    y={y + 4}
+                    textAnchor="end"
+                    fontSize={11}
+                    fill={WIRE_COLOR}
+                    style={{ cursor: "context-menu" }}
+                    onContextMenu={(event) => openQubitMenu(qubitId, event)}
+                  >
+                    {qubitId}
+                  </text>
+                  <line
+                    x1={MARGIN.left}
+                    x2={width - MARGIN.right}
+                    y1={y}
+                    y2={y}
+                    stroke={WIRE_COLOR}
+                  />
+                </g>
+              );
+            })}
+
+            <rect
+              x={0}
+              y={addQubitZoneTop}
+              width={width}
+              height={Math.max(height - addQubitZoneTop, 1)}
+              fill="transparent"
+              onContextMenu={openAddQubitMenu}
             />
-          </g>
-        )}
 
-        {overlays.map((overlay, overlayIndex) => {
-          const targetYs = (overlay.targets ?? [])
-            .map((targetId) => qubitRowY.get(targetId))
-            .filter((y) => y != null);
-          if (targetYs.length === 0) return null;
-          const x0 = xForTime(overlay.timeStart) - COLUMN_SPACING / 2 + GATE_WIDTH / 2;
-          const x1 = xForTime(overlay.timeEnd) + COLUMN_SPACING / 2 - GATE_WIDTH / 2;
-          // §3.2 only requires `id` be a string -- live data sends "" on every
-          // overlay of at least one instance (Bernstein-Vazirani), so the
-          // index is the fallback that keeps both the React key and the DOM
-          // id (§4.1) unique when `id` alone can't.
-          return (
-            <OverlayBand
-              key={overlay.id || overlayIndex}
-              idPrefix={scopeId}
-              overlay={overlay}
-              overlayIndex={overlayIndex}
-              x0={x0}
-              x1={x1}
-              yMin={Math.min(...targetYs)}
-              yMax={Math.max(...targetYs)}
-            />
-          );
-        })}
+            {gates.map((gate) => (
+              <EditableGateMark
+                key={gate.id}
+                gate={gate}
+                x={xForTime(gate.time)}
+                qubitRowY={qubitRowY}
+                classicalY={classicalRowY}
+                highlighted={hoveredGateId === gate.id}
+                onEnter={() => setHoveredGateId(gate.id)}
+                onLeave={() =>
+                  setHoveredGateId((current) => (current === gate.id ? null : current))
+                }
+                onGateContextMenu={openGateMenu}
+              />
+            ))}
+          </svg>
+        </Box>
+      </DndContext>
 
-        {gates.map((gate) => {
-          const x = xForTime(gate.time);
-          const targetYs = (gate.targets ?? [])
-            .map((targetId) => qubitRowY.get(targetId))
-            .filter((y) => y != null);
-          return (
-            <GateMark
-              key={gate.id}
-              idPrefix={scopeId}
-              gate={gate}
-              x={x}
-              targetYs={targetYs}
-              classicalY={classicalRowY}
-              highlighted={hoveredGateId === gate.id}
-              onEnter={() => setHoveredGateId(gate.id)}
-              onLeave={() => setHoveredGateId((current) => (current === gate.id ? null : current))}
-            />
-          );
-        })}
-      </svg>
-      {editable && (
-        <QuantumCircuitEditPanel
-          idPrefix={scopeId}
-          qubits={frame.d3.qubits}
-          gates={frame.d3.gates}
-          onCircuitEdit={onCircuitEdit}
-        />
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        Drag a gate&apos;s box or a connector dot onto a grid cell to retime or retarget it.
+        Right-click a qubit label, empty grid space, or a gate to add, rename, relabel, or remove.
+      </Typography>
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        These changes preview here, but can&apos;t be sent to Run yet for this visualization type.
+      </Typography>
+
+      {menu?.kind === "qubit" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            Qubit {menu.wireId}
+          </Typography>
+          <TextField
+            id={`${scopeId}-rename-qubit`}
+            size="small"
+            autoFocus
+            label="Name"
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitRenameQubit()}
+          />
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitRenameQubit}>
+              Save
+            </Button>
+            <Button size="small" color="error" variant="outlined" onClick={submitRemoveQubit}>
+              Remove
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
+      )}
+
+      {menu?.kind === "addQubit" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            New qubit
+          </Typography>
+          <TextField
+            id={`${scopeId}-add-qubit`}
+            size="small"
+            autoFocus
+            label="Name"
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitAddQubit()}
+          />
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitAddQubit}>
+              Add
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
+      )}
+
+      {menu?.kind === "gate" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            Edit gate
+          </Typography>
+          <TextField
+            id={`${scopeId}-relabel-gate`}
+            size="small"
+            autoFocus
+            label="Gate type"
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitRelabelGate()}
+          />
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitRelabelGate}>
+              Save
+            </Button>
+            <Button size="small" color="error" variant="outlined" onClick={submitRemoveGate}>
+              Remove
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
+      )}
+
+      {menu?.kind === "cell" && (
+        <FloatingMenu menuRef={menuRef} x={menu.x} y={menu.y}>
+          <Typography variant="caption" sx={{ fontWeight: 700, color: "text.primary" }}>
+            New gate on {menu.wireId}
+          </Typography>
+          <TextField
+            id={`${scopeId}-add-gate`}
+            size="small"
+            autoFocus
+            label="Gate type"
+            placeholder="h"
+            value={menuValue}
+            onChange={(event) => setMenuValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && submitAddGate()}
+          />
+          {menuError && (
+            <Typography variant="caption" color="error">
+              {menuError}
+            </Typography>
+          )}
+          <Box sx={{ display: "flex", gap: 1 }}>
+            <Button size="small" variant="contained" onClick={submitAddGate}>
+              Add
+            </Button>
+            <Button size="small" onClick={closeMenu}>
+              Cancel
+            </Button>
+          </Box>
+        </FloatingMenu>
       )}
     </Box>
   );

--- a/components/detail/visualizations/floatingMenu.js
+++ b/components/detail/visualizations/floatingMenu.js
@@ -1,0 +1,65 @@
+// components/detail/visualizations/floatingMenu.js
+//
+// Shared floating context-menu chrome for the diagram editors that use right-click menus
+// positioned at the click point (GraphRenderer.js/T54, BooleanSatisfiabilityRenderer.js/T55)
+// -- extracted once a second renderer needed the identical pattern, rather than duplicated a
+// second time. A menu is a DOM sibling of whatever it floats over (never inside an SVG or a
+// dnd-kit draggable subtree), positioned with `position: fixed` at the screen point a
+// right-click happened, so a click inside the menu never reaches the canvas's own
+// pointerdown/contextmenu handlers underneath it.
+
+import Paper from "@mui/material/Paper";
+import { useEffect } from "react";
+
+/**
+ * Closes `onClose` on an outside click or Escape, while a menu is open. Reads only the given
+ * ref, not a hardcoded global selector (§4.1).
+ *
+ * @param {React.RefObject} menuRef
+ * @param {boolean} isOpen
+ * @param {() => void} onClose
+ */
+export function useCloseFloatingMenu(menuRef, isOpen, onClose) {
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    function handlePointerDown(event) {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        onClose();
+      }
+    }
+    function handleKeyDown(event) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+    // menuRef is a ref object -- stable across renders, but it arrives as a parameter here
+    // (not a `useRef()` call in this function body), so eslint's exhaustive-deps special
+    // case for refs doesn't apply and it's listed explicitly instead.
+  }, [isOpen, onClose, menuRef]);
+}
+
+export function FloatingMenu({ menuRef, x, y, children }) {
+  return (
+    <Paper
+      ref={menuRef}
+      elevation={8}
+      sx={{
+        position: "fixed",
+        left: x + 4,
+        top: y + 4,
+        p: 1.5,
+        zIndex: 20,
+        minWidth: 200,
+        display: "flex",
+        flexDirection: "column",
+        gap: 1,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}

--- a/components/detail/visualizations/quantumCircuitGrid.js
+++ b/components/detail/visualizations/quantumCircuitGrid.js
@@ -1,0 +1,127 @@
+// components/detail/visualizations/quantumCircuitGrid.js
+//
+// T56 (#129) -- pure grid math for QuantumCircuitRenderer.js's drag-to-retime/retarget
+// editor. A gate's `time` field is really a position along one timeline shared by every
+// wire (QuantumCircuitRenderer.js's `buildLayout` already compresses distinct time values
+// into consecutive display columns) -- so moving a gate is either "reuse an existing
+// column" (when the wire being dropped on has nothing else there) or "insert a new column
+// at this position and renumber", never a raw numeric time write.
+//
+// Every function here takes `sortedTimes` as a parameter rather than recomputing it from
+// `gates` alone -- `buildLayout` folds overlay boundary times into its own sorted-times
+// list too (an overlay band can mark a time no gate occupies), so column *positions* on
+// screen are `buildLayout`'s to define. Recomputing a gates-only version here would drift
+// out of sync with what's actually rendered at each column index; taking the same
+// `sortedTimes` the renderer already built keeps the drop target a user clicks on and the
+// column index this module resolves it to identical by construction.
+//
+// Known accepted gap: an overlay's own `timeStart`/`timeEnd` are not remapped when a move
+// inserts a new column and shifts later gates -- overlays are read-only/decorative
+// (VISUALIZATION_TYPE_CONTRACTS.md §3.2 covers gates/wires, not overlay authoring), so a
+// band can visually drift relative to the gates it used to bracket after an edit. Not
+// solved here; recorded rather than silently risked, the same discipline
+// data/instanceSerializers.js's own header uses for its own open gaps.
+//
+// No React/DOM dependency -- plain functions over a `gates` array, mirroring
+// graphGeometry.js's role for GraphRenderer.js.
+
+import { nextEditId } from "../../../data/frameEditOps";
+
+// Does some OTHER gate already occupy `wireId` at `time`? A wire can only run one
+// operation at once; different wires sharing a time value (parallel gates) is normal and
+// not a collision.
+function hasCollision(gates, excludeGateId, wireId, time) {
+  return gates.some(
+    (gate) => gate.id !== excludeGateId && gate.time === time && gate.targets.includes(wireId),
+  );
+}
+
+// The old-time -> new-time remap for inserting one new column at `columnIndex` into
+// `sortedTimes` -- every column at or after the insertion point shifts one ordinal
+// position later. Operates on sort position, not raw numeric gaps, so it's correct
+// whether or not `sortedTimes` happens to already be consecutive integers.
+function insertColumnRemap(sortedTimes, columnIndex) {
+  const remap = new Map();
+  sortedTimes.forEach((oldTime, index) => {
+    remap.set(oldTime, index < columnIndex ? index : index + 1);
+  });
+  return remap;
+}
+
+/**
+ * Moves one target of an existing gate to `wireId` at `columnIndex` on the shared
+ * timeline. `columnIndex === sortedTimes.length` means "after every existing column".
+ * Returns a new `gates` array; every other gate's `time` is renumbered alongside the moved
+ * gate's if a new column had to be spliced in (the "push existing gates aside" behavior
+ * decided on issue #125's thread -- a global shift across every wire, not just the one
+ * being dropped on).
+ *
+ * @param {Array} gates
+ * @param {string} gateId
+ * @param {number} targetIndex Which position in `gate.targets` this drag is moving -- the
+ *   box (the gate's last/lowest-drawn target) or one of the connector dots (any earlier
+ *   target).
+ * @param {string} wireId The wire (qubit id) dropped on.
+ * @param {number} columnIndex
+ * @param {number[]} sortedTimes From `buildLayout` -- see file header for why this must be
+ *   the same array the renderer used to position the drop target, not recomputed here.
+ */
+export function moveGateToCell(gates, gateId, targetIndex, wireId, columnIndex, sortedTimes) {
+  const movingGate = gates.find((gate) => gate.id === gateId);
+  if (!movingGate) return gates;
+
+  const clampedColumn = Math.max(0, Math.min(columnIndex, sortedTimes.length));
+  const landsOnExistingColumn = clampedColumn < sortedTimes.length;
+  const candidateTime = landsOnExistingColumn ? sortedTimes[clampedColumn] : null;
+
+  if (landsOnExistingColumn && !hasCollision(gates, gateId, wireId, candidateTime)) {
+    return gates.map((gate) => {
+      if (gate.id !== gateId) return gate;
+      const nextTargets = [...gate.targets];
+      nextTargets[targetIndex] = wireId;
+      return { ...gate, targets: nextTargets, time: candidateTime };
+    });
+  }
+
+  const remap = insertColumnRemap(sortedTimes, clampedColumn);
+  return gates.map((gate) => {
+    if (gate.id === gateId) {
+      const nextTargets = [...gate.targets];
+      nextTargets[targetIndex] = wireId;
+      return { ...gate, targets: nextTargets, time: clampedColumn };
+    }
+    return { ...gate, time: remap.get(gate.time) ?? gate.time };
+  });
+}
+
+/**
+ * Adds a brand-new single-target gate on `wireId` at `columnIndex`, using the same
+ * reuse-or-insert rule as `moveGateToCell`.
+ *
+ * @returns {{gates: Array, newGateId: string}}
+ */
+export function addGateAtCell(gates, gateType, wireId, columnIndex, sortedTimes) {
+  const clampedColumn = Math.max(0, Math.min(columnIndex, sortedTimes.length));
+  const landsOnExistingColumn = clampedColumn < sortedTimes.length;
+  const candidateTime = landsOnExistingColumn ? sortedTimes[clampedColumn] : null;
+  const newGateId = nextEditId("gate");
+  const newGate = {
+    id: newGateId,
+    type: gateType,
+    targets: [wireId],
+    classical: null,
+    params: null,
+    label: null,
+    time: 0,
+  };
+
+  if (landsOnExistingColumn && !hasCollision(gates, null, wireId, candidateTime)) {
+    newGate.time = candidateTime;
+    return { gates: [...gates, newGate], newGateId };
+  }
+
+  const remap = insertColumnRemap(sortedTimes, clampedColumn);
+  const shifted = gates.map((gate) => ({ ...gate, time: remap.get(gate.time) ?? gate.time }));
+  newGate.time = clampedColumn;
+  return { gates: [...shifted, newGate], newGateId };
+}

--- a/components/detail/visualizations/quantumCircuitGrid.js
+++ b/components/detail/visualizations/quantumCircuitGrid.js
@@ -15,14 +15,13 @@
 // `sortedTimes` the renderer already built keeps the drop target a user clicks on and the
 // column index this module resolves it to identical by construction.
 //
-// Known accepted gap: an overlay's own `timeStart`/`timeEnd` are not remapped when a move
-// inserts a new column and shifts later gates -- overlays are read-only/decorative
-// (VISUALIZATION_TYPE_CONTRACTS.md §3.2 covers gates/wires, not overlay authoring), so a
-// band can visually drift relative to the gates it used to bracket after an edit. Not
-// solved here; recorded rather than silently risked, the same discipline
-// data/instanceSerializers.js's own header uses for its own open gaps.
+// Overlays are remapped alongside gates, not left to drift: `buildLayout` already folds
+// overlay boundary times into `sortedTimes` (see above), so `insertColumnRemap`'s map
+// already has a correct entry for every overlay's `timeStart`/`timeEnd`, not just for gate
+// times -- reusing it for overlays too is what closes the gap rather than leaving a
+// decorative band pointing at a column that no longer means what it used to.
 //
-// No React/DOM dependency -- plain functions over a `gates` array, mirroring
+// No React/DOM dependency -- plain functions over `gates`/`overlays` arrays, mirroring
 // graphGeometry.js's role for GraphRenderer.js.
 
 import { nextEditId } from "../../../data/frameEditOps";
@@ -39,7 +38,9 @@ function hasCollision(gates, excludeGateId, wireId, time) {
 // The old-time -> new-time remap for inserting one new column at `columnIndex` into
 // `sortedTimes` -- every column at or after the insertion point shifts one ordinal
 // position later. Operates on sort position, not raw numeric gaps, so it's correct
-// whether or not `sortedTimes` happens to already be consecutive integers.
+// whether or not `sortedTimes` happens to already be consecutive integers. Used for both
+// gates' `time` and overlays' `timeStart`/`timeEnd` -- `sortedTimes` already folds overlay
+// boundaries in (see file header), so one remap covers both.
 function insertColumnRemap(sortedTimes, columnIndex) {
   const remap = new Map();
   sortedTimes.forEach((oldTime, index) => {
@@ -48,15 +49,24 @@ function insertColumnRemap(sortedTimes, columnIndex) {
   return remap;
 }
 
+function remapOverlays(overlays, remap) {
+  return overlays.map((overlay) => ({
+    ...overlay,
+    timeStart: remap.get(overlay.timeStart) ?? overlay.timeStart,
+    timeEnd: remap.get(overlay.timeEnd) ?? overlay.timeEnd,
+  }));
+}
+
 /**
  * Moves one target of an existing gate to `wireId` at `columnIndex` on the shared
  * timeline. `columnIndex === sortedTimes.length` means "after every existing column".
- * Returns a new `gates` array; every other gate's `time` is renumbered alongside the moved
- * gate's if a new column had to be spliced in (the "push existing gates aside" behavior
- * decided on issue #125's thread -- a global shift across every wire, not just the one
- * being dropped on).
+ * Every other gate's `time`, and every overlay's `timeStart`/`timeEnd`, is renumbered
+ * alongside the moved gate's if a new column had to be spliced in (the "push existing
+ * gates aside" behavior decided on issue #125's thread -- a global shift across every
+ * wire, not just the one being dropped on).
  *
  * @param {Array} gates
+ * @param {Array} overlays
  * @param {string} gateId
  * @param {number} targetIndex Which position in `gate.targets` this drag is moving -- the
  *   box (the gate's last/lowest-drawn target) or one of the connector dots (any earlier
@@ -65,26 +75,36 @@ function insertColumnRemap(sortedTimes, columnIndex) {
  * @param {number} columnIndex
  * @param {number[]} sortedTimes From `buildLayout` -- see file header for why this must be
  *   the same array the renderer used to position the drop target, not recomputed here.
+ * @returns {{gates: Array, overlays: Array}}
  */
-export function moveGateToCell(gates, gateId, targetIndex, wireId, columnIndex, sortedTimes) {
+export function moveGateToCell(
+  gates,
+  overlays,
+  gateId,
+  targetIndex,
+  wireId,
+  columnIndex,
+  sortedTimes,
+) {
   const movingGate = gates.find((gate) => gate.id === gateId);
-  if (!movingGate) return gates;
+  if (!movingGate) return { gates, overlays };
 
   const clampedColumn = Math.max(0, Math.min(columnIndex, sortedTimes.length));
   const landsOnExistingColumn = clampedColumn < sortedTimes.length;
   const candidateTime = landsOnExistingColumn ? sortedTimes[clampedColumn] : null;
 
   if (landsOnExistingColumn && !hasCollision(gates, gateId, wireId, candidateTime)) {
-    return gates.map((gate) => {
+    const nextGates = gates.map((gate) => {
       if (gate.id !== gateId) return gate;
       const nextTargets = [...gate.targets];
       nextTargets[targetIndex] = wireId;
       return { ...gate, targets: nextTargets, time: candidateTime };
     });
+    return { gates: nextGates, overlays };
   }
 
   const remap = insertColumnRemap(sortedTimes, clampedColumn);
-  return gates.map((gate) => {
+  const nextGates = gates.map((gate) => {
     if (gate.id === gateId) {
       const nextTargets = [...gate.targets];
       nextTargets[targetIndex] = wireId;
@@ -92,15 +112,16 @@ export function moveGateToCell(gates, gateId, targetIndex, wireId, columnIndex, 
     }
     return { ...gate, time: remap.get(gate.time) ?? gate.time };
   });
+  return { gates: nextGates, overlays: remapOverlays(overlays, remap) };
 }
 
 /**
  * Adds a brand-new single-target gate on `wireId` at `columnIndex`, using the same
  * reuse-or-insert rule as `moveGateToCell`.
  *
- * @returns {{gates: Array, newGateId: string}}
+ * @returns {{gates: Array, overlays: Array, newGateId: string}}
  */
-export function addGateAtCell(gates, gateType, wireId, columnIndex, sortedTimes) {
+export function addGateAtCell(gates, overlays, gateType, wireId, columnIndex, sortedTimes) {
   const clampedColumn = Math.max(0, Math.min(columnIndex, sortedTimes.length));
   const landsOnExistingColumn = clampedColumn < sortedTimes.length;
   const candidateTime = landsOnExistingColumn ? sortedTimes[clampedColumn] : null;
@@ -117,11 +138,11 @@ export function addGateAtCell(gates, gateType, wireId, columnIndex, sortedTimes)
 
   if (landsOnExistingColumn && !hasCollision(gates, null, wireId, candidateTime)) {
     newGate.time = candidateTime;
-    return { gates: [...gates, newGate], newGateId };
+    return { gates: [...gates, newGate], overlays, newGateId };
   }
 
   const remap = insertColumnRemap(sortedTimes, clampedColumn);
   const shifted = gates.map((gate) => ({ ...gate, time: remap.get(gate.time) ?? gate.time }));
   newGate.time = clampedColumn;
-  return { gates: [...shifted, newGate], newGateId };
+  return { gates: [...shifted, newGate], overlays: remapOverlays(overlays, remap), newGateId };
 }

--- a/data/frameEditOps.js
+++ b/data/frameEditOps.js
@@ -80,7 +80,9 @@ export function applyGraphOp(current, op) {
       };
     }
     case "addEdge": {
-      if (op.source === op.target) return current;
+      // #127: self-loops (op.source === op.target) are allowed -- DFA/NFA instances need
+      // them routinely (a state transitioning to itself), and they already render fine
+      // (graphGeometry.js's computeSelfLoopPath) when present in loaded instance data.
       const alreadyExists = current.links.some(
         (link) =>
           (link.source === op.source && link.target === op.target) ||

--- a/data/frameEditOps.js
+++ b/data/frameEditOps.js
@@ -181,12 +181,14 @@ export function applyCircuitOp(current, op) {
       };
     // T56 (#129): drag-to-retime/retarget and right-click "add gate at this cell" both
     // touch more than one gate at once (a retime can shift every later gate's `time`
-    // forward -- see components/detail/visualizations/quantumCircuitGrid.js), so the
-    // renderer computes the whole next `gates` array itself and hands it over wholesale
-    // rather than this function trying to re-derive collision/shift logic from a
-    // single-gate op descriptor.
+    // forward, and remaps overlay timeStart/timeEnd alongside it -- see
+    // components/detail/visualizations/quantumCircuitGrid.js), so the renderer computes
+    // the whole next `gates`/`overlays` pair itself and hands it over wholesale rather
+    // than this function trying to re-derive collision/shift logic from a single-gate op
+    // descriptor. `overlays` is optional -- the "reuse an existing free column" path
+    // never touches overlay times, so callers on that path can omit it.
     case "replaceGates":
-      return { ...current, gates: op.gates };
+      return { ...current, gates: op.gates, overlays: op.overlays ?? current.overlays };
     default:
       return current;
   }

--- a/data/frameEditOps.js
+++ b/data/frameEditOps.js
@@ -179,6 +179,14 @@ export function applyCircuitOp(current, op) {
           gate.id === op.id ? { ...gate, type: op.gateType } : gate,
         ),
       };
+    // T56 (#129): drag-to-retime/retarget and right-click "add gate at this cell" both
+    // touch more than one gate at once (a retime can shift every later gate's `time`
+    // forward -- see components/detail/visualizations/quantumCircuitGrid.js), so the
+    // renderer computes the whole next `gates` array itself and hands it over wholesale
+    // rather than this function trying to re-derive collision/shift logic from a
+    // single-gate op descriptor.
+    case "replaceGates":
+      return { ...current, gates: op.gates };
     default:
       return current;
   }


### PR DESCRIPTION
Issue: T56 (#129): Rework quantumCircuit editing: drag-to-retime/retarget on the grid, via dnd-kit
Branch: task/T56-quantum-dnd-editor (branched from task/T55-sat-dnd-editor, not main — it reuses floatingMenu.js, which only exists on that branch. Merge #130 (T55) before or alongside this one — until then this branch's diff includes T55's changes too.)

Changed:
components/detail/visualizations/QuantumCircuitRenderer.js   (rewritten)
components/detail/visualizations/quantumCircuitGrid.js       (new, pure grid math)
data/frameEditOps.js                                         (added "replaceGates" op)

Done when, met:
- Dragging a gate's box or a connector dot onto a grid cell retimes/retargets it — reuses the cell's existing time value if the target wire is free there, otherwise inserts a new column at that position and shifts every gate at or after it forward by one, across every wire (the global-shift behavior confirmed on #125's thread)
- Right-click a qubit label → rename/remove; right-click empty grid space → add a gate at that specific wire+column (not always appended at the end); right-click a gate → relabel/delete
- Works via mouse, touch, and keyboard (@dnd-kit's KeyboardSensor, using its default nudge-based coordinate getter since this isn't a sortable list)
- QuantumCircuitEditPanel (the side-panel form) removed entirely

Still true, unchanged: no serializer exists for this type, so these edits still preview locally only and can't be sent to Run — that gap was never in this task's scope.

One accepted, documented gap: an overlay's own timeStart/timeEnd aren't remapped when a retime inserts a column and shifts later gates, so a decorative overlay band can drift relative to the gates it used to bracket after an edit. Overlays are read-only annotations, not part of the editable contract, so this is recorded rather than solved — flagged in quantumCircuitGrid.js's header.

Closes #129 